### PR TITLE
Bugfix: macOS openmp install upgrade and scripts

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -1,0 +1,53 @@
+name: macOS build
+
+on:
+  push:
+    branches: [ "master", "*macOS*" ]
+    paths-ignore:
+      - '**/README.md'
+  pull_request:
+    branches: [ "master" ]
+    paths-ignore:
+      - '**/README.md'
+
+jobs:
+  build:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: install dependencies
+      run: brew install boost cmake hdf5
+
+    - name: build LLVM OpenMP
+      run: |
+        mkdir -p external && cd external
+        curl -L https://github.com/llvm/llvm-project/releases/download/llvmorg-19.1.7/cmake-19.1.7.src.tar.xz -o cmake-19.1.7.src.tar.xz
+        tar xf cmake-19.1.7.src.tar.xz
+        curl -L https://github.com/llvm/llvm-project/releases/download/llvmorg-19.1.7/openmp-19.1.7.src.tar.xz -o openmp-19.1.7.src.tar.xz
+        tar xf openmp-19.1.7.src.tar.xz
+
+        mkdir -p openmp-19.1.7.src/build && cd openmp-19.1.7.src/build
+        cmake -DCMAKE_INSTALL_PREFIX=$(pwd)/../../openmp-install \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_MODULE_PATH=$(pwd)/../../cmake-19.1.7.src/Modules \
+              -DCMAKE_OSX_ARCHITECTURES=arm64 \
+              -DLIBOMP_INSTALL_ALIASES=OFF \
+              ..
+        make -j4 && make install && cd ../../
+
+    - name: make debug 2d
+      run: make clean; make ndims=2 opt=0 openmp=0 BOOST_ROOT_DIR=$(brew --prefix boost)
+    - name: make debug 3d
+      run: make clean; make ndims=3 opt=0 openmp=0 BOOST_ROOT_DIR=$(brew --prefix boost)
+    - name: make 2d
+      run: make clean; make ndims=2 opt=2 openmp=1 BOOST_ROOT_DIR=$(brew --prefix boost)
+    - name: make 3d
+      run: make clean; make ndims=3 opt=2 openmp=1 BOOST_ROOT_DIR=$(brew --prefix boost)
+    - name: make 3d hdf5
+      run: make clean; make ndims=3 opt=2 openmp=1 hdf5=1
+            BOOST_ROOT_DIR=$(brew --prefix boost)
+            HDF5_INCLUDE_DIR=$(brew --prefix hdf5)/include
+            HDF5_LIB_DIR=$(brew --prefix hdf5)/lib

--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,11 @@ ifneq (, $(findstring clang++, $(CXX)))
 	ifeq ($(openmp), 1)
 		# path to OpenMP library directory (for clang++ on macOS)
 		OPENMP_ROOT_DIR = external/openmp-install
+		ifeq ($(filter /%,$(OPENMP_ROOT_DIR)),$(OPENMP_ROOT_DIR))
+			OPENMP_RPATH := $(OPENMP_ROOT_DIR)/lib
+		else
+			OPENMP_RPATH := @executable_path/$(OPENMP_ROOT_DIR)/lib
+		endif
 		CXXFLAGS += -Xpreprocessor -fopenmp -I$(OPENMP_ROOT_DIR)/include
 		LDFLAGS += -L$(OPENMP_ROOT_DIR)/lib -lomp
 	endif
@@ -404,8 +409,8 @@ ifeq ($(OSNAME), Darwin)  # fix for dynamic library problem on Mac
 		install_name_tool -change libboost_program_options.dylib $(BOOST_LIB_DIR)/libboost_program_options.dylib $@
 		install_name_tool -add_rpath $(BOOST_LIB_DIR) $@
 ifeq ($(openmp), 1)
-		@if [ "$(BOOST_LIB_DIR)" != "$(OPENMP_ROOT_DIR)/lib" ]; then \
-			install_name_tool -add_rpath $(OPENMP_ROOT_DIR)/lib $@; \
+		@if [ "$(BOOST_LIB_DIR)" != "$(OPENMP_RPATH)" ]; then \
+			install_name_tool -add_rpath $(OPENMP_RPATH) $@; \
 		fi
 endif
 ifeq ($(useexo), 1)  # fix for dynamic library problem on Mac

--- a/README.md
+++ b/README.md
@@ -53,30 +53,31 @@ alike.
 
 * [LLVM](https://github.com/llvm/llvm-project) OpenMP library for macOS requires special setup due to Apple Clang lacking built-in OpenMP. 
   * Suggested building procedure
-    * Download LLVM CMake Modules and OpenMP. (LLVM OpenMP 15.0.7 or newer version will suffice.)
+    * Download LLVM CMake Modules and OpenMP. (LLVM OpenMP 19.1.7 or newer version will suffice.)
       ```BASH
       mkdir -p external && cd external
       # Download CMake modules
-      curl -L https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.7/cmake-15.0.7.src.tar.xz -o cmake-15.0.7.src.tar.xz
-      tar xf cmake-15.0.7.src.tar.xz
+      curl -L https://github.com/llvm/llvm-project/releases/download/llvmorg-19.1.7/cmake-19.1.7.src.tar.xz -o cmake-19.1.7.src.tar.xz
+      tar xf cmake-19.1.7.src.tar.xz
 
       # Download OpenMP source
-      curl -L https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.7/openmp-15.0.7.src.tar.xz -o openmp-15.0.7.src.tar.xz
-      tar xf openmp-15.0.7.src.tar.xz
+      curl -L https://github.com/llvm/llvm-project/releases/download/llvmorg-19.1.7/openmp-19.1.7.src.tar.xz -o openmp-19.1.7.src.tar.xz
+      tar xf openmp-19.1.7.src.tar.xz
       ```
     * Build OpenMP
       ```BASH
       # Configure and build for ARM64 (Apple Silicon) or x86_64 (Intel Mac)
-      mkdir -p openmp-15.0.7.src/build && cd openmp-15.0.7.src/build
+      mkdir -p openmp-19.1.7.src/build && cd openmp-19.1.7.src/build
       cmake -DCMAKE_INSTALL_PREFIX=$(pwd)/../../openmp-install \
             -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_MODULE_PATH=$(pwd)/../../cmake-15.0.7.src/Modules \
+            -DCMAKE_MODULE_PATH=$(pwd)/../../cmake-19.1.7.src/Modules \
             -DCMAKE_OSX_ARCHITECTURES=arm64 \
             -DLIBOMP_INSTALL_ALIASES=OFF \
             ..
       make -j4 && make install && cd ../../
       ```
     * Installed LLVM OpenMP will be in `external/openmp-install`.
+
 ## Or, using docker
 * Build docker image
   ```bash

--- a/README.md
+++ b/README.md
@@ -78,7 +78,23 @@ alike.
       ```
     * Installed LLVM OpenMP will be in `external/openmp-install`.
 
+  * macOS / Apple Silicon — OpenMP thread-wait performance
+
+    LLVM `libomp` hardcodes hybrid-CPU detection for all Apple Silicon, setting
+    thread *blocktime* to **0 µs**. Threads yield immediately after each parallel
+    region instead of spin-waiting, reducing CPU utilisation to ~250% on a 6-core
+    Mac vs. ~600% on Linux. DES3D automatically sets `OMP_WAIT_POLICY=active` at startup on macOS (unless
+    `OMP_WAIT_POLICY` or `KMP_BLOCKTIME` is already set), restoring near-Linux
+    throughput. A notice is printed at startup confirming this.
+
+    To override:
+    ```bash
+    export OMP_WAIT_POLICY=passive   # yield immediately, lower power
+    export KMP_BLOCKTIME=20          # fine-grained control (ms, libomp only)
+    ```
+
 ## Or, using docker
+
 * Build docker image
   ```bash
   ./build.sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Basic build](https://github.com/GeoFLAC/DynEarthSol/actions/workflows/basic-build.yml/badge.svg)](https://github.com/GeoFLAC/DynEarthSol/actions/workflows/basic-build.yml)
 [![Exodus build](https://github.com/GeoFLAC/DynEarthSol/actions/workflows/exodus-build.yml/badge.svg)](https://github.com/GeoFLAC/DynEarthSol/actions/workflows/exodus-build.yml)
 [![MMG build](https://github.com/GeoFLAC/DynEarthSol/actions/workflows/mmg-build.yml/badge.svg)](https://github.com/GeoFLAC/DynEarthSol/actions/workflows/mmg-build.yml)
+[![macOS build](https://github.com/GeoFLAC/DynEarthSol/actions/workflows/macos-build.yml/badge.svg)](https://github.com/GeoFLAC/DynEarthSol/actions/workflows/macos-build.yml)
 
 # Overview
 

--- a/dynearthsol.cxx
+++ b/dynearthsol.cxx
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <limits>
+#include <cstdlib>
 
 
 #include "constants.hpp"
@@ -507,6 +508,19 @@ void initial_body_force_adjustment(const Param &param, Variables &var)
 
 int main(int argc, const char* argv[])
 {
+#if defined(__APPLE__) && defined(_OPENMP)
+    // macOS/LLVM libomp sets blocktime=0 on Apple Silicon (hybrid CPU detection),
+    // causing threads to immediately yield between parallel regions. This hurts
+    // throughput in tight time loops with many short parallel regions.
+    // OMP_WAIT_POLICY=active restores spin-wait behavior. No-op if already set.
+    if (!getenv("OMP_WAIT_POLICY") && !getenv("KMP_BLOCKTIME")) {
+        setenv("OMP_WAIT_POLICY", "active", 0);
+        std::cout << "[OpenMP] macOS: OMP_WAIT_POLICY=active set to avoid libomp "
+                     "zero-blocktime regression on Apple Silicon.\n"
+                     "         Override: export OMP_WAIT_POLICY=passive | KMP_BLOCKTIME=<ms>\n";
+    }
+#endif
+
     //
     // read command line
     //

--- a/remeshing.cxx
+++ b/remeshing.cxx
@@ -2657,7 +2657,13 @@ void initialize_elem_size_n(const Variables &var, double_vec &init_elem_size_n)
      */
 
 #ifndef ACC
+#ifdef GPP1X
+    // for Apple clang version 17.0.0
+    // future version of clang might fix this problem
+    #pragma omp parallel for default(none) shared(var, sizefactor)
+#else
     #pragma omp parallel for default(none) shared(var)
+#endif
 #endif
     #pragma acc parallel loop gang vector async
     for (int e = 0; e < var.nelem; e++) {


### PR DESCRIPTION
This pull request introduces improved support for building and running the project on macOS, especially on Apple Silicon systems. The major changes include a new GitHub Actions workflow for macOS builds, updates to OpenMP handling and documentation, and runtime enhancements to address OpenMP performance issues on macOS. Additionally, there are minor code and build system tweaks for compatibility and performance.

**macOS build and OpenMP support:**

* Added a new GitHub Actions workflow (`.github/workflows/macos-build.yml`) to automate macOS builds, including steps for installing dependencies, building LLVM OpenMP, and running various build configurations.
* Updated OpenMP build instructions in `README.md` to use LLVM OpenMP version 19.1.7 and added documentation about macOS/Apple Silicon thread-wait performance and environment variable overrides.

**Build system improvements:**

* Enhanced `Makefile` to set `OPENMP_RPATH` correctly based on absolute or relative paths for dynamic library linking on macOS, and updated `install_name_tool` usage to use this variable for proper rpath handling. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R163-R169) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L407-R415)

**Runtime performance and compatibility:**

* Added logic in `dynearthsol.cxx` to automatically set `OMP_WAIT_POLICY=active` at startup on macOS with OpenMP, mitigating performance regression due to libomp's default zero-blocktime on Apple Silicon. Prints a notice at startup and allows user override.

**Compiler compatibility:**

* Modified `remeshing.cxx` to use a different OpenMP pragma when `GPP1X` is defined, addressing compatibility with Apple clang version 17.0.0.