### PR TITLE
Regular mesh Support for DES

### DIFF
--- a/benchmarks-cores/test-3d-equ-long.cfg
+++ b/benchmarks-cores/test-3d-equ-long.cfg
@@ -1,0 +1,100 @@
+[sim]
+modelname = benchmark
+max_time_in_yr = 1000.e3
+output_time_interval_in_yr = 20.e3
+
+has_output_during_remeshing = no
+is_outputting_averaged_fields = no
+
+checkpoint_frame_interval = 5
+#is_restarting = yes
+#restarting_from_modelname = benchmark
+#restarting_from_frame = 120
+
+[mesh]
+meshing_option = 1
+meshing_elem_shape = 1
+xlength = 250e3
+ylength = 30e3
+zlength = 100e3
+resolution = 10.e3
+largest_size = 10
+smallest_size = 0.001
+
+quality_check_step_interval = 1000
+min_quality = 0.2
+max_boundary_distortion = 0.5
+
+remeshing_option = 13
+
+[control]
+surface_process_option = 1
+surface_diffusivity = 2e-5
+
+dt_fraction = 1.0
+inertial_scaling = 1e4
+is_using_mixed_stress = no
+surf_base_level = 15.e3
+
+[bc]
+vbc_x0 = 1
+vbc_x1 = 1
+vbc_val_x0 = -1e-9
+vbc_val_x1 = 1e-9
+
+vbc_y0 = 1
+vbc_y1 = 1
+vbc_val_y0 = 0
+vbc_val_y1 = 0
+
+has_water_loading = yes
+
+surface_temperature = 273
+mantle_temperature = 1573
+
+[ic]
+mattype_option = 1
+num_mattype_layers = 3
+layer_mattypes = [3,1,0]
+mattype_layer_depths = [0.24, 0.7]
+
+weakzone_option = 1
+weakzone_azimuth = 15
+weakzone_inclination = -60
+weakzone_halfwidth = 1.25
+weakzone_depth_min = 0.0
+weakzone_depth_max = 0.5
+weakzone_xcenter = 0.6
+weakzone_ycenter = 0.5
+weakzone_zcenter = 0
+weakzone_plstrain = 1.0
+
+[mat]
+rheology_type = elasto-visco-plastic
+num_materials = 5
+mattype_sed = 4
+
+
+# lower mantle, lithospheric mantle, lower crust, upper crust, sediment
+rho0 = [ 3300, 3280, 2850, 2700, 2400 ]
+alpha = [ 3e-5 ]
+bulk_modulus = [ 122e9, 122e9, 63e9, 55e9, 55e9 ]
+shear_modulus = [ 74e9,  74e9, 40e9, 36e9, 36e9 ]
+
+visc_exponent =          [   3.5,   3.5,    3.05,     4.0,    4.0 ]
+visc_coefficient =       [  7.e4,  7.e4, 1.25e-1, 1.25e-1,   5.e2 ]
+visc_activation_energy = [ 4.8e5, 5.3e5,   3.0e5,  2.23e5, 2.23e5 ]
+
+heat_capacity = [ 1000 ]
+therm_cond = [ 3.3 ]
+pls0 = [ 0 ]
+pls1 = [ 0.5 ]
+cohesion0 = [ 4e7 ]
+cohesion1 = [ 4e6, 4e6, 4e6, 4e6, 4e6 ]
+friction_angle0 = [ 30, 30, 30, 30, 30 ]
+friction_angle1 = [ 15, 15, 15, 15, 15 ]
+dilation_angle0 = [ 0 ]
+dilation_angle1 = [ 0 ]
+
+max_viscosity = 1e24
+min_viscosity = 1e19

--- a/benchmarks-cores/test-3d-equ-tiny.cfg
+++ b/benchmarks-cores/test-3d-equ-tiny.cfg
@@ -1,0 +1,102 @@
+[sim]
+modelname = benchmark
+# max_time_in_yr = 1000.e3
+# output_time_interval_in_yr = 20.e3
+max_steps = 40
+output_step_interval = 10
+
+has_output_during_remeshing = no
+is_outputting_averaged_fields = no
+
+checkpoint_frame_interval = 5
+#is_restarting = yes
+#restarting_from_modelname = benchmark
+#restarting_from_frame = 120
+
+[mesh]
+meshing_option = 1
+meshing_elem_shape = 1
+xlength = 250e3
+ylength = 30e3
+zlength = 100e3
+resolution = 10.e3
+largest_size = 10
+smallest_size = 0.001
+
+quality_check_step_interval = 1000
+min_quality = 0.2
+max_boundary_distortion = 0.5
+
+remeshing_option = 13
+
+[control]
+surface_process_option = 1
+surface_diffusivity = 2e-5
+
+dt_fraction = 1.0
+inertial_scaling = 1e4
+is_using_mixed_stress = no
+surf_base_level = 15.e3
+
+[bc]
+vbc_x0 = 1
+vbc_x1 = 1
+vbc_val_x0 = -1e-9
+vbc_val_x1 = 1e-9
+
+vbc_y0 = 1
+vbc_y1 = 1
+vbc_val_y0 = 0
+vbc_val_y1 = 0
+
+has_water_loading = yes
+
+surface_temperature = 273
+mantle_temperature = 1573
+
+[ic]
+mattype_option = 1
+num_mattype_layers = 3
+layer_mattypes = [3,1,0]
+mattype_layer_depths = [0.24, 0.7]
+
+weakzone_option = 1
+weakzone_azimuth = 15
+weakzone_inclination = -60
+weakzone_halfwidth = 1.25
+weakzone_depth_min = 0.0
+weakzone_depth_max = 0.5
+weakzone_xcenter = 0.6
+weakzone_ycenter = 0.5
+weakzone_zcenter = 0
+weakzone_plstrain = 1.0
+
+[mat]
+rheology_type = elasto-visco-plastic
+num_materials = 5
+mattype_sed = 4
+
+
+# lower mantle, lithospheric mantle, lower crust, upper crust, sediment
+rho0 = [ 3300, 3280, 2850, 2700, 2400 ]
+alpha = [ 3e-5 ]
+bulk_modulus = [ 122e9, 122e9, 63e9, 55e9, 55e9 ]
+shear_modulus = [ 74e9,  74e9, 40e9, 36e9, 36e9 ]
+
+visc_exponent =          [   3.5,   3.5,    3.05,     4.0,    4.0 ]
+visc_coefficient =       [  7.e4,  7.e4, 1.25e-1, 1.25e-1,   5.e2 ]
+visc_activation_energy = [ 4.8e5, 5.3e5,   3.0e5,  2.23e5, 2.23e5 ]
+
+heat_capacity = [ 1000 ]
+therm_cond = [ 3.3 ]
+pls0 = [ 0 ]
+pls1 = [ 0.5 ]
+cohesion0 = [ 4e7 ]
+cohesion1 = [ 4e6, 4e6, 4e6, 4e6, 4e6 ]
+friction_angle0 = [ 30, 30, 30, 30, 30 ]
+friction_angle1 = [ 15, 15, 15, 15, 15 ]
+dilation_angle0 = [ 0 ]
+dilation_angle1 = [ 0 ]
+
+max_viscosity = 1e24
+min_viscosity = 1e19

--- a/benchmarks-cores/test-rect-tiny-long.cfg
+++ b/benchmarks-cores/test-rect-tiny-long.cfg
@@ -1,0 +1,113 @@
+[sim]
+modelname = benchmark
+
+max_steps = 1000
+output_step_interval = 10
+#max_time_in_yr = 10.01e6
+#output_time_interval_in_yr = 1.e5
+has_marker_output = yes
+has_output_during_remeshing = yes
+
+is_outputting_averaged_fields = no
+
+[mesh]
+meshing_option = 1
+meshing_elem_shape = 1
+meshing_verbosity = -1
+meshing_sediment = no
+
+xlength = 150e3
+ylength = 50e3
+zlength = 100e3
+resolution = 1e4
+largest_size = 1.e5
+smallest_size = 5.e-2
+
+quality_check_step_interval = 2
+
+min_angle = 10.
+min_quality = 0.2
+max_boundary_distortion = 1e-1
+remeshing_option = 11
+is_discarding_internal_segments = yes
+
+[markers]
+init_marker_option = 1
+#init_marker_spacing = 0.25
+
+[control]
+ref_pressure_option = 1
+
+surface_process_option = 1
+surface_diffusivity = 1e-7
+
+[bc]
+vbc_x0 = 1
+vbc_val_x0 = -1e-10
+
+
+vbc_x1 = 1
+vbc_val_x1 = 0.e-11
+
+
+has_water_loading = no
+
+surface_temperature = 273
+mantle_temperature = 1573
+
+[ic]
+weakzone_option = 3
+weakzone_standard_deviation = 3e3
+weakzone_xcenter = 0.5
+weakzone_ycenter = 0
+weakzone_zcenter = 0.3
+weakzone_plstrain = 1.0
+
+### How to build the thermal profile
+
+temperature_option = 1
+#Temp_filename = Thermal.dat
+#Nodes_filename = Coord.dat
+#Connectivity_filename = Connectivity.dat
+
+#oceanic_plate_age_in_yr = 100e6
+isostasy_adjustment_time_in_yr = 1e3
+
+continental_plate_age_in_yr = 200e6
+radiogenic_crustal_thickness = 33e3
+radiogenic_folding_depth = 10.e3
+radiogenic_heating_of_crust = 3.e-10
+lithospheric_thickness = 120.e3
+
+[mat]
+rheology_type = elasto-visco-plastic
+num_materials = 8
+mattype_crust = 3
+mattype_mantle = 1
+mattype_sed = 4
+
+# lower mantle, upper mantle, lower crust, upper crust, sediment, bdy upper mantle, bdy lower crust, bdy upper crust
+rho0 = [ 3300, 3280, 2850, 2700, 2400, 3280, 2850, 2700 ]
+alpha = [ 3e-5 ]
+bulk_modulus = [ 122e9, 122e9, 63e9, 55e9, 55e9, 122e9, 63e9, 55e9 ]
+shear_modulus = [ 74e9,  74e9, 40e9, 36e9, 36e9,  74e9, 40e9, 36e9 ]
+
+visc_exponent =          [   3.5,   3.5,    3.05,     4.0,    4.0,   3.5,    3.05,     4.0 ]
+visc_coefficient =       [  7.e4,  7.e4, 1.25e-1, 1.25e-1,   5.e2,  7.e4, 1.25e-1, 1.25e-1 ]
+visc_activation_energy = [ 4.8e5, 5.3e5,   3.0e5,  2.23e5, 2.23e5, 5.3e5,   3.0e5,  2.23e5 ]
+heat_capacity = [ 1000 ]
+therm_cond = [ 3.3 ]
+pls0 = [ 0 ]
+pls1 = [ 0.5 ]
+cohesion0 = [ 4e7 ]
+cohesion1 = [ 4e6 ]
+friction_angle0 = [ 30, 30, 30, 30, 5, 40, 40, 40 ]
+friction_angle1 = [ 15, 15, 15,  5, 1, 40, 40, 40 ]
+dilation_angle0 = [ 0 ]
+dilation_angle1 = [ 0 ]
+
+max_viscosity = 1e24
+min_viscosity = 1e19
+
+#[debug]
+#has_two_layers_for = yes

--- a/benchmarks-cores/test-rect-tiny-long.cfg
+++ b/benchmarks-cores/test-rect-tiny-long.cfg
@@ -12,7 +12,7 @@ is_outputting_averaged_fields = no
 
 [mesh]
 meshing_option = 1
-meshing_elem_shape = 1
+meshing_elem_shape = 2
 meshing_verbosity = -1
 meshing_sediment = no
 

--- a/benchmarks-cores/test-rect-tiny.cfg
+++ b/benchmarks-cores/test-rect-tiny.cfg
@@ -1,0 +1,116 @@
+[sim]
+modelname = benchmark
+
+max_steps = 4
+output_step_interval = 1
+#max_time_in_yr = 10.01e6
+#output_time_interval_in_yr = 1.e5
+has_marker_output = yes
+has_output_during_remeshing = no
+
+is_outputting_averaged_fields = no
+
+[mesh]
+meshing_option = 1
+meshing_elem_shape = 1
+meshing_verbosity = -1
+meshing_sediment = no
+
+xlength = 150e3
+ylength = 100e3
+zlength = 50e3
+resolution = 1e4
+largest_size = 1.e5
+smallest_size = 5.e-2
+
+quality_check_step_interval = 2
+
+min_angle = 10.
+min_quality = 0.2
+max_boundary_distortion = 1e1
+remeshing_option = 11
+is_discarding_internal_segments = yes
+
+[markers]
+init_marker_option = 1
+#init_marker_spacing = 0.25
+
+[control]
+ref_pressure_option = 1
+
+surface_process_option = 1
+surface_diffusivity = 1e-7
+
+[bc]
+vbc_x0 = 1
+vbc_val_x0 = -1e-10
+
+
+vbc_x1 = 1
+vbc_val_x1 = 0.e-11
+
+
+has_water_loading = no
+
+surface_temperature = 273
+mantle_temperature = 1573
+
+[ic]
+weakzone_option = 3
+weakzone_standard_deviation = 3e3
+weakzone_xcenter = 0.5
+weakzone_ycenter = 0
+weakzone_zcenter = 0.3
+weakzone_plstrain = 1.0
+
+### How to build the thermal profile
+
+temperature_option = 1
+#Temp_filename = Thermal.dat
+#Nodes_filename = Coord.dat
+#Connectivity_filename = Connectivity.dat
+
+#oceanic_plate_age_in_yr = 100e6
+#isostasy_adjustment_time_in_yr = 100e3
+
+continental_plate_age_in_yr = 200e6
+radiogenic_crustal_thickness = 33e3
+radiogenic_folding_depth = 10.e3
+radiogenic_heating_of_crust = 3.e-10
+lithospheric_thickness = 120.e3
+
+[mat]
+rheology_type = elasto-visco-plastic
+num_materials = 8
+mattype_crust = 3
+mattype_mantle = 1
+mattype_sed = 4
+
+# lower mantle, upper mantle, lower crust, upper crust, sediment, bdy upper mantle, bdy lower crust, bdy upper crust
+rho0 = [ 3300, 3280, 2850, 2700, 2400, 3280, 2850, 2700 ]
+alpha = [ 3e-5 ]
+bulk_modulus = [ 122e9, 122e9, 63e9, 55e9, 55e9, 122e9, 63e9, 55e9 ]
+shear_modulus = [ 74e9,  74e9, 40e9, 36e9, 36e9,  74e9, 40e9, 36e9 ]
+
+visc_exponent =          [   3.5,   3.5,    3.05,     4.0,    4.0,   3.5,    3.05,     4.0 ]
+visc_coefficient =       [  7.e4,  7.e4, 1.25e-1, 1.25e-1,   5.e2,  7.e4, 1.25e-1, 1.25e-1 ]
+visc_activation_energy = [ 4.8e5, 5.3e5,   3.0e5,  2.23e5, 2.23e5, 5.3e5,   3.0e5,  2.23e5 ]
+#visc_exponent = [ 3.5, 3.5, 4.0, 4.0, 4.0]
+#visc_coefficient = [ 7.e4, 7.e4, 1.25e-1, 1.25e-1, 5.e2 ]
+#visc_activation_energy = [ 4.8e5, 5.3e5, 5.0e5, 2.23e5, 2.23e5 ]
+heat_capacity = [ 1000 ]
+therm_cond = [ 3.3 ]
+pls0 = [ 0 ]
+pls1 = [ 0.5 ]
+cohesion0 = [ 4e7 ]
+cohesion1 = [ 4e6 ]
+friction_angle0 = [ 30, 30, 30, 30, 5, 40, 40, 40 ]
+friction_angle1 = [ 15, 15, 15,  5, 1, 40, 40, 40 ]
+dilation_angle0 = [ 0 ]
+dilation_angle1 = [ 0 ]
+
+max_viscosity = 1e24
+min_viscosity = 1e19
+
+#[debug]
+#has_two_layers_for = yes

--- a/benchmarks-cores/test-rect-tiny.cfg
+++ b/benchmarks-cores/test-rect-tiny.cfg
@@ -12,7 +12,7 @@ is_outputting_averaged_fields = no
 
 [mesh]
 meshing_option = 1
-meshing_elem_shape = 1
+meshing_elem_shape = 2
 meshing_verbosity = -1
 meshing_sediment = no
 

--- a/constants.hpp
+++ b/constants.hpp
@@ -17,7 +17,8 @@ const int NDIMS = 2;
 
 // triangles (3 node) in 2D and tetrahedra (4 nodes) in 3D
 const int NODES_PER_ELEM = NDIMS + 1;
-const int NODES_PER_REGULAR = (NDIMS-1) * 4;
+const int NODES_PER_CELL = (NDIMS-1) * 4;
+const int ELEMS_PER_CELL = (NDIMS-2)*3 + 2;
 
 // # of indep. components of a symmetric tensor
 // 2D -> 3;  3D -> 6

--- a/constants.hpp
+++ b/constants.hpp
@@ -17,6 +17,7 @@ const int NDIMS = 2;
 
 // triangles (3 node) in 2D and tetrahedra (4 nodes) in 3D
 const int NODES_PER_ELEM = NDIMS + 1;
+const int NODES_PER_REGULAR = (NDIMS-1) * 4;
 
 // # of indep. components of a symmetric tensor
 // 2D -> 3;  3D -> 6

--- a/dynearthsol.cxx
+++ b/dynearthsol.cxx
@@ -612,7 +612,7 @@ int main(int argc, const char* argv[])
         if (var.steps % param.mesh.quality_check_step_interval == 0) {
             if (param.control.has_moving_mesh)
             {
-                int quality_is_bad, bad_quality_index;
+                int quality_is_bad, bad_quality_index = -1;
                 quality_is_bad = bad_mesh_quality(param, var, bad_quality_index);
                 if (quality_is_bad) {
 

--- a/input.cxx
+++ b/input.cxx
@@ -817,6 +817,20 @@ static void validate_parameters(const po::variables_map &vm, Param &p)
             std::exit(1);
     }
 
+    // these parameters are required in mesh.meshing_elem_shape >= 1
+#ifdef THREED
+    if (p.mesh.meshing_elem_shape == 2) {
+        std::cerr << "Error: mesh.meshing_elem_shape == 2 is not available in 3D.\n";
+        std::exit(1);
+    }
+#endif
+    if (p.mesh.meshing_elem_shape >= 1) {
+        if ( p.mesh.meshing_option != 1) {
+            std::cerr << "Error: mesh.meshing_elem_shape >= 1 is only for mesh.meshing_option == 1.\n";
+            std::exit(1);
+        }
+    }
+
     //
     // these parameters are required in mesh.meshing_option == 2
     //

--- a/input.cxx
+++ b/input.cxx
@@ -146,7 +146,8 @@ static void declare_parameters(po::options_description &cfg,
          " 2: create a new bottom boundary at the initial depth, other boundaries are intact (2D only).\n"
          "10: no modification on any boundary, except small boundary segments might get merged.\n"
          "11: move all bottom nodes to initial depth, other boundaries are intact, small boundary segments might get merged.\n"
-         "12: flatten x0 when using fixed bottom boundary.\n")
+         "12: flatten x0 when using fixed bottom boundary.\n"
+         "13: move all bottom, left, and right nodes to initial dimensions.\n")
 
         ("mesh.is_discarding_internal_segments", po::value<bool>(&p.mesh.is_discarding_internal_segments)->default_value(true),
          "Discarding internal segments after initial mesh is created? "

--- a/input.cxx
+++ b/input.cxx
@@ -74,7 +74,7 @@ static void declare_parameters(po::options_description &cfg,
          "95: read the mesh from from a .exo file\n"
          )
         ("mesh.meshing_elem_shape", po::value<int>(&p.mesh.meshing_elem_shape)->default_value(0),
-         "Element shape for meshing. 0: tetrahedra; 1: hexahedra.")
+         "Element shape for meshing. 0: tetrahedra; 1: hexahedra.; 2: equilateral tetrahedra.")
         ("mesh.meshing_verbosity", po::value<int>(&p.mesh.meshing_verbosity)->default_value(-1),
          "Output verbose during mesh/remeshing. -1 for no output.")
         ("mesh.meshing_sediment", po::value<bool>(&p.mesh.meshing_sediment)->default_value(false),

--- a/input.cxx
+++ b/input.cxx
@@ -73,6 +73,8 @@ static void declare_parameters(po::options_description &cfg,
          "91: same as 90, but the max. element size is normalized with resolution.\n"
          "95: read the mesh from from a .exo file\n"
          )
+        ("mesh.meshing_elem_shape", po::value<int>(&p.mesh.meshing_elem_shape)->default_value(0),
+         "Element shape for meshing. 0: tetrahedra; 1: hexahedra.")
         ("mesh.meshing_verbosity", po::value<int>(&p.mesh.meshing_verbosity)->default_value(-1),
          "Output verbose during mesh/remeshing. -1 for no output.")
         ("mesh.meshing_sediment", po::value<bool>(&p.mesh.meshing_sediment)->default_value(false),

--- a/mesh.cxx
+++ b/mesh.cxx
@@ -2092,9 +2092,13 @@ void renumbering_mesh(const Param& param, array_t &coord, conn_t &connectivity,
         dmid = idx[1];
         dmax = idx[NDIMS-1];
     } else {
+#ifdef THREED
         dmax = 0;
-        dmid = 1;
-        dmin = 2;
+#else
+        dmax = NDIMS-2;
+#endif
+        dmid = NDIMS-2;
+        dmin = NDIMS-1;
     }
     //
     // sort coordinate of nodes and element centers

--- a/mesh.cxx
+++ b/mesh.cxx
@@ -119,15 +119,28 @@ void create_quadrilateral_cells(int nx, int nz, int *&cells) {
 
 void create_elem_from_cell(const Variables& var, int *&connectivity) {
     connectivity = new int[var.nelem*3];
-    for (int i = 0; i < var.ncell; ++i) {
-        // wrong order will cause the bug
-        connectivity[i*6] = (*var.cell)[i][0];
-        connectivity[i*6+1] = (*var.cell)[i][2];
-        connectivity[i*6+2] = (*var.cell)[i][1];
+    for (int i = 0; i < var.nx - 1; ++i) {
+        for (int j = 0; j < var.nz - 1; ++j) {
+            int idx = i * (var.nz - 1) + j;
+            // should be counter-clockwise
+            if ((i+j) % 2 == 0){
+                connectivity[idx*6] = (*var.cell)[idx][0];
+                connectivity[idx*6+1] = (*var.cell)[idx][2];
+                connectivity[idx*6+2] = (*var.cell)[idx][1];
 
-        connectivity[i*6+3] = (*var.cell)[i][0];
-        connectivity[i*6+4] = (*var.cell)[i][3];
-        connectivity[i*6+5] = (*var.cell)[i][2];
+                connectivity[idx*6+3] = (*var.cell)[idx][0];
+                connectivity[idx*6+4] = (*var.cell)[idx][3];
+                connectivity[idx*6+5] = (*var.cell)[idx][2];                
+            } else {
+                connectivity[idx*6] = (*var.cell)[idx][0];
+                connectivity[idx*6+1] = (*var.cell)[idx][3];
+                connectivity[idx*6+2] = (*var.cell)[idx][1];
+
+                connectivity[idx*6+3] = (*var.cell)[idx][1];
+                connectivity[idx*6+4] = (*var.cell)[idx][3];
+                connectivity[idx*6+5] = (*var.cell)[idx][2];
+            }
+        }
     }
 }
 

--- a/mesh.cxx
+++ b/mesh.cxx
@@ -99,6 +99,158 @@ void set_2d_quality_str(std::string &quality, double min_angle)
     }
 }
 
+regular_t* get_quadrilateral_cells(int nx, int ny) {
+    int num_cells = (nx - 1) * (ny - 1);
+    regular_t* cells = new regular_t(num_cells);
+
+    int cell_idx = 0;
+    for (int i = 0; i < nx - 1; ++i) {
+        for (int j = 0; j < ny - 1; ++j) {
+            int idx0 = i * ny + j;
+            int idx1 = idx0 + ny;
+            (*cells)[cell_idx][0] = idx0;
+            (*cells)[cell_idx][1] = idx1;
+            (*cells)[cell_idx][2] = idx1 + 1;
+            (*cells)[cell_idx][3] = idx0 + 1;
+            cell_idx++;
+        }
+    }
+    return cells;
+}
+
+int* quadri_to_triang(const regular_t* cells) {
+    int num_cells = cells->size();
+    int *triangles = new int[num_cells * 2 * 3];
+
+    int tri_idx = 0;
+    for (int i = 0; i < num_cells; ++i) {
+        (triangles)[tri_idx] = (*cells)[i][0];
+        (triangles)[tri_idx+1] = (*cells)[i][1];
+        (triangles)[tri_idx+2] = (*cells)[i][2];
+        tri_idx += 3;
+
+        (triangles)[tri_idx] = (*cells)[i][0];
+        (triangles)[tri_idx+1] = (*cells)[i][2];
+        (triangles)[tri_idx+2] = (*cells)[i][3];
+        tri_idx += 3;
+    }
+    return triangles;
+}
+
+double* get_regular_mesh(int nx, int ny, double xlength, double ylength) {
+    double dx = xlength / (nx - 1);
+    double dy = -ylength / (ny - 1);
+    double *points = new double[nx * ny * 2];
+
+    for (int i = 0; i < nx; ++i) {
+        for (int j = 0; j < ny; ++j) {
+            points[(j + i * ny)*2] = i * dx;
+            points[(j + i * ny)*2 + 1] = j * dy;
+        }
+    }
+    return points;
+}
+
+int* get_regular_segments(int nx, int ny) {
+    int num_segments = (nx + ny - 2) * 2;
+    int *segments = new int[num_segments*2];
+
+    int seg_idx = 0;
+    for (int i = 0; i < nx - 1; ++i) {
+        for (int j = 0; j < ny - 1; ++j) {
+            if (i == 0) {
+                (segments)[seg_idx] = j + i * ny;
+                (segments)[seg_idx+1] = j + i * ny + 1;
+                seg_idx += 2;
+            }
+            if (j == 0) {
+                (segments)[seg_idx] = j + i * ny;
+                (segments)[seg_idx+1] = j + i * ny + ny;
+                seg_idx += 2;
+            }
+        }
+    }
+    for (int i = 1; i < nx; ++i) {
+        (segments)[seg_idx] = i * ny - 1;
+        (segments)[seg_idx+1] = i * ny + ny - 1;
+        seg_idx += 2;
+    }
+    for (int j = 0; j < ny - 1; ++j) {
+        (segments)[seg_idx] = ny * (nx - 1) + j;
+        (segments)[seg_idx+1] = ny * (nx - 1) + j + 1;
+        seg_idx += 2;
+    }
+    return segments;
+}
+
+int* get_regular_segflags(int nx, int ny) {
+    int num_segments = (nx + ny - 2) * 2;
+    int* segflags = new int[num_segments];
+
+    int seg_idx = 0;
+    for (int i = 0; i < nx - 1; ++i) {
+        for (int j = 0; j < ny - 1; ++j) {
+            if (i == 0) {
+                segflags[seg_idx] = 1;
+                seg_idx++;
+            }
+            if (j == 0) {
+                segflags[seg_idx] = 32;
+                seg_idx++;
+            }
+        }
+    }
+    for (int i = 1; i < nx; ++i) {
+        segflags[seg_idx] = 16;
+        seg_idx++;
+    }
+    for (int j = 0; j < ny; ++j) {
+        segflags[seg_idx] = 2;
+        seg_idx++;
+    }
+
+    return segflags;
+}
+
+double* get_regular_attributes(int nx, int ny) {
+    int num_triang = (nx - 1) * (ny - 1) * 2;
+    double* regattr = new double[num_triang];
+
+    for (int i = 0; i < num_triang; ++i)
+        regattr[i] = 0;
+
+    return regattr;
+}
+
+void rectangulate_polygon
+(double xlength, double ylength,
+ double min_angle, double max_area,
+ int npoints, int nsegments,
+ const double *points, const int *segments, const int *segflags,
+ const int nregions, const double *regionattributes,
+ int *noutpoints, int *ntriangles, int *noutsegments,
+ double **outpoints, int **triangles,
+ int **outsegments, int **outsegflags, double **outregattr)
+{
+
+    int nx = std::round(xlength/std::sqrt(max_area)) + 1;
+    int ny = std::round(ylength/std::sqrt(max_area)) + 1;
+
+    regular_t* cells = get_quadrilateral_cells(nx, ny);
+
+    *noutpoints = nx*ny;
+    *outpoints = get_regular_mesh(nx, ny, xlength, ylength);
+
+    *ntriangles = (nx - 1) * (ny - 1) * 2;
+    *triangles = quadri_to_triang(cells);
+
+    *noutsegments = (nx + ny - 2) * 2;
+    *outsegments = get_regular_segments(nx, ny);
+    *outsegflags = get_regular_segflags(nx, ny);
+    *outregattr = get_regular_attributes(nx, ny);
+
+}
+
 
 void triangulate_polygon
 (double min_angle, double max_area,
@@ -1351,14 +1503,29 @@ void points_to_new_mesh(const Mesh &mesh, int npoints, const double *points,
 
 #else
 
-    triangulate_polygon(mesh.min_angle, max_elem_size,
-                        mesh.meshing_verbosity,
-                        npoints, n_init_segments, points,
-                        init_segments, init_segflags,
-                        n_regions, regattr,
-                        &nnode, &nelem, &nseg,
-                        &pcoord, &pconnectivity,
-                        &psegment, &psegflag, &pregattr);
+    if (mesh.meshing_elem_shape == 0) {
+        triangulate_polygon(mesh.min_angle, max_elem_size,
+                            mesh.meshing_verbosity,
+                            npoints, n_init_segments, points,
+                            init_segments, init_segflags,
+                            n_regions, regattr,
+                            &nnode, &nelem, &nseg,
+                            &pcoord, &pconnectivity,
+                            &psegment, &psegflag, &pregattr);
+    } else if (mesh.meshing_elem_shape == 1) {
+        if (mesh.meshing_option != 1) {
+            std::cerr << "Error: meshing_option must be 1 for rectangulate_polygon\n";
+            std::exit(10);
+        }
+        rectangulate_polygon(mesh.xlength, mesh.ylength,
+                             mesh.min_angle,max_elem_size,
+                             npoints, n_init_segments, points,
+                             init_segments, init_segflags,
+                             n_regions, regattr,
+                             &nnode, &nelem, &nseg,
+                             &pcoord, &pconnectivity,
+                             &psegment, &psegflag, &pregattr);
+    }
 
 #endif
 

--- a/mesh.cxx
+++ b/mesh.cxx
@@ -256,7 +256,7 @@ void create_elem_from_cell(const Variables& var, int *&connectivity) {
         for (int j = 0; j<var.ny -1; ++j) {
             for (int k = 0; k<var.nz - 1; ++k) {
                 int idx = i * (var.ny - 1) * (var.nz - 1) + j * (var.nz - 1) + k;
-                int order = idx%2;
+                int order = (i%2 + j%2 + k%2)%2;
                 for (int n = 0; n < 5; ++n) {
                     int idx_elem = idx*5+n;
                     divide_hexahedron_to_tetrahedra_index((*var.cell)[idx], order, n, conn);
@@ -396,7 +396,9 @@ void create_regular_segments(const Variables& var, int *&segments, int *&segflag
             // left
             int i = 0;
             idx_cell = i * (var.ny - 1) * (var.nz - 1) + j * (var.nz - 1) + k;
-            if (idx_cell%2)
+            int order = (i%2 + j%2 + k%2)%2;
+
+            if (order)
                 idx_elem = idx_cell*5 + 1;
             else
                 idx_elem = idx_cell*5;
@@ -418,7 +420,7 @@ void create_regular_segments(const Variables& var, int *&segments, int *&segflag
             // right
             i = var.nx - 2;
             idx_cell = i * (var.ny - 1) * (var.nz - 1) + j * (var.nz - 1) + k;
-            if (idx_cell%2)
+            if (order)
                 idx_elem = idx_cell*5;
             else
                 idx_elem = idx_cell*5 + 1;
@@ -445,6 +447,7 @@ void create_regular_segments(const Variables& var, int *&segments, int *&segflag
             // front
             int j = 0;
             idx_cell = i * (var.ny - 1) * (var.nz - 1) + j * (var.nz - 1) + k;
+            int order = (i%2 + j%2 + k%2)%2;
             idx_elem = idx_cell*5 + 1;
             conn = (*var.connectivity)[idx_elem];
             segments[seg_idx*3] = conn[0];
@@ -453,7 +456,7 @@ void create_regular_segments(const Variables& var, int *&segments, int *&segflag
             segflags[seg_idx] = BOUNDY0;
             seg_idx++;
 
-            if (idx_cell%2)
+            if (order)
                 idx_elem = idx_cell*5 + 3;
             else
                 idx_elem = idx_cell*5 + 2;
@@ -469,7 +472,7 @@ void create_regular_segments(const Variables& var, int *&segments, int *&segflag
             idx_cell = i * (var.ny - 1) * (var.nz - 1) + j * (var.nz - 1) + k;
             idx_elem = idx_cell*5;
             conn = (*var.connectivity)[idx_elem];
-            if (idx_cell%2) {
+            if (order) {
                 segments[seg_idx*3] = conn[0];
                 segments[seg_idx*3+1] = conn[1];
                 segments[seg_idx*3+2] = conn[3];
@@ -481,7 +484,7 @@ void create_regular_segments(const Variables& var, int *&segments, int *&segflag
             segflags[seg_idx] = BOUNDY1;
             seg_idx++;
 
-            if (idx_cell%2) {
+            if (order) {
                 idx_elem = idx_cell*5 + 2;
                 conn = (*var.connectivity)[idx_elem];
                 segments[seg_idx*3] = conn[0];

--- a/mesh.cxx
+++ b/mesh.cxx
@@ -256,7 +256,7 @@ void create_elem_from_cell(const Variables& var, int *&connectivity) {
         for (int j = 0; j<var.ny -1; ++j) {
             for (int k = 0; k<var.nz - 1; ++k) {
                 int idx = i * (var.ny - 1) * (var.nz - 1) + j * (var.nz - 1) + k;
-                int order = (i%2 + j%2 + k%2)%2;
+                int order = (i+j+k)%2;
                 for (int n = 0; n < 5; ++n) {
                     int idx_elem = idx*5+n;
                     divide_hexahedron_to_tetrahedra_index((*var.cell)[idx], order, n, conn);
@@ -396,7 +396,7 @@ void create_regular_segments(const Variables& var, int *&segments, int *&segflag
             // left
             int i = 0;
             idx_cell = i * (var.ny - 1) * (var.nz - 1) + j * (var.nz - 1) + k;
-            int order = (i%2 + j%2 + k%2)%2;
+            int order = (i+j+k)%2;
 
             if (order)
                 idx_elem = idx_cell*5 + 1;
@@ -419,6 +419,7 @@ void create_regular_segments(const Variables& var, int *&segments, int *&segflag
 
             // right
             i = var.nx - 2;
+            order = (i+j+k)%2;
             idx_cell = i * (var.ny - 1) * (var.nz - 1) + j * (var.nz - 1) + k;
             if (order)
                 idx_elem = idx_cell*5;
@@ -447,7 +448,7 @@ void create_regular_segments(const Variables& var, int *&segments, int *&segflag
             // front
             int j = 0;
             idx_cell = i * (var.ny - 1) * (var.nz - 1) + j * (var.nz - 1) + k;
-            int order = (i%2 + j%2 + k%2)%2;
+            int order = (i+j+k)%2;
             idx_elem = idx_cell*5 + 1;
             conn = (*var.connectivity)[idx_elem];
             segments[seg_idx*3] = conn[0];
@@ -469,6 +470,7 @@ void create_regular_segments(const Variables& var, int *&segments, int *&segflag
  
             // back
             j = var.ny - 2;
+            order = (i+j+k)%2;
             idx_cell = i * (var.ny - 1) * (var.nz - 1) + j * (var.nz - 1) + k;
             idx_elem = idx_cell*5;
             conn = (*var.connectivity)[idx_elem];

--- a/mesh.cxx
+++ b/mesh.cxx
@@ -2088,8 +2088,8 @@ void renumbering_mesh(const Param& param, array_t &coord, conn_t &connectivity,
         dmax = idx[NDIMS-1];
     } else {
         dmax = 0;
-        dmid = 2;
-        dmin = 1;
+        dmid = 1;
+        dmin = 2;
     }
     //
     // sort coordinate of nodes and element centers

--- a/mesh.cxx
+++ b/mesh.cxx
@@ -200,9 +200,9 @@ void divide_hexahedron_to_tetrahedra_index(const int *cell, int order, int n, in
             break;
         case 2:
             conn[0] = cell[1];
-            conn[1] = cell[5];
-            conn[2] = cell[6];
-            conn[3] = cell[4];
+            conn[1] = cell[4];
+            conn[2] = cell[5];
+            conn[3] = cell[6];
             break;
         case 3:
             conn[0] = cell[3];
@@ -259,7 +259,7 @@ void create_elem_from_cell(const Variables& var, int *&connectivity) {
                 int order = idx%2;
                 for (int n = 0; n < 5; ++n) {
                     int idx_elem = idx*5+n;
-                    divide_hexahedron_to_tetrahedra_index((*var.cell)[idx], 0, n, conn);
+                    divide_hexahedron_to_tetrahedra_index((*var.cell)[idx], order, n, conn);
                     connectivity[idx_elem*4] = conn[0];
                     connectivity[idx_elem*4+1] = conn[1];
                     connectivity[idx_elem*4+2] = conn[2];
@@ -389,13 +389,17 @@ void create_regular_segments(const Variables& var, int *&segments, int *&segflag
             seg_idx++;
         }
     }
+
     // left and right
     for (int j = 0; j < var.ny - 1; ++j) {
         for (int k = 0; k < var.nz - 1; ++k) {
             // left
             int i = 0;
             idx_cell = i * (var.ny - 1) * (var.nz - 1) + j * (var.nz - 1) + k;
-            idx_elem = idx_cell*5;
+            if (idx_cell%2)
+                idx_elem = idx_cell*5 + 1;
+            else
+                idx_elem = idx_cell*5;
             conn = (*var.connectivity)[idx_elem];
             segments[seg_idx*3] = conn[0];
             segments[seg_idx*3+1] = conn[1];
@@ -414,7 +418,10 @@ void create_regular_segments(const Variables& var, int *&segments, int *&segflag
             // right
             i = var.nx - 2;
             idx_cell = i * (var.ny - 1) * (var.nz - 1) + j * (var.nz - 1) + k;
-            idx_elem = idx_cell*5 + 1;
+            if (idx_cell%2)
+                idx_elem = idx_cell*5;
+            else
+                idx_elem = idx_cell*5 + 1;
             conn = (*var.connectivity)[idx_elem];
             segments[seg_idx*3] = conn[1];
             segments[seg_idx*3+1] = conn[2];
@@ -431,6 +438,7 @@ void create_regular_segments(const Variables& var, int *&segments, int *&segflag
             seg_idx++;
         }
     }
+
     // front and back
     for (int i = 0; i < var.nx - 1; ++i) {
         for (int k = 0; k < var.nz - 1; ++k) {
@@ -445,7 +453,10 @@ void create_regular_segments(const Variables& var, int *&segments, int *&segflag
             segflags[seg_idx] = BOUNDY0;
             seg_idx++;
 
-            idx_elem = idx_cell*5 + 2;
+            if (idx_cell%2)
+                idx_elem = idx_cell*5 + 3;
+            else
+                idx_elem = idx_cell*5 + 2;
             conn = (*var.connectivity)[idx_elem];
             segments[seg_idx*3] = conn[0];
             segments[seg_idx*3+1] = conn[1];
@@ -458,17 +469,31 @@ void create_regular_segments(const Variables& var, int *&segments, int *&segflag
             idx_cell = i * (var.ny - 1) * (var.nz - 1) + j * (var.nz - 1) + k;
             idx_elem = idx_cell*5;
             conn = (*var.connectivity)[idx_elem];
-            segments[seg_idx*3] = conn[1];
-            segments[seg_idx*3+1] = conn[2];
-            segments[seg_idx*3+2] = conn[3];
+            if (idx_cell%2) {
+                segments[seg_idx*3] = conn[0];
+                segments[seg_idx*3+1] = conn[1];
+                segments[seg_idx*3+2] = conn[3];
+            } else {
+                segments[seg_idx*3] = conn[1];
+                segments[seg_idx*3+1] = conn[2];
+                segments[seg_idx*3+2] = conn[3];
+            }
             segflags[seg_idx] = BOUNDY1;
             seg_idx++;
 
-            idx_elem = idx_cell*5 + 3;
-            conn = (*var.connectivity)[idx_elem];
-            segments[seg_idx*3] = conn[0];
-            segments[seg_idx*3+1] = conn[2];
-            segments[seg_idx*3+2] = conn[1];
+            if (idx_cell%2) {
+                idx_elem = idx_cell*5 + 2;
+                conn = (*var.connectivity)[idx_elem];
+                segments[seg_idx*3] = conn[0];
+                segments[seg_idx*3+1] = conn[3];
+                segments[seg_idx*3+2] = conn[2];
+            } else {
+                idx_elem = idx_cell*5 + 3;
+                conn = (*var.connectivity)[idx_elem];
+                segments[seg_idx*3] = conn[0];
+                segments[seg_idx*3+1] = conn[2];
+                segments[seg_idx*3+2] = conn[1];
+            }
             segflags[seg_idx] = BOUNDY1;
             seg_idx++;
         }

--- a/mesh.cxx
+++ b/mesh.cxx
@@ -231,7 +231,6 @@ void create_equilateral_node(const Param& param, const Variables& var, double *&
     double dz = -param.mesh.resolution * std::sqrt(3.0) / 2.;
 
     double bdy_dx = (param.mesh.xlength - (var.nx-1)*dx) / 2.;
-    double bdy_dz = param.mesh.zlength - (var.nz-1)*dz;
 
     int ind = 0;
     for (int j=0; j<var.nz; j+=2) {
@@ -287,86 +286,6 @@ void create_equilateral_node(const Param& param, const Variables& var, double *&
     }
 }
 
-
-void create_equilateral_elem(const Variables& var, int *&connectivity) {
-    connectivity = new int[var.nelem*3];
-
-    int istart_n1 = var.nx * (int(var.nz/2)+var.nz%2);
-
-    int ind = 0;
-    for (int j=0; j<var.nz-1;j++) {
-        int jnc = j%2;
-        int in0 = var.nx * int((j+1)/2);
-        int in1 = istart_n1 + (var.nx+1)*int(j/2);
-        int istarts[2] = {in0, in1};
-
-        for (int k=0; k<2;k++) {
-            int inc = (k+j)%2;
-            int istart0 = istarts[inc];
-            int istart1 = istarts[1-inc];
-
-            if (inc==0) {
-                for (int i=0; i<var.nx-1;i++) {
-                    connectivity[ind*3] = istart0+i;
-                    connectivity[ind*3+1+jnc] = istart1+i+1;
-                    connectivity[ind*3+2-jnc] = istart0+i+1;
-                    // printf("conn %d %d %d\n", connectivity[ind*3], connectivity[ind*3+1], connectivity[ind*3+2]);
-                    ind++;
-                }
-            } else {
-                for (int i=0; i<var.nx;i++) {
-                    connectivity[ind*3] = istart0+i;
-                    connectivity[ind*3+1+jnc] = istart0+i+1;
-                    connectivity[ind*3+2-jnc] = istart1+i;
-                    // printf("conn %d %d %d\n", connectivity[ind*3], connectivity[ind*3+1], connectivity[ind*3+2]);
-                    ind++;
-                }
-            }
-        }
-    }
-}
-
-void create_equilateral_segments(const Variables& var, int *&segments, int *&segflags) {
-    segments = new int[var.nseg*2];
-    segflags = new int[var.nseg];
-    int seg_idx = 0;
-    int flag_idx = 0;
-
-    // top
-    for (int i = 0; i<var.nx-1; ++i) {
-        segments[seg_idx*2] = i;
-        segments[seg_idx*2+1] = i+1;
-        seg_idx++;
-        segflags[flag_idx] = 32;
-        flag_idx++;
-    }
-    // bottom
-    int nbot = var.nx-var.nz%2;
-    for (int i = 0; i<nbot; ++i) {
-        segments[seg_idx*2] = var.nnode - nbot - 1 + i;
-        segments[seg_idx*2+1] = var.nnode - nbot + i;
-        seg_idx++;
-        segflags[flag_idx] = 16;
-        flag_idx++;
-    }
-
-    // left and right
-    int istart_n2 = var.nx * (int(var.nz/2)+var.nz%2);
-    for (int j=0; j<var.nz-1;j++) {
-        int jnc = j%2;
-        segments[seg_idx*2+jnc] = (int(j/2)+jnc)*var.nx;
-        segments[seg_idx*2+1-jnc] = istart_n2 + (int(j/2))*(var.nx+1);
-        seg_idx++;
-        segflags[flag_idx] = 1;
-        flag_idx++;
-
-        segments[seg_idx*2+jnc] = (int(j/2)+jnc+1)*var.nx -1;
-        segments[seg_idx*2+1-jnc] = istart_n2 + (int(j/2)+1)*(var.nx+1) -1;
-        seg_idx++;
-        segflags[flag_idx] = 2;
-        flag_idx++;
-    }
-}
 
 void new_mesh_regular_equilateral(const Param& param, Variables& var)
 {
@@ -1651,6 +1570,84 @@ void new_mesh_from_exofile(const Param& param, Variables& var)
 
 } // end of anonymous namespace
 
+
+void create_equilateral_elem(const Variables& var, int *&connectivity) {
+    connectivity = new int[var.nelem*3];
+
+    int istart_n1 = var.nx * (int(var.nz/2)+var.nz%2);
+
+    int ind = 0;
+    for (int j=0; j<var.nz-1;j++) {
+        int jnc = j%2;
+        int in0 = var.nx * int((j+1)/2);
+        int in1 = istart_n1 + (var.nx+1)*int(j/2);
+        int istarts[2] = {in0, in1};
+
+        for (int k=0; k<2;k++) {
+            int inc = (k+j)%2;
+            int istart0 = istarts[inc];
+            int istart1 = istarts[1-inc];
+
+            if (inc==0) {
+                for (int i=0; i<var.nx-1;i++) {
+                    connectivity[ind*3] = istart0+i;
+                    connectivity[ind*3+1+jnc] = istart1+i+1;
+                    connectivity[ind*3+2-jnc] = istart0+i+1;
+                    ind++;
+                }
+            } else {
+                for (int i=0; i<var.nx;i++) {
+                    connectivity[ind*3] = istart0+i;
+                    connectivity[ind*3+1+jnc] = istart0+i+1;
+                    connectivity[ind*3+2-jnc] = istart1+i;
+                    ind++;
+                }
+            }
+        }
+    }
+}
+
+void create_equilateral_segments(const Variables& var, int *&segments, int *&segflags) {
+    segments = new int[var.nseg*2];
+    segflags = new int[var.nseg];
+    int seg_idx = 0;
+    int flag_idx = 0;
+
+    // top
+    for (int i = 0; i<var.nx-1; ++i) {
+        segments[seg_idx*2] = i;
+        segments[seg_idx*2+1] = i+1;
+        seg_idx++;
+        segflags[flag_idx] = 32;
+        flag_idx++;
+    }
+    // bottom
+    int nbot = var.nx-var.nz%2;
+    for (int i = 0; i<nbot; ++i) {
+        segments[seg_idx*2] = var.nnode - nbot - 1 + i;
+        segments[seg_idx*2+1] = var.nnode - nbot + i;
+        seg_idx++;
+        segflags[flag_idx] = 16;
+        flag_idx++;
+    }
+
+    // left and right
+    int istart_n2 = var.nx * (int(var.nz/2)+var.nz%2);
+    for (int j=0; j<var.nz-1;j++) {
+        int jnc = j%2;
+        segments[seg_idx*2+jnc] = (int(j/2)+jnc)*var.nx;
+        segments[seg_idx*2+1-jnc] = istart_n2 + (int(j/2))*(var.nx+1);
+        seg_idx++;
+        segflags[flag_idx] = 1;
+        flag_idx++;
+
+        segments[seg_idx*2+jnc] = (int(j/2)+jnc+1)*var.nx -1;
+        segments[seg_idx*2+1-jnc] = istart_n2 + (int(j/2)+1)*(var.nx+1) -1;
+        seg_idx++;
+        segflags[flag_idx] = 2;
+        flag_idx++;
+    }
+}
 
 void points_to_new_mesh(const Mesh &mesh, int npoints, const double *points,
                         int n_init_segments, const int *init_segments, const int *init_segflags,

--- a/mesh.hpp
+++ b/mesh.hpp
@@ -30,5 +30,7 @@ void create_elemmarkers(const Param&, Variables&);
 void create_markers(const Param&, Variables&);
 void create_new_mesh(const Param&, Variables&);
 double** elem_center(const array_t &coord, const conn_t &connectivity);
+void create_equilateral_elem(const Variables& var, int *&connectivity);
+void create_equilateral_segments(const Variables& var, int *&segments, int *&segflags);
 
 #endif

--- a/parameters.hpp
+++ b/parameters.hpp
@@ -29,7 +29,7 @@ typedef Array2D<double,2> dh_t;
 typedef Array2D<int,NODES_PER_ELEM> conn_t;
 typedef Array2D<int,NDIMS> segment_t;
 typedef Array2D<int,1> segflag_t;
-typedef Array2D<int,NODES_PER_REGULAR> regular_t;
+typedef Array2D<int,NODES_PER_CELL> regular_t;
 
 // forward declaration
 class PhaseChange;

--- a/parameters.hpp
+++ b/parameters.hpp
@@ -418,6 +418,7 @@ struct Variables {
     int nnode;
     int nelem;
     int nseg;
+    int nx, ny, nz, ncell;
 
     double max_vbc_val;
     double compensation_pressure;
@@ -431,6 +432,7 @@ struct Variables {
     regattr_t *regattr;
     array_t *old_coord;
     conn_t *old_connectivity;
+    regular_t *cell;
 
 
     uint_vec *bcflag;

--- a/parameters.hpp
+++ b/parameters.hpp
@@ -29,6 +29,7 @@ typedef Array2D<double,2> dh_t;
 typedef Array2D<int,NODES_PER_ELEM> conn_t;
 typedef Array2D<int,NDIMS> segment_t;
 typedef Array2D<int,1> segflag_t;
+typedef Array2D<int,NODES_PER_REGULAR> regular_t;
 
 // forward declaration
 class PhaseChange;
@@ -56,6 +57,7 @@ struct Sim {
 
 struct Mesh {
     int meshing_option;
+    int meshing_elem_shape;
     int meshing_verbosity;
     bool meshing_sediment;
     int tetgen_optlevel;

--- a/remeshing.cxx
+++ b/remeshing.cxx
@@ -1436,11 +1436,28 @@ void new_uniformed_regular_mesh(const Param &param, Variables &var,
               const segment_t &old_segment, const segflag_t &old_segflag)
 {
 
-    // create a copy of original mesh
-    var.coord = new array_t(var.nnode);
-    var.connectivity = new conn_t(old_conn);
-    var.segment = new segment_t(old_segment);
-    var.segflag = new segflag_t(old_segflag);
+    double *qcoord = new double[var.nnode * NDIMS];
+    int *qconn = new int[var.nelem * NODES_PER_ELEM];
+    int *qsegment = new int[var.nseg * NODES_PER_FACET];
+    int *qsegflag = new int[var.nseg];
+
+    var.coord->reset(qcoord, var.nnode);
+    var.connectivity->reset(qconn, var.nelem);
+    var.segment->reset(qsegment, var.nseg);
+    var.segflag->reset(qsegflag, var.nseg);
+
+    for (int i = 0; i < var.nelem; ++i) {
+        int* p = (*var.connectivity)[i];
+        p[0] = old_conn[i][0];
+        p[1] = old_conn[i][1];
+        p[2] = old_conn[i][2];
+    }
+    for (int i = 0; i < var.nseg; ++i) {
+        int* p = (*var.segment)[i];
+        p[0] = old_segment[i][0];
+        p[1] = old_segment[i][1];
+        (*var.segflag)[i][0] = old_segflag[i][0];
+    }
 
     array_t inz(var.nz);
     array_t outz(var.nz);

--- a/remeshing.cxx
+++ b/remeshing.cxx
@@ -1802,15 +1802,15 @@ void new_uniformed_regular_mesh(const Param &param, Variables &var,
 
     // interpolate coordinates
 #ifdef THREED
-    const int_vec nxyz = {var.nx, var.ny, var.nz};
+    int_vec nxyz = {var.nx, var.ny, var.nz};
 
     // interpolate edges
     for (int n0=0;n0<NDIMS;n0++) {
         for (int n1=n0+1;n1<NDIMS;n1++) {
             if (n0 >= n1) continue;
-            const int n2 = 3 - n0 - n1;
+            int n2 = 3 - n0 - n1;
 
-            #pragma omp parallel for default(none) shared(param,var,old_coord,n0,n1) collapse(2)
+            #pragma omp parallel for default(none) shared(param,var,old_coord,nxyz,n0,n1,n2) collapse(2)
             for (int ii=0; ii<2; ii++) {
                 for (int jj=0; jj<2; jj++) {
                     array_t in(nxyz[n2]);
@@ -1876,7 +1876,7 @@ void new_uniformed_regular_mesh(const Param &param, Variables &var,
 
     // interpolation x, y, z in each plane
     for (int n0=0; n0<NDIMS; n0++) {
-        #pragma omp parallel for default(none) shared(param,var,old_coord,n0)
+        #pragma omp parallel for default(none) shared(param,var,old_coord,nxyz,n0)
         for (int ii=1; ii<nxyz[n0]-1; ii++) {
             for (int n1=0; n1<NDIMS; n1++) {
                 if (n0 == n1) continue;
@@ -1906,9 +1906,9 @@ void new_uniformed_regular_mesh(const Param &param, Variables &var,
     for (int n0=0; n0<NDIMS; n0++) {
         for (int n1=0; n1<NDIMS; n1++) {
             if (n0 >= n1) continue;
-            const int n2 = 3 - n0 - n1;
+            int n2 = 3 - n0 - n1;
 
-            #pragma omp parallel for default(none) shared(param,var,old_coord,n0,n1) collapse(2)
+            #pragma omp parallel for default(none) shared(param,var,old_coord,nxyz,n0,n1,n2) collapse(2)
             for (int ii=1; ii<nxyz[n0]-1;ii++) {
                 for (int jj=1; jj<nxyz[n1]-1;jj++) {
                     for (int kk=0; kk<2; kk++) {
@@ -2040,9 +2040,9 @@ void new_uniformed_regular_mesh(const Param &param, Variables &var,
     for (int n0=0; n0<NDIMS;n0++) {
         for (int n1=0; n1<NDIMS;n1++) {
             if (n0 >= n1) continue;
-            const int n2 = 3 - n0 - n1;
+            int n2 = 3 - n0 - n1;
 
-            #pragma omp parallel for default(none) shared(var,n0,n1) collapse(2)
+            #pragma omp parallel for default(none) shared(var,nxyz,n0,n1,n2) collapse(2)
             for (int ii=1; ii<nxyz[n0]-1;ii++) {
                 for (int jj=1; jj<nxyz[n1]-1; jj++) {
                     int_vec idx0(3);
@@ -2265,9 +2265,9 @@ void optimize_mesh(const Param &param, Variables &var, int bad_quality,
         excl_func = &is_corner;
         flatten_bottom(old_bcflag, qcoord, -param.mesh.zlength,
                    points_to_delete, min_dist);
-        flatten_x0(old_bcflag, qcoord, points_to_delete);
+        flatten_x0(old_bcflag, qcoord, points_to_delete, min_dist);
         flatten_x1(old_bcflag, qcoord, param.mesh.xlength, points_to_delete, min_dist);
-        flatten_y0(old_bcflag, qcoord, points_to_delete);
+        flatten_y0(old_bcflag, qcoord, points_to_delete, min_dist);
         flatten_y1(old_bcflag, qcoord, param.mesh.ylength, points_to_delete, min_dist);
         break;
     default:

--- a/remeshing.cxx
+++ b/remeshing.cxx
@@ -1533,7 +1533,7 @@ void new_uniformed_regular_mesh(const Param &param, Variables &var,
     // interpolate the z with bottom and top side nodes
     for (int i = 1; i < var.nx - 1; ++i) {
         double zi = (*var.coord)[i * var.nz][1];
-        double ze = (*var.coord)[i * var.nz - 1][1];
+        double ze = (*var.coord)[(i + 1) * var.nz - 1][1];
         double dz = (ze - zi) / (var.nz - 1);
         for (int j = 1; j < var.nz - 1; ++j)
             (*var.coord)[i * var.nz + j][1] = zi + j * dz; 

--- a/remeshing.cxx
+++ b/remeshing.cxx
@@ -1724,7 +1724,7 @@ void new_uniformed_regular_mesh(const Param &param, Variables &var,
             if (n0 >= n1) continue;
             const int n2 = 3 - n0 - n1;
 
-            #pragma omp parallel for default(none) shared(param,var,old_coord,n0,n1,n2,nxyz) collapse(2)
+            #pragma omp parallel for default(none) shared(param,var,old_coord,n0,n1) collapse(2)
             for (int ii=0; ii<2; ii++) {
                 for (int jj=0; jj<2; jj++) {
                     array_t in(nxyz[n2]);
@@ -1761,7 +1761,7 @@ void new_uniformed_regular_mesh(const Param &param, Variables &var,
 
     // interpolation x, y, z in each plane
     for (int n0=0; n0<NDIMS; n0++) {
-        #pragma omp parallel for default(none) shared(param,var,old_coord,n0,nxyz)
+        #pragma omp parallel for default(none) shared(param,var,old_coord,n0)
         for (int ii=1; ii<nxyz[n0]-1; ii++) {
             for (int n1=0; n1<NDIMS; n1++) {
                 if (n0 == n1) continue;
@@ -1793,7 +1793,7 @@ void new_uniformed_regular_mesh(const Param &param, Variables &var,
             if (n0 >= n1) continue;
             const int n2 = 3 - n0 - n1;
 
-            #pragma omp parallel for default(none) shared(param,var,old_coord,n0,n1,n2,nxyz) collapse(2)
+            #pragma omp parallel for default(none) shared(param,var,old_coord,n0,n1) collapse(2)
             for (int ii=1; ii<nxyz[n0]-1;ii++) {
                 for (int jj=1; jj<nxyz[n1]-1;jj++) {
                     for (int kk=0; kk<2; kk++) {
@@ -1901,7 +1901,7 @@ void new_uniformed_regular_mesh(const Param &param, Variables &var,
             if (n0 >= n1) continue;
             const int n2 = 3 - n0 - n1;
 
-            #pragma omp parallel for default(none) shared(var,n0,n1,n2,nxyz) collapse(2)
+            #pragma omp parallel for default(none) shared(var,n0,n1) collapse(2)
             for (int ii=1; ii<nxyz[n0]-1;ii++) {
                 for (int jj=1; jj<nxyz[n1]-1; jj++) {
                     int_vec idx0(3);


### PR DESCRIPTION
This pull request adds support for generating regular meshes in DES (both 2D and 3D), aimed at improving mesh stability and remeshing efficiency.
Regular mesh generation can be enabled using:
- `meshing_option=1`
-- `meshing_elem_shape=1` (for rectangular grids in 2D and 3D)
-- `meshing_elem_shape=2` (for 2D equilateral triangle grids)

In regular mesh mode (`meshing_elem_shape=1`), remeshing preserves the original numbering of nodes and elements, maintaining the same connectivity and segment definitions. The nodes are re-interpolated to match regular spacing.

For `meshing_elem_shape=2`, the mesh is also re-interpolated to maintain regular spacing, but the node and element numbering is recalculated each time to adapt to mesh resolution. If boundaries move significantly from their original positions, the number of nodes and elements may increase or decrease accordingly.

A new option, `remeshing_option=13`, has been added to allow automatic resetting of boundary positions (bottom and sides) during remeshing, ensuring resolution consistency when using fixed-element-number regular meshes (`meshing_elem_shape=1`).

Remeshing is currently implemented by simply re-interpolating nodes with regular spacing, parallelized using OpenMP. However, nearest-neighbor searching still relies on the single-threaded KD-tree library (ANN). Remeshing performance could be further improved by integrating a parallel NN search library or implementing a regular-grid-specific search algorithm.

The test input files `test-3d-equ-tiny.cfg` and `test-3d-equ-long.cfg` are included in the `benchmarks-cores` directory.

<img width="1536" alt="Screenshot 2025-04-07 at 11 30 37" src="https://github.com/user-attachments/assets/db499d2e-7cc5-4a68-88d5-0819ab8d72b6" />