### PR TITLE
Update LICENSE and .zenodo.json for copyright and DES v2.0 Zenodo DOI

### DIFF
--- a/.github/workflows/basic-build.yml
+++ b/.github/workflows/basic-build.yml
@@ -5,10 +5,20 @@ on:
     branches: [ "master" ]
     paths-ignore:
       - '**/README.md'
+      - 'LICENSE'
+      - '.zenodo.json'
+      - 'CITATION.cff'
+      - '*.md'
+      - '*.py'
   pull_request:
     branches: [ "master" ]
     paths-ignore:
       - '**/README.md'
+      - 'LICENSE'
+      - '.zenodo.json'
+      - 'CITATION.cff'
+      - '*.md'
+      - '*.py'
 
 jobs:
   build:

--- a/.github/workflows/exodus-build.yml
+++ b/.github/workflows/exodus-build.yml
@@ -5,10 +5,20 @@ on:
     branches: [ "master" ]
     paths-ignore:
       - '**/README.md'
+      - 'LICENSE'
+      - '.zenodo.json'
+      - 'CITATION.cff'
+      - '*.md'
+      - '*.py'
   pull_request:
     branches: [ "master" ]
     paths-ignore:
       - '**/README.md'
+      - 'LICENSE'
+      - '.zenodo.json'
+      - 'CITATION.cff'
+      - '*.md'
+      - '*.py'
 
 jobs:
   build:

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -5,10 +5,20 @@ on:
     branches: [ "master", "bugfix*" ]
     paths-ignore:
       - '**/README.md'
+      - 'LICENSE'
+      - '.zenodo.json'
+      - 'CITATION.cff'
+      - '*.md'
+      - '*.py'
   pull_request:
     branches: [ "master" ]
     paths-ignore:
       - '**/README.md'
+      - 'LICENSE'
+      - '.zenodo.json'
+      - 'CITATION.cff'
+      - '*.md'
+      - '*.py'
 
 jobs:
   build:

--- a/.github/workflows/get-g++version.yml
+++ b/.github/workflows/get-g++version.yml
@@ -5,10 +5,20 @@ on:
     branches: [ "master" ]
     paths-ignore:
       - '**/README.md'
+      - 'LICENSE'
+      - '.zenodo.json'
+      - 'CITATION.cff'
+      - '*.md'
+      - '*.py'
   pull_request:
     branches: [ "master" ]
     paths-ignore:
       - '**/README.md'
+      - 'LICENSE'
+      - '.zenodo.json'
+      - 'CITATION.cff'
+      - '*.md'
+      - '*.py'
 
 jobs:
   build:

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -5,10 +5,20 @@ on:
     branches: [ "master", "*macOS*" ]
     paths-ignore:
       - '**/README.md'
+      - 'LICENSE'
+      - '.zenodo.json'
+      - 'CITATION.cff'
+      - '*.md'
+      - '*.py'
   pull_request:
     branches: [ "master" ]
     paths-ignore:
       - '**/README.md'
+      - 'LICENSE'
+      - '.zenodo.json'
+      - 'CITATION.cff'
+      - '*.md'
+      - '*.py'
 
 jobs:
   build:

--- a/.github/workflows/mmg-build.yml
+++ b/.github/workflows/mmg-build.yml
@@ -5,10 +5,20 @@ on:
     branches: [ "master" ]
     paths-ignore:
       - '**/README.md'
+      - 'LICENSE'
+      - '.zenodo.json'
+      - 'CITATION.cff'
+      - '*.md'
+      - '*.py'
   pull_request:
     branches: [ "master" ]
     paths-ignore:
       - '**/README.md'
+      - 'LICENSE'
+      - '.zenodo.json'
+      - 'CITATION.cff'
+      - '*.md'
+      - '*.py'
 
 jobs:
   build:

--- a/.github/workflows/nvc-build.yml
+++ b/.github/workflows/nvc-build.yml
@@ -9,6 +9,9 @@ on:
       - "**CUDA**"
     paths-ignore:
       - '**/README.md'
+      - 'LICENSE'
+      - '.zenodo.json'
+      - 'CITATION.cff'
       - '*.md'
       - '*.py'
 
@@ -17,6 +20,9 @@ on:
       - "master"
     paths-ignore:
       - '**/README.md'
+      - 'LICENSE'
+      - '.zenodo.json'
+      - 'CITATION.cff'
       - '*.md'
       - '*.py'
 

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,36 +1,39 @@
 {
-    "description": "DynEarthSol for sedimentology.",
+    "description": "DynEarthSol (DES) is a finite element code that solves the momentum balance and heat transfer in Lagrangian form using unstructured meshes. It is designed to study the long-term deformation of Earth's lithosphere and similar geodynamic problems. The software features GPU acceleration and supports optional integrations with Exodus, MMG for mesh optimization, and HDF5 for advanced output visualization.",
     "license": "MIT",
     "title": "DynEarthSol",
     "upload_type": "software",
     "keywords": [
-        "DynEarthSol",
-        "Sedimentology"
+        "Geodynamics","Lithosphere",
+        "FLAC","Finite Element Method","Lagrangian",
+        "OpenMP","OpenACC","HDF5","MMG","Exodus"
     ],
     "creators": [
         {
-            "orcid": "0000-0002-7144-1394",
-            "affiliation": "Taiwan International Graduate Program (TIGP) - Earth System Science Program, Academia Sinica and National Central University, Academia Sinica, Taiwan",
-            "name": "Shyu, Chase J."
+            "orcid": "0000-0001-7839-4263",
+            "affiliation": "Institute for Geophysics, Jackson School of Geosciences, University of Texas at Austin, Texas 78758, United States",
+            "name": "Lavier, Luc L."
         },
         {
             "orcid": "0000-0002-1815-9613",
-            "affiliation": "Institute of Earth Sciences, Academia Sinica, Taiwan",
+            "affiliation": "Institute of Earth Sciences, Academia Sinica, Taipei 11529, Taiwan",
             "name": "Tan, Eh"
         },
         {
             "orcid": "0000-0002-8857-6092",
-            "affiliation": "Center for Earthquake Research and Information, University of Memphis, Memphis, TN, USA",
+            "affiliation": "Center for Earthquake Research and Information, The University of Memphis, Tennessee 38152, United States",
             "name": "Choi, Eunseo"
+        },
+        {
+            "orcid": "0000-0002-7144-1394",
+            "affiliation": "Institute for Geophysics, Jackson School of Geosciences, University of Texas at Austin, Texas 78758, United States",
+            "name": "Shyu, Chase J."
+        },
+        {
+            "orcid": "0000-0001-5287-9959",
+            "affiliation": "Earthquake Research Center, Korea Institute of Geoscience and Mineral Resources, 124 Gwahak-ro, Yuseong-gu, Daejeon 34132, Republic of Korea",
+            "name": "Lee, Sungho"
         }
     ],
-    "access_right": "open",
-    "related_identifiers": [
-        {
-            "scheme": "doi", 
-            "identifier": "10.5281/zenodo.7455730", 
-            "relation": "isVersionOf"
-        }
-    ]
-
+    "access_right": "open"
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,5 +1,5 @@
 {
-    "description": "DynEarthSol (DES) is a finite element code that solves the momentum balance and heat transfer in Lagrangian form using unstructured meshes. It is designed to study the long-term deformation of Earth's lithosphere and similar geodynamic problems. The software features GPU acceleration and supports optional integrations with Exodus, MMG for mesh optimization, and HDF5 for advanced output visualization.",
+    "description": "DynEarthSol (DES) is a finite element code that solves the momentum balance and heat equations in Lagrangian form using unstructured meshes. It is designed to study the long-term deformation of Earth's lithosphere and similar geodynamic problems, with the option to couple with an external surface process modeling code (goSPL). It can also simulate on- and off-fault deformation over multiple earthquake cycles. The software features GPU acceleration and supports optional integration with Exodus for importing externally generated meshes, MMG for mesh optimization, and HDF5 for high-performance output visualization.",
     "license": "MIT",
     "title": "DynEarthSol",
     "upload_type": "software",

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,17 +1,22 @@
-cff-version: 1.0.0
+cff-version: 2.0.0
 message: "If you use this software, please cite it as below."
 authors:
-- family-names: "Shyu"
-  given-names: "Chase J."
-  orcid: "https://orcid.org/0000-0002-7144-1394"
+- family-names: "Lavier"
+  given-names: "Luc L."
+  orcid: "https://orcid.org/0000-0001-7839-4263"
 - family-names: "Tan"
   given-names: "Eh"
   orcid: "https://orcid.org/0000-0002-1815-9613"
 - family-names: "Choi"
   given-names: "Eunseo"
   orcid: "https://orcid.org/0000-0002-8857-6092"
+- family-names: "Shyu"
+  given-names: "Chase J."
+  orcid: "https://orcid.org/0000-0002-7144-1394"
+- family-names: "Lee"
+  given-names: "Sungho"
+  orcid: "https://orcid.org/0000-0001-5287-9959"
+
 title: "DynEarthSol"
-version: 0.1.0
-doi: 10.5281/zenodo.7455730
-date-released: 2022-12-19
-url: "https://doi.org/10.5281/zenodo.7455730"
+version: 2.0.0
+url: "https://geoflac.github.io/DynEarthSol/"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-Copyright (C) 2024-2025 by Luc Lavier, Eh Tan, Eunseo Choi, Chase Shyu, and Sungho Lee.
-Copyright (C) 2016-2023 by Luc Lavier, Eh Tan, Eunseo Choi, and Chase Shyu.
-Copyright (C) 2012-2015 by Luc Lavier, Eh Tan, and Eunseo Choi.
+Copyright (C) 2024-2026 by Luc L. Lavier, Eh Tan, Eunseo Choi, Chase J. Shyu, and Sungho Lee.
+Copyright (C) 2016-2023 by Luc L. Lavier, Eh Tan, Eunseo Choi, and Chase J. Shyu.
+Copyright (C) 2012-2015 by Luc L. Lavier, Eh Tan, and Eunseo Choi.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
This pull request updates the project metadata and license information to update contributor details, and clarify copyright years and names. These changes improve the clarity and accuracy of the project's documentation and legal information.

**Project metadata and description updates:**
- Expanded the `description` field in `.zenodo.json` to give a detailed overview of the software's capabilities, including its use of finite element methods, Lagrangian form, GPU acceleration, and optional integrations with Exodus, MMG, and HDF5.
- Updated the `keywords` in `.zenodo.json` to better reflect the software's focus areas, such as geodynamics, lithosphere, finite element method, and technical features like OpenMP and HDF5.

**Contributor and affiliation updates:**
- Revised the list of `creators` in `.zenodo.json` to update ORCIDs, affiliations, and names for accuracy and to add new contributors. [[1]](diffhunk://#diff-69450eccf330a9c709df151fad75b5a9c02976ac29bd5d251bb16eb367997892L2-R15) [[2]](diffhunk://#diff-69450eccf330a9c709df151fad75b5a9c02976ac29bd5d251bb16eb367997892L25-R38)

**License and copyright:**
- Updated the `LICENSE` file to reflect the correct copyright years (now through 2026) and standardized contributor names with middle initials.