### PR TITLE
Surface-only interpolation for sediment deposits during remeshing

### DIFF
--- a/barycentric-fn.hpp
+++ b/barycentric-fn.hpp
@@ -25,6 +25,10 @@ public:
                                const array_t &coord,
                                const conn_t &connectivity,
                                const double_vec &volume);
+    Barycentric_transformation(const array_t &coord,
+                               const conn_t&conn_surface,
+                               const double_vec &volume,
+                               const bool is_surface);
     Barycentric_transformation(const double** coord,
                                const double volume);
     ~Barycentric_transformation();
@@ -39,6 +43,12 @@ private:
 
     inline int index(int node, int dim) const;
 
+    void compute_coeff2d(const double *a,
+                         const double *b,
+                         const double *c,
+                         double area,
+                         double *coeff_e);
+
 #ifdef THREED
     void compute_coeff3d(const double *a,
                          const double *b,
@@ -47,10 +57,9 @@ private:
                          double volume,
                          double *coeff_e);
 #else
-    void compute_coeff2d(const double *a,
+    void compute_coeff1d(const double *a,
                          const double *b,
-                         const double *c,
-                         double area,
+                         double length,
                          double *coeff_e);
 #endif
 

--- a/bc.cxx
+++ b/bc.cxx
@@ -2054,7 +2054,6 @@ void surface_processes(const Param& param, const Variables& var, array_t& coord,
 #endif
         #pragma acc parallel loop async
         for (int i=0;i<var.surfinfo.etop;i++) {
-            int e = (*var.surfinfo.top_facet_elems)[i];
             int_vec n(NDIMS);
             double dh_e = 0.;
 
@@ -2070,7 +2069,7 @@ void surface_processes(const Param& param, const Variables& var, array_t& coord,
 #else
             double base = (*var.coord)[n[0]][0] - (*var.coord)[n[1]][0];
 #endif
-            (*var.surfinfo.edvacc_surf)[e] += dh_e * base / NDIMS;
+            (*var.surfinfo.edvacc_surf)[i] += dh_e * base / NDIMS;
         }
     }
 
@@ -2081,8 +2080,7 @@ void surface_processes(const Param& param, const Variables& var, array_t& coord,
 // #endif
 //         #pragma acc parallel loop async reduction(+:sum)
 //         for (int i=0; i<var.surfinfo.etop; i++) {
-//             int e = (*var.surfinfo.top_facet_elems)[i];
-//             sum += (*var.surfinfo.edvacc_surf)[e];
+//             sum += (*var.surfinfo.edvacc_surf)[i];
 //         }
 //         #pragma acc wait
 //         printf("Sum of accu. surface deposition volume: %.2e\n", sum);

--- a/geometry.cxx
+++ b/geometry.cxx
@@ -83,6 +83,19 @@ static double triangle_area(const double *a,
 #endif
 }
 
+double compute_area(const double **coord)
+{
+    const double *a = coord[0];
+    const double *b = coord[1];
+#ifdef THREED
+    const double *c = coord[2];
+
+    return triangle_area(a, b, c);
+#else
+    return std::sqrt(dist2(a, b));
+#endif
+}
+
 double compute_volume(const double **coord)
 {
     const double *a = coord[0];

--- a/geometry.cxx
+++ b/geometry.cxx
@@ -48,6 +48,22 @@ static double tetrahedron_volume(const double *d0,
             x23*(y12*z01 - y01*z12)) / 6;
 }
 
+#pragma acc routine seq
+static double triangle_area2d(const double *a,
+                            const double *b,
+                            const double *c)
+{
+    double ab0, ab1, ac0, ac1;
+
+    // ab: vector from a to b
+    ab0 = b[0] - a[0];
+    ab1 = b[1] - a[1];
+    // ac: vector from a to c
+    ac0 = c[0] - a[0];
+    ac1 = c[1] - a[1];
+
+    return std::fabs(ab0*ac1 - ab1*ac0) / 2;
+}
 
 /* Given two points, returns the area of the enclosed triangle */
 #pragma acc routine seq
@@ -83,16 +99,17 @@ static double triangle_area(const double *a,
 #endif
 }
 
-double compute_area(const double **coord)
+double compute_area_facet(const double **coord)
 {
     const double *a = coord[0];
     const double *b = coord[1];
-#ifdef THREED
+
+#ifndef THREED
+    return std::fabs(a[0]-b[0]);
+#else
     const double *c = coord[2];
 
-    return triangle_area(a, b, c);
-#else
-    return std::sqrt(dist2(a, b));
+    return triangle_area2d(a, b, c);
 #endif
 }
 

--- a/geometry.hpp
+++ b/geometry.hpp
@@ -4,6 +4,8 @@
 double dist2(const double* a, const double* b);
 #pragma acc routine seq
 double compute_volume(const double **coord);
+#pragma acc routine seq
+double compute_area(const double **coord);
 void compute_volume(const array_t &coord, const conn_t &connectivity,
                     double_vec &volume);
 void compute_volume(const Variables &var, double_vec &volume);

--- a/geometry.hpp
+++ b/geometry.hpp
@@ -5,7 +5,7 @@ double dist2(const double* a, const double* b);
 #pragma acc routine seq
 double compute_volume(const double **coord);
 #pragma acc routine seq
-double compute_area(const double **coord);
+double compute_area_facet(const double **coord);
 void compute_volume(const array_t &coord, const conn_t &connectivity,
                     double_vec &volume);
 void compute_volume(const Variables &var, double_vec &volume);

--- a/markerset.cxx
+++ b/markerset.cxx
@@ -265,18 +265,17 @@ void MarkerSet::set_surface_marker(const Param& param,const Variables& var, cons
     //     double max_edvacc = 0.0;
     //     #pragma omp parallel for reduction(max:max_edvacc)
     //     for (int i=0; i<var.surfinfo.etop; i++) {
-    //         int e = (*var.surfinfo.top_facet_elems)[i];
-    //         if (edvacc[e] > max_edvacc) {
-    //             max_edvacc = edvacc[e];
+    //         if (edvacc[i] > max_edvacc) {
+    //             max_edvacc = edvacc[i];
     //         }
     //     }
 
     //     printf("Surface accu mat #%d: ", mattype);
     //     for (int i=0; i<var.surfinfo.etop; i++) {
     //         int e = (*var.surfinfo.top_facet_elems)[i];
-    //         if (edvacc[e] > max_edvacc - 1.) {
-    //             double ratio = (param.markers.markers_per_element * edvacc[e]) / (*var.volume)[e];
-    //             printf("elem[%6d] = %.1e, ratio = %5.1f%% ", e, edvacc[e], ratio*100.);
+    //         if (edvacc[i] > max_edvacc - 1.) {
+    //             double ratio = (param.markers.markers_per_element * edvacc[i]) / (*var.volume)[e];
+    //             printf("elem[%6d] = %.1e, ratio = %5.1f%% ", e, edvacc[i], ratio*100.);
     //         }
     //     }
     //     printf("\n");
@@ -288,8 +287,8 @@ void MarkerSet::set_surface_marker(const Param& param,const Variables& var, cons
         int e = (*var.surfinfo.top_facet_elems)[i];
         (*var.etmp_int)[i] = -1;
 
-        if (edvacc[e] < 0.) {
-            edvacc[e] = 0.;
+        if (edvacc[i] < 0.) {
+            edvacc[i] = 0.;
             continue;
         }
 
@@ -302,7 +301,7 @@ void MarkerSet::set_surface_marker(const Param& param,const Variables& var, cons
             nmarkers = (*var.markers_in_elem)[e].size();
         }
 
-        if ((nmarkers * edvacc[e]) < (*var.volume)[e]) continue;
+        if ((nmarkers * edvacc[i]) < (*var.volume)[e]) continue;
 
         double eta[NDIMS], mcoord[NDIMS] = {0.};
 
@@ -330,7 +329,7 @@ void MarkerSet::set_surface_marker(const Param& param,const Variables& var, cons
 
         // height of marker
         double dv_apply = (*var.volume)[e] / nmarkers;
-        edvacc[e] -= dv_apply;
+        edvacc[i] -= dv_apply;
 
         double edh = dv_apply / base;
         mcoord[NDIMS-1] -= edh * marker_dh_applied_ratio;

--- a/markerset.cxx
+++ b/markerset.cxx
@@ -349,11 +349,18 @@ void MarkerSet::set_surface_marker(const Param& param,const Variables& var, cons
 
         if (!bary.is_inside(eta0)) {
             int inc = 0;
-            printf("  A generated marker (mat=%d) in element %d is trying to remap in element ", mattype, e);
             remap_marker(var, mcoord, e, elem_dest, eta0, inc);
+
+            char buffer[200];
+            sprintf(buffer, "  A generated marker (mat=%d) in element %7d is trying to remap in elements ",
+                    mattype, e);
+            std::string msg(buffer);
+
             if (inc) {
-                printf("... Success!\n");
+                msg += "... Success!\n";
+                printf("%s", msg.c_str());
             } else {
+                printf("%s", msg.c_str());
                 printf("... Surface marker generated fail!\n Coordinate: ");
                 for (int j=0; j<NDIMS; j++) printf(" %f", mcoord[j]);
                 printf("\neta: ");

--- a/mesh.hpp
+++ b/mesh.hpp
@@ -33,7 +33,7 @@ void create_elemmarkers(const Param&, Variables&);
 void create_markers(const Param&, Variables&);
 void create_new_mesh(const Param&, Variables&);
 void elem_center(const array_t &coord, const conn_t &connectivity, array_t& points);
-void facet_center(const array_t &coord, const segment_t &connectivity, array_t& center);
+void facet_center(const array_t &coord, const conn_t &connectivity, array_t& center);
 void create_equilateral_elem(const Variables& var, int *&connectivity);
 void create_equilateral_segments(const Variables& var, int *&segments, int *&segflags);
 

--- a/mesh.hpp
+++ b/mesh.hpp
@@ -33,6 +33,7 @@ void create_elemmarkers(const Param&, Variables&);
 void create_markers(const Param&, Variables&);
 void create_new_mesh(const Param&, Variables&);
 void elem_center(const array_t &coord, const conn_t &connectivity, array_t& points);
+void facet_center(const array_t &coord, const segment_t &connectivity, array_t& center);
 void create_equilateral_elem(const Variables& var, int *&connectivity);
 void create_equilateral_segments(const Variables& var, int *&segments, int *&segflags);
 

--- a/nn-interpolation.cxx
+++ b/nn-interpolation.cxx
@@ -206,7 +206,7 @@ namespace {
 
                 // Count
                 int total_count = 0;
-                for (int k=0; k<=elem_size; ++k)
+                for (int k=0; k<elem_size; ++k)
                     total_count += elem_count_buf[k];
 
                 // std::cout << "  has " << total_count << " points\n";

--- a/nn-interpolation.cxx
+++ b/nn-interpolation.cxx
@@ -85,6 +85,12 @@ namespace {
         const double spacing0 = 1.0 / neta0;
         const double spacing1 = 1.0 / neta1;
         const double spacing2 = 1.0 / neta2;
+
+        const int neta0_surf = 20; // larger neta0, more accurate mapping
+        const int neta1_surf = neta0_surf + 1; // different from neta0 to prevent the temporary point falling the edge of elements
+        const double spacing0_surf = 1.0 / neta0_surf;
+        const double spacing1_surf = 1.0 / neta1_surf;
+
         const int max_el = std::min(32, old_nelem);
         const double eps = 1e-15;
 
@@ -96,15 +102,15 @@ namespace {
 
         double_vec2D sample_eta;
         if (is_surface) {
-            for (int i=0; i<neta0; i++) {
+            for (int i=0; i<neta0_surf; i++) {
 #ifdef THREED
-                for (int j=0; j<neta1; j++) {
-                    double eta[3] = {(i + 0.5) * spacing0,
-                                    (j + 0.5) * spacing1,
-                                    1 - (i + 0.5) * spacing0 - (j + 0.5) * spacing1};
+                for (int j=0; j<neta1_surf; j++) {
+                    double eta[3] = {(i + 0.5) * spacing0_surf,
+                                    (j + 0.5) * spacing1_surf,
+                                    1 - (i + 0.5) * spacing0_surf - (j + 0.5) * spacing1_surf};
 #else
-                    double eta[2] = {(i + 0.5) * spacing0,
-                                    1 - (i + 0.5) * spacing0};
+                    double eta[2] = {(i + 0.5) * spacing0_surf,
+                                    1 - (i + 0.5) * spacing0_surf};
 #endif
                     if (eta[NODES_PER_FACET-1] < eps) continue;
 

--- a/nn-interpolation.hpp
+++ b/nn-interpolation.hpp
@@ -4,6 +4,8 @@
 void nearest_neighbor_interpolation(const Param& Param, Variables &var,
                                     const Barycentric_transformation &bary,
                                     const array_t &old_coord,
-                                    const conn_t &old_connectivity);
+                                    const conn_t &old_connectivity,
+                                    const bool is_surface = false,
+                                    const int_pair_vec &old_bfacets_surface = int_pair_vec());
 
 #endif

--- a/nn-interpolation.hpp
+++ b/nn-interpolation.hpp
@@ -5,7 +5,6 @@ void nearest_neighbor_interpolation(const Param& Param, Variables &var,
                                     const Barycentric_transformation &bary,
                                     const array_t &old_coord,
                                     const conn_t &old_connectivity,
-                                    const bool is_surface = false,
-                                    const int_pair_vec &old_bfacets_surface = int_pair_vec());
+                                    const bool is_surface = false);
 
 #endif

--- a/parameters.hpp
+++ b/parameters.hpp
@@ -534,11 +534,10 @@ struct Variables {
     // These 5 arrays are allocated by external library
     array_t *coord;
     conn_t *connectivity;
+    conn_t *connectivity_surface;
     segment_t *segment;
     segflag_t *segflag;
     regattr_t *regattr;
-    array_t *old_coord;
-    conn_t *old_connectivity;
     regular_t *cell;
 
 

--- a/remeshing.cxx
+++ b/remeshing.cxx
@@ -3069,7 +3069,7 @@ void remesh(const Param &param, Variables &var, int bad_quality)
 
     // convert value field to average field
 #ifndef ACC
-    #pragma omp parallel for default(none) shared(var)
+    #pragma omp parallel for default(none) shared(var,old_surface_area)
 #endif
     #pragma acc parallel loop async
     for (int i=0; i<var.surfinfo.etop; i++) {
@@ -3204,7 +3204,7 @@ void remesh(const Param &param, Variables &var, int bad_quality)
 
     // convert value field back to portional field for nn interpolation
 #ifndef ACC
-    #pragma omp parallel for default(none) shared(var)
+    #pragma omp parallel for default(none) shared(var,surface_area)
 #endif
     #pragma acc parallel loop async
     for (int i=0; i<var.surfinfo.etop; i++) {

--- a/remeshing.cxx
+++ b/remeshing.cxx
@@ -3057,7 +3057,7 @@ void remesh(const Param &param, Variables &var, int bad_quality)
     double_vec old_surface_area(var.surfinfo.etop);
 
 #ifndef ACC
-    #pragma omp parallel for default(none) shared(var,NODES_PER_FACET,old_surface_area)
+    #pragma omp parallel for default(none) shared(var,old_surface_area)
 #endif
     #pragma acc parallel loop async
     for (int i=0; i<var.surfinfo.etop; ++i) {
@@ -3192,7 +3192,7 @@ void remesh(const Param &param, Variables &var, int bad_quality)
     double_vec surface_area(var.surfinfo.etop);
 
 #ifndef ACC
-    #pragma omp parallel for default(none) shared(var,NODES_PER_FACET,surface_area)
+    #pragma omp parallel for default(none) shared(var,surface_area)
 #endif
     #pragma acc parallel loop async
     for (int i=0; i<var.surfinfo.etop; ++i) {

--- a/remeshing.cxx
+++ b/remeshing.cxx
@@ -3054,32 +3054,41 @@ void remesh(const Param &param, Variables &var, int bad_quality)
 #endif
     std::cout << "  Remeshing starts...\n";
 
-    // convert portional field to average field
+    double_vec old_surface_area(var.surfinfo.etop);
+
 #ifndef ACC
-    #pragma omp parallel for default(none) shared(var, NODE_OF_FACET)
+    #pragma omp parallel for default(none) shared(var,NODES_PER_FACET,old_surface_area)
 #endif
-    #pragma acc parallel loop
+    #pragma acc parallel loop async
+    for (int i=0; i<var.surfinfo.etop; ++i) {
+        const double *coord[NODES_PER_FACET];
+        for (int j=0; j<NODES_PER_FACET; ++j)
+            coord[j] = (*var.coord)[(*var.connectivity_surface)[i][j]];
+        old_surface_area[i] = compute_area_facet(coord);
+    }
+
+    // convert value field to average field
+#ifndef ACC
+    #pragma omp parallel for default(none) shared(var)
+#endif
+    #pragma acc parallel loop async
     for (int i=0; i<var.surfinfo.etop; i++) {
-        int e = (*var.bfacets[iboundz1])[i].first;
-        int f = (*var.bfacets[iboundz1])[i].second;
-
-        const double *coord[NDIMS];
-
-        for (int j=0; j<NDIMS; j++)
-            coord[j] = (*var.coord)[(*var.connectivity)[e][NODE_OF_FACET[f][j]]];        
-
-        double inv_volume = 1.0 / compute_area(coord);
+        double inv_volume = 1.0 / old_surface_area[i];
         (*var.surfinfo.edvacc_surf)[i] *= inv_volume;
     }
+
+    #pragma acc wait
 
     {
         // creating a "copy" of mesh pointer so that they are not deleted
         array_t old_coord;
         conn_t old_connectivity;
+        conn_t old_connectivity_surface;
         segment_t old_segment;
         segflag_t old_segflag;
         old_coord.steal_ref(*var.coord);
         old_connectivity.steal_ref(*var.connectivity);
+        old_connectivity_surface.steal_ref(*var.connectivity_surface);
         old_segment.steal_ref(*var.segment);
         old_segflag.steal_ref(*var.segflag);
 
@@ -3124,9 +3133,6 @@ void remesh(const Param &param, Variables &var, int bad_quality)
             renumbering_mesh(param, *var.coord, *var.connectivity, *var.segment, NULL);
         }
 
-        int_pair_vec old_bfacets_surface(var.surfinfo.etop);
-        old_bfacets_surface = (*var.bfacets[iboundz1]);
-
         for (int i=0; i<nbdrytypes; ++i)
             var.bfacets[i]->clear();
         create_boundary_facets(var);
@@ -3138,8 +3144,10 @@ void remesh(const Param &param, Variables &var, int bad_quality)
             // interpolating fields defined on elements
             nearest_neighbor_interpolation(param, var, bary, old_coord, old_connectivity);
 
+            Barycentric_transformation bary_surface(old_coord, old_connectivity_surface, old_surface_area, true);
+
             // interpolating fields defined on surface elements
-            nearest_neighbor_interpolation(param, var, bary, old_coord, old_connectivity, true, old_bfacets_surface);
+            nearest_neighbor_interpolation(param, var, bary_surface, old_coord, old_connectivity_surface, true);
 
             // interpolating fields defined on nodes
             barycentric_node_interpolation(param, var, bary, old_coord, old_connectivity);
@@ -3181,21 +3189,26 @@ void remesh(const Param &param, Variables &var, int bad_quality)
 
     compute_volume(*var.coord, *var.connectivity, *var.volume);
 
+    double_vec surface_area(var.surfinfo.etop);
+
+#ifndef ACC
+    #pragma omp parallel for default(none) shared(var,NODES_PER_FACET,surface_area)
+#endif
+    #pragma acc parallel loop async
+    for (int i=0; i<var.surfinfo.etop; ++i) {
+        const double *coord[NODES_PER_FACET];
+        for (int j=0; j<NODES_PER_FACET; ++j)
+            coord[j] = (*var.coord)[(*var.connectivity_surface)[i][j]];
+        surface_area[i] = compute_area_facet(coord);
+    }
+
     // convert value field back to portional field for nn interpolation
 #ifndef ACC
-    #pragma omp parallel for default(none) shared(var, NODE_OF_FACET)
+    #pragma omp parallel for default(none) shared(var)
 #endif
     #pragma acc parallel loop async
     for (int i=0; i<var.surfinfo.etop; i++) {
-        int e = (*var.bfacets[iboundz1])[i].first;
-        int f = (*var.bfacets[iboundz1])[i].second;
-
-        const double *coord[NDIMS];
-
-        for (int j=0; j<NDIMS; j++)
-            coord[j] = (*var.coord)[(*var.connectivity)[e][NODE_OF_FACET[f][j]]];        
-
-        (*var.surfinfo.edvacc_surf)[i] *= compute_area(coord);
+        (*var.surfinfo.edvacc_surf)[i] *= surface_area[i];
     }
 
     // TODO: using edvoldt and volume to get volume_old


### PR DESCRIPTION
Surface-only interpolation for sediment deposits during remeshing

Features:
- Add compute_area() for triangle (3D) and line segment (2D) area/length calculations
- Add facet_center() to calculate geometric center of facet
- Restrict deposit interpolation during remeshing to surface facets only (3D: in-plane, 2D: along-line)
- Improve output message of remap_marker() in set_surface_marker()

Bug Fixes:
- Prevent diffusion of surface deposit information into model interior during remeshing, which previously underestimated surface volume and delayed marker generation