### PR TITLE
Fix bug of missing break after rh_evp in update_stress()

### DIFF
--- a/rheology.cxx
+++ b/rheology.cxx
@@ -845,7 +845,8 @@ void update_stress(const Param& param, Variables& var, tensor_t& stress,
                     syy = spyy;
                 }
             }
-            case MatProps::rh_ep_rsf: // rate-and-state frition model
+            break;
+        case MatProps::rh_ep_rsf: // rate-and-state frition model
             {
                 double depls = 0;
                 double bulkm = var.mat->bulkm(e);


### PR DESCRIPTION
Fix bug of missing break after rh_evp in update_stress()