### PR TITLE
Fix bugs before and after RAS and clean code

### DIFF
--- a/brc-interpolation.cxx
+++ b/brc-interpolation.cxx
@@ -233,11 +233,6 @@ void barycentric_node_interpolation(Variables &var,
     interpolate_field(brc, el, old_connectivity, *var.ppressure, *a);
     delete var.ppressure;
     var.ppressure = a;
-  
-    a = new double_vec(var.nnode);
-    interpolate_field(brc, el, old_connectivity, *var.dppressure, *a);
-    delete var.dppressure;
-    var.dppressure = a;
 
     a = new double_vec(var.nnode);
     interpolate_field(brc, el, old_connectivity, *var.dppressure, *a);

--- a/fields.cxx
+++ b/fields.cxx
@@ -436,7 +436,7 @@ static void apply_damping(const Param& param, const Variables& var, array_t& for
             shared(var, param, force, small_vel)
 #else
         #pragma omp parallel for default(none) \
-            shared(var, param, force)
+            shared(var, param, force)  firstprivate(small_vel)
 #endif
         #pragma acc parallel loop
         for (int i=0; i<var.nnode; ++i) {
@@ -481,7 +481,7 @@ static void apply_damping(const Param& param, const Variables& var, array_t& for
             shared(var, param, force, small_vel)
 #else
         #pragma omp parallel for default(none) \
-        shared(var, param, force, small_vel)
+        shared(var, param, force) firstprivate(small_vel)
 #endif
         #pragma acc parallel loop
         for (int i=0; i<var.nnode; ++i) {

--- a/ic.cxx
+++ b/ic.cxx
@@ -598,9 +598,8 @@ void initial_temperature(const Param &param, const Variables &var,
     }
 
     double max_temp = 0.0;
-    for (int i=0; i<var.nnode; ++i) {
+    for (int i=0; i<var.nnode; ++i)
         if (temperature[i] > max_temp) max_temp = temperature[i];
-    }
     bottom_temperature = max_temp;
 }
 

--- a/mesh.cxx
+++ b/mesh.cxx
@@ -856,23 +856,6 @@ void new_mesh_regular(const Param& param, Variables& var)
     double *pcoord, *pregattr;
     int *pconnectivity, *psegment, *psegflag, *pcell;
 
-    var.nx = std::round(param.mesh.xlength/param.mesh.resolution) + 1;
-    var.nz = std::round(param.mesh.zlength/param.mesh.resolution) + 1;
-    var.ncell = (var.nx-1) * (var.nz-1);
-    var.nnode = var.nx * var.nz;
-    var.nelem = 2 * var.ncell;
-    var.nseg = 2 * (var.nx + var.nz - 2);
-#ifdef THREED
-    var.ny = std::round(param.mesh.ylength/param.mesh.resolution) + 1;
-    var.ncell *= (var.ny-1);
-    var.nnode *= var.ny;
-    var.nelem = 5 * var.ncell;
-    var.nseg = 4 * ( (var.nx-1) * (var.ny-1) + \
-                     (var.ny-1) * (var.nz-1) + \
-                     (var.nz-1) * (var.nx-1) );
-#endif
-    
-
     create_quadrilateral_cells(var, pcell);
     var.cell = new regular_t(pcell, var.ncell);
 

--- a/output.cxx
+++ b/output.cxx
@@ -227,11 +227,11 @@ void Output::write(const Variables& var)
 }
 
 
-void Output::write_exact(const Param& param, const Variables& var)
+void Output::write_exact(const Variables& var)
 {
     _write(var, true);
     // check for NaN in var
-    check_nan(param,var);
+    check_nan(var);
 }
 
 
@@ -296,6 +296,8 @@ void Output::write_checkpoint(const Param& param, const Variables& var)
     bin.write_array(*var.segflag, "segflag", var.segflag->size());
     // Note: regattr is not needed for restarting
     // bin.write_array(*var.regattr, "regattr", var.regattr->size());
+
+    bin.write_array(*var.surfinfo.edvacc_surf, "dv surface acc", var.surfinfo.edvacc_surf->size());
 
     bin.write_array(*var.volume_old, "volume_old", var.volume_old->size());
     if (param.mat.is_plane_strain)

--- a/output.hpp
+++ b/output.hpp
@@ -27,7 +27,7 @@ public:
     Output(const Param& param, int64_t start_time, int start_frame);
     ~Output();
     void write(const Variables& var);
-    void write_exact(const Param& param, const Variables& var);
+    void write_exact(const Variables& var);
     void write_checkpoint(const Param& param, const Variables& var);
     void average_fields(Variables& var);
 

--- a/remeshing.cxx
+++ b/remeshing.cxx
@@ -2988,6 +2988,7 @@ int bad_mesh_quality(const Param &param, const Variables &var, int &index)
     }
     // check if any side node is too far away from the side
     if (param.mesh.remeshing_option == 13) {
+        index = -1;
         const double dist = param.mesh.max_boundary_distortion * param.mesh.resolution;
         for (int i=0; i<var.nnode; ++i) {
             if (is_x0((*var.bcflag)[i])) {

--- a/rheology.cxx
+++ b/rheology.cxx
@@ -825,12 +825,12 @@ void update_stress(const Param& param, Variables& var, tensor_t& stress,
                 if (var.mat->is_plane_strain) {
                     spyy = syy;
                     elasto_plastic2d(bulkm, shearm, amc, anphi, anpsi, hardn, ten_max,
-                                     de, depls, s, syy, failure_mode, 
+                                     de, depls, sp, spyy, failure_mode, 
                                      param.control.has_hydraulic_diffusion, dpp);
                 }
                 else {
                     elasto_plastic(bulkm, shearm, amc, anphi, anpsi, hardn, ten_max,
-                                   de, depls, s, failure_mode, 
+                                   de, depls, sp, failure_mode, 
                                    param.control.has_hydraulic_diffusion, dpp);
                 }
                 double spII = second_invariant2(sp);
@@ -910,12 +910,12 @@ void update_stress(const Param& param, Variables& var, tensor_t& stress,
                 if (var.mat->is_plane_strain) {
                     spyy = syy;
                     elasto_plastic2d(bulkm, shearm, amc, anphi, anpsi, hardn, ten_max,
-                                     de, depls, s, syy, failure_mode, 
+                                     de, depls, sp, spyy, failure_mode, 
                                      param.control.has_hydraulic_diffusion, dpp);
                 }
                 else {
                     elasto_plastic(bulkm, shearm, amc, anphi, anpsi, hardn, ten_max,
-                                   de, depls, s, failure_mode, 
+                                   de, depls, sp, failure_mode, 
                                    param.control.has_hydraulic_diffusion, dpp);
                 }
                 double spII = second_invariant2(sp);

--- a/utils.hpp
+++ b/utils.hpp
@@ -163,11 +163,11 @@ static void out_nan_error(const char* msg, const int idx0, const int idx1 = -1) 
     std::exit(11);
 }
 
-static void check_nan(const Param& param, const Variables& var) {
+static void check_nan(const Variables& var) {
 #ifdef USE_NPROF
     nvtxRangePushA(__FUNCTION__);
 #endif
-    #pragma omp parallel default(none) shared(param,var)
+    #pragma omp parallel default(none) shared(var)
     {
         #pragma omp for
         for (int e=0; e<var.nelem;e++) {


### PR DESCRIPTION
Bug after RAS:
- fix bug of omp share parameter in g++ 8.5 in apply_damping
- fix bug of remeshing_option = 13
- fix duplicate interpolate_field of dppressure

Clean code:
- remove unused param input for write_exact
- update code formatting of dynearthsol.cxx

Bug before RAS
- fix bug of restart for regular mesh
- fix bug of restart for bottom temperature
- fix missing edvacc_surf chkpt for restart