### PR TITLE
Regular bugfix: Fix various bugs related to meshing and NumPy compatibility

### DIFF
--- a/2vtk.py
+++ b/2vtk.py
@@ -433,7 +433,7 @@ def process_vtkhdf_update(args):
                     del f[path]
                 dset = f.create_dataset(path, data=data, compression="gzip", compression_opts=9, shuffle=True)
                 if name_attr:
-                    dset.attrs['Name'] = np.string_(name_attr) # VTK expects string attributes? or just Name?
+                    dset.attrs['Name'] = np.bytes_(name_attr) # VTK expects string attributes? or just Name?
                 
                 # Create soft link at root
                 # e.g. /stress II -> /VTKHDF/grid/CellData/stress II

--- a/bc.cxx
+++ b/bc.cxx
@@ -88,7 +88,7 @@ double find_max_vbc(const BC &bc)
 
 
 void create_boundary_normals(const Variables &var, array_t &bnormals,
-                             std::map<std::pair<int,int>, double*>  &edge_vectors, double_vec& edge_vec, int_vec &edge_vec_idx)
+                             std::map<std::pair<int,int>, double_vec>  &edge_vectors, double_vec& edge_vec, int_vec &edge_vec_idx)
 {
     /* This subroutine finds the outward normal unit vectors of boundaries.
      * There are two types of boundaries: ibound{x,y,z}? and iboundn?.
@@ -162,7 +162,7 @@ void create_boundary_normals(const Variables &var, array_t &bnormals,
         const double eps = 1e-15;
         for (int j=i+1; j<nbdrytypes; j++) {
             if (var.bfacets[j]->size() == 0) continue;
-            double *s = new double[NDIMS];  // intersection of two boundaries
+            double_vec s (NDIMS);  // intersection of two boundaries
                                             // whole-application lifetime, no need to delete manually
 #ifdef THREED
             // quick path: both walls are vertical

--- a/bc.hpp
+++ b/bc.hpp
@@ -4,7 +4,7 @@
 bool is_on_boundary(const Variables &var, int node);
 double find_max_vbc(const BC &bc);
 void create_boundary_normals(const Variables &var, array_t &bnormals,
-                             std::map<std::pair<int,int>, double*>  &edge_vectors, double_vec& edge_vec, int_vec &edge_vec_idx);
+                             std::map<std::pair<int,int>, double_vec>  &edge_vectors, double_vec& edge_vec, int_vec &edge_vec_idx);
 void apply_vbcs(const Param &param, const Variables &var, array_t &vel);
 void apply_stress_bcs(const Param& param, const Variables& var, array_t& force);
 void apply_stress_bcs_neumann(const Param& param, const Variables& var, array_t& force);

--- a/dynearthsol.cxx
+++ b/dynearthsol.cxx
@@ -393,11 +393,6 @@ void restart(const Param& param, Variables& var)
 void end(Variables& var) {
     delete var.output;
 
-    for (int i=0; i<nbdrytypes; i++) {
-        if (var.bfacets[i]->size() == 0) continue;
-        for (int j=i+1; j<nbdrytypes; j++)
-            delete[] var.edge_vectors[std::make_pair(i, j)];
-    }
     for (size_t i=0; i<var.markersets.size(); i++)
         delete var.markersets[i];
 }

--- a/markerset.cxx
+++ b/markerset.cxx
@@ -1372,9 +1372,15 @@ namespace {
         bool is_no_nn = false;
 
 #ifndef ACC
+#ifdef GPP1X
         #pragma omp parallel for default(none) shared(param, var, unplenished_elems, \
                 ms, marker_data_all, ne, is_surface, emi_ptr, top_elems_ptr, ntop_elems, \
                 genesis, nneed_mk, mk_start, neighbors, queries, etas) reduction(||:is_no_nn)
+#else
+        #pragma omp parallel for default(none) shared(param, var, unplenished_elems, \
+                ms, marker_data_all, ne, is_surface, emi_ptr, top_elems_ptr, \
+                genesis, nneed_mk, mk_start, neighbors, queries, etas) reduction(||:is_no_nn)
+#endif
 #endif
         #pragma acc parallel loop gang vector reduction(||:is_no_nn)
         for (int i=0; i<ne; ++i) {

--- a/mesh.cxx
+++ b/mesh.cxx
@@ -1956,10 +1956,18 @@ void create_equilateral_segments(const Variables& var, int *&segments, int *&seg
         flag_idx++;
     }
     // bottom
-    int nbot = var.nx-var.nz%2;
-    for (int i = 0; i<nbot; ++i) {
-        segments[seg_idx*2] = var.nnode - nbot - 1 + i;
-        segments[seg_idx*2+1] = var.nnode - nbot + i;
+    int nbot = var.nx - var.nz%2;
+    int bot_node0;
+    if (var.nz % 2 == 0) {
+        // last odd row: tail of node array
+        bot_node0 = var.nnode - nbot - 1;
+    } else {
+        // last even row: middle of node array
+        bot_node0 = int(var.nz/2) * var.nx;
+    }
+    for (int i = 0; i < nbot; ++i) {
+        segments[seg_idx*2]   = bot_node0 + i;
+        segments[seg_idx*2+1] = bot_node0 + i + 1;
         seg_idx++;
         segflags[flag_idx] = 16;
         flag_idx++;

--- a/parameters.hpp
+++ b/parameters.hpp
@@ -643,7 +643,7 @@ struct Variables {
     double stress_bc_values[nbdrytypes];
     double vbc_val_z1_loading_period;
 
-    std::map<std::pair<int,int>, double*> edge_vectors;
+    std::map<std::pair<int,int>, double_vec> edge_vectors;
     double_vec edge_vec;
     int_vec edge_vec_idx;
     double_vec vbc_vertical_div_x0;

--- a/remeshing.cxx
+++ b/remeshing.cxx
@@ -1662,8 +1662,16 @@ void new_uniformed_equilateral_mesh(const Param &param, Variables &var,
     outx_bot[nx_new-nz_new%2][0] = old_coord[side_bottom[var.nx-var.nz%2]][0];
 
     interpolate_curve(param, inx_bot, outx_bot, 0);
-    for (int i = 0; i < nx_new+1-nz_new%2; ++i) {
-        ArrayAccessor p = (*var.coord)[nnode_new - nbot + i];
+    int bot_node0;
+    if (nz_new % 2 == 0) {
+        // last odd row
+        bot_node0 = nnode_new - nbot;
+    } else {
+        // last even row
+        bot_node0 = int(nz_new/2) * nx_new;
+    }
+    for (int i = 0; i < nbot; ++i) {
+        ArrayAccessor p = (*var.coord)[bot_node0 + i];
         p[0] = outx_bot[i][0];
         p[1] = outx_bot[i][1];
     }
@@ -1675,7 +1683,7 @@ void new_uniformed_equilateral_mesh(const Param &param, Variables &var,
         for (int i = 1; i < nx_new-1; ++i)
             (*var.coord)[i + j*nx_new][0] = xi + bdy_dx + i * dx;
     }
-    for (int j = 0; j < int(nz_new/2)-1; ++j) {
+    for (int j = 0; j < int(nz_new/2)-1+nz_new%2; ++j) {
         double xi = (*var.coord)[istart_n2+j*(nx_new+1)][0];
         double xe = (*var.coord)[istart_n2+(j+1)*(nx_new+1)-1][0];
         for (int i = 1; i < nx_new; ++i)


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes related to mesh generation, parallelization in the codebase, and memory management. The most significant changes address the correct indexing and placement of nodes and segments in equilateral mesh generation, as well as enhancements to parallelization directives for compatibility across different compilers.

**Mesh Generation and Indexing Fixes:**

* Corrected the calculation of the starting node index (`bot_node0`) for the bottom row in both `mesh.cxx` and `remeshing.cxx`, ensuring proper handling of even and odd numbers of rows for segment and coordinate assignment. This fixes potential off-by-one and placement errors in mesh boundaries. [[1]](diffhunk://#diff-98bd3359e916aed89063d37305319191b0e296a4c3073107db856fb132ea80b3R1960-R1970) [[2]](diffhunk://#diff-6bbd6707c50439001c17ce97393893962a88b55a5bbbdd75c780c8eabb0640eaL1665-R1674)
* Updated the loop bounds for assigning coordinates in the bottom rows to correctly handle cases where the number of rows is odd, preventing out-of-bounds access or missing nodes.

**Data Structure and Memory Management Improvements:**

* Changed the type of `edge_vectors` in `Variables` and related function signatures from `std::map<std::pair<int,int>, double*>` to `std::map<std::pair<int,int>, double_vec>`, eliminating manual memory management and simplifying ownership semantics (`parameters.hpp`, `bc.hpp`, `bc.cxx`) [[1]](diffhunk://#diff-f1647ebc026b61621988b6130781dd1f5a6211b3b669f5a299ed8a695f11b972L646-R646) [[2]](diffhunk://#diff-f2b5042853e70ad0517500ae94f379d679b47fc06fb624c34f168489fabbdfd8L7-R7) [[3]](diffhunk://#diff-75d3e8106169e381c9fd13e4fb3d747fcd881f0e09cba64d2a40f6c0d2fd3c4eL91-R91).
* Replaced raw pointer allocation (`new double[NDIMS]`) with stack-allocated `double_vec` for intersection vectors, further reducing manual memory management (`bc.cxx`).
* Removed manual deletion of `edge_vectors` memory in `end()`, as the new structure does not require explicit cleanup (`dynearthsol.cxx`).

**Parallelization Enhancements:**

* Added conditional OpenMP pragmas in `markerset.cxx` to support both the GPP1X compiler and others, improving compatibility and maintainability of parallel sections.

**Minor Improvements:**

* Changed the attribute assignment in `write_dataset` from `np.string_` to `np.bytes_` for the `'Name'` attribute to better match VTK expectations for string attributes.