### PR TITLE
feature: implement SPR stress recovery for remeshing

### DIFF
--- a/array2d.hpp
+++ b/array2d.hpp
@@ -370,6 +370,34 @@ public:
         n_ = 0;
     }
 
+    void fill_component(int d, const T& val = T(0)) {
+        if (!a_ || n_ == 0 || d < 0 || d >= N) return;
+
+        T* ptr = a_;
+        int stride;
+        int offset;
+
+#ifdef SOA
+        stride = 1;
+        offset = d * n_;
+#else
+        stride = N;
+        offset = d;
+#endif
+
+#ifndef ACC
+        #pragma omp parallel for if(n_ > 10000)
+#endif
+        #pragma acc parallel loop gang vector
+        for (int i = 0; i < n_; ++i) {
+            ptr[offset + i * stride] = val;
+        }
+    }
+
+    void zero_component(int d) {
+        fill_component(d, T(0));
+    }
+
     //
     // index accessing
     //
@@ -414,7 +442,7 @@ public:
 #endif
     }
 
-    ConstComponentAccessor component(int d) const {
+    ConstComponentAccessor component_const(int d) const {
 #ifdef SOA
         return ConstComponentAccessor{ a_ + d * n_, 1, n_ };
 #else

--- a/array2d.hpp
+++ b/array2d.hpp
@@ -93,6 +93,27 @@ public:
     };
 
     //
+    // Component accessor — access all elements for one dimension
+    //
+    struct ComponentAccessor {
+        T*  ptr_;    // a_[d*n_] (SOA) or a_[d] (AoS)
+        int stride_; // 1 (SOA) or N (AoS)
+        int n_;
+
+        T& operator[](int i) const { return ptr_[i * stride_]; }
+        int size() const { return n_; }
+    };
+
+    struct ConstComponentAccessor {
+        const T* ptr_;
+        int stride_;
+        int n_;
+
+        const T& operator[](int i) const { return ptr_[i * stride_]; }
+        int size() const { return n_; }
+    };
+
+    //
     // View
     //
     struct ConstIndirectAccessor {
@@ -382,6 +403,22 @@ public:
         return ConstAccessor{ a_ + i, n_ };
 #else
         return ConstAccessor{ a_ + i*N, 1 };
+#endif
+    }
+
+    ComponentAccessor component(int d) {
+#ifdef SOA
+        return ComponentAccessor{ a_ + d * n_, 1, n_ };
+#else
+        return ComponentAccessor{ a_ + d, N, n_ };
+#endif
+    }
+
+    ConstComponentAccessor component(int d) const {
+#ifdef SOA
+        return ConstComponentAccessor{ a_ + d * n_, 1, n_ };
+#else
+        return ConstComponentAccessor{ a_ + d, N, n_ };
 #endif
     }
 

--- a/brc-interpolation.cxx
+++ b/brc-interpolation.cxx
@@ -70,6 +70,34 @@ void interpolate_field(const brc_t &brc, const int_vec &el, const conn_t &connec
 }
 
 
+void interpolate_field(const brc_t &brc, const int_vec &el, const conn_t &connectivity,
+                       const tensor_t &source, tensor_t &target, int ntarget)
+{
+#ifdef NPROF_DETAIL
+    nvtxRangePush(__FUNCTION__);
+#endif
+
+#ifndef ACC
+    #pragma omp parallel for default(none) \
+        shared(brc, el, connectivity, source, target, ntarget)
+#endif
+    #pragma acc parallel loop gang vector async
+    for (int i = 0; i < ntarget; i++) {
+        int e = el[i];
+        ConstConnAccessor conn = connectivity[e];
+        for (int d = 0; d < NSTR; d++) {
+            double result = 0;
+            for (int j = 0; j < NODES_PER_ELEM; j++)
+                result += source[conn[j]][d] * brc[i][j];
+            target[i][d] = result;
+        }
+    }
+#ifdef NPROF_DETAIL
+    nvtxRangePop();
+#endif
+}
+
+
 void prepare_interpolation(const Param& param, const Variables &var,
                            const Barycentric_transformation &bary,
                            const array_t &old_coord,
@@ -303,11 +331,11 @@ void barycentric_node_interpolation(const Param& param, Variables &var,
 #ifdef NPROF_DETAIL
     nvtxRangePush(__FUNCTION__);
 #endif
-    int_vec el(var.nnode);
-    brc_t brc(var.nnode);
-    prepare_interpolation(param, var, bary, old_coord, old_connectivity, *var.support, brc, el);
-
     const int n = var.nnode;
+
+    int_vec el(n);
+    brc_t brc(n);
+    prepare_interpolation(param, var, bary, old_coord, old_connectivity, *var.support, brc, el);
 
     double_vec *new_temperature = new double_vec(n);
     interpolate_field(brc, el, old_connectivity, *var.temperature, *new_temperature, n);
@@ -319,7 +347,7 @@ void barycentric_node_interpolation(const Param& param, Variables &var,
     interpolate_field(brc, el, old_connectivity, *var.dppressure, *new_dppressure, n);
 
 #ifdef USEMMG
-    double_vec *new_init_elem_size_n = new double_vec(var.nnode);
+    double_vec *new_init_elem_size_n = new double_vec(n);
     interpolate_field(brc, el, old_connectivity, *var.init_elem_size_n, *new_init_elem_size_n, n);
 #endif
 
@@ -330,6 +358,9 @@ void barycentric_node_interpolation(const Param& param, Variables &var,
 
     array_t *new_coord0 = new array_t(n);
     interpolate_field(brc, el, old_connectivity, *var.coord0, *new_coord0, n);
+
+    tensor_t *new_stress_n = new tensor_t(n);
+    interpolate_field(brc, el, old_connectivity, *var.stress_n, *new_stress_n, n);
 
     delete var.temperature;
     var.temperature = new_temperature;
@@ -352,6 +383,20 @@ void barycentric_node_interpolation(const Param& param, Variables &var,
 
     delete var.coord0;
     var.coord0 = new_coord0;
+
+    delete var.stress_n;
+    var.stress_n = new_stress_n;
+
+    if (param.mat.is_plane_strain) {
+        double_vec *new_stressyy_n = new double_vec(n);
+        interpolate_field(brc, el, old_connectivity,
+                          *var.stressyy_n, *new_stressyy_n, n);
+
+        #pragma acc wait
+
+        delete var.stressyy_n;
+        var.stressyy_n = new_stressyy_n;
+    }
 
 #ifdef NPROF_DETAIL
     nvtxRangePop();

--- a/dynearthsol.cxx
+++ b/dynearthsol.cxx
@@ -726,7 +726,9 @@ int main(int argc, const char* argv[])
         if (param.control.has_thermal_diffusion)
             update_temperature(param, var, *var.temperature, *var.tmp_result);
 
-        update_old_mean_stress(param, var, *var.stress, *var.old_mean_stress);
+        if (param.control.has_hydraulic_diffusion)
+            update_old_mean_stress(param, var, *var.stress, *var.old_mean_stress);
+
         update_strain_rate(var, *var.strain_rate);
         compute_dvoldt(var, *var.ntmp, *var.etmp);
         compute_edvoldt(var, *var.ntmp, *var.edvoldt);

--- a/dynearthsol.cxx
+++ b/dynearthsol.cxx
@@ -738,9 +738,9 @@ int main(int argc, const char* argv[])
             *var.ppressure, *var.dppressure, *var.vel,
             *var.dyn_fric_coeff, *var.state_variable);
 
-	// Nodal Mixed Discretization For Stress
+        // Nodal Mixed Discretization For Stress
         if (param.control.is_using_mixed_stress)
-            NMD_stress(param, var, *var.ntmp, *var.stress, *var.etmp);
+            NMD_stress(var, *var.stress, *var.ntmp, *var.etmp);
             
         update_force(param, var, *var.force, *var.force_residual, *var.tmp_result);
         update_velocity(var, *var.vel);

--- a/examples/defaults.cfg
+++ b/examples/defaults.cfg
@@ -147,7 +147,6 @@ resolution = 30e3
 #use_global_velocity_scaling = no
 
 #is_using_mixed_stress = yes
-#mixed_stress_reference_viscosity = 1e19
 
 [bc]
 #surface_temperature = 273

--- a/fields.cxx
+++ b/fields.cxx
@@ -59,7 +59,6 @@ void allocate_variables(const Param &param, Variables& var)
     const int e = var.nelem;
 
     var.volume = new double_vec(e);
-    var.volume_old = new double_vec(e);
     var.volume_n = new double_vec(n);
 
     var.mass = new double_vec(n);
@@ -72,6 +71,7 @@ void allocate_variables(const Param &param, Variables& var)
 
     {
         // these fields are reallocated during remeshing interpolation
+        var.volume_old = new double_vec(e); // for dv remeshing interpolation
         var.temperature = new double_vec(n);
         var.ppressure = new double_vec(n);
         var.dppressure = new double_vec(n);
@@ -146,10 +146,8 @@ void reallocate_variables(const Param& param, Variables& var)
     const int e = var.nelem;
 
     delete var.volume;
-    delete var.volume_old;
     delete var.volume_n;
     var.volume = new double_vec(e);
-    var.volume_old = new double_vec(e);
     var.volume_n = new double_vec(n);
 
     delete var.mass;

--- a/fields.cxx
+++ b/fields.cxx
@@ -67,7 +67,9 @@ void allocate_variables(const Param &param, Variables& var)
     var.ymass = new double_vec(n);
     var.edvoldt = new double_vec(e);
 
-//    var.marker_in_elem = new int_vec2D(e);
+    var.stress = new tensor_t(e, 0);
+    var.stressyy = new double_vec(e, 0);
+    var.old_mean_stress = new double_vec(e, 0);
 
     {
         // these fields are reallocated during remeshing interpolation
@@ -80,9 +82,6 @@ void allocate_variables(const Param &param, Variables& var)
         var.delta_plstrain = new double_vec(e);
         var.vel = new array_t(n, 0);
         var.strain = new tensor_t(e, 0);
-        var.stress = new tensor_t(e, 0);
-        var.stressyy = new double_vec(e, 0);
-        var.old_mean_stress = new double_vec(e, 0);
         // var.stress_old = new tensor_t(e, 0);
         var.radiogenic_source = new double_vec(e, 0);
         var.dyn_fric_coeff = new double_vec(e);
@@ -177,7 +176,17 @@ void reallocate_variables(const Param& param, Variables& var)
     delete var.strain_rate;
     var.strain_rate = new tensor_t(e, 0);
 
+    delete var.stress;
+    var.stress = new tensor_t(e);
 
+    // TODO: keep this reallocation because rheology always reads double& syy
+    delete var.stressyy;
+    var.stressyy = new double_vec(var.nelem);
+
+    if (param.control.has_hydraulic_diffusion) {
+        delete var.old_mean_stress;
+        var.old_mean_stress = new double_vec(var.nelem);
+    }
 
     delete var.mat;
     var.mat = new MatProps(param, var);

--- a/geometry.cxx
+++ b/geometry.cxx
@@ -447,55 +447,59 @@ static bool spr_solve_centered_3d(const double A[4][4], const double b[4],
 // Used as fallback when the SPR normal matrix is near-singular, and as a
 // clamp range for the polynomial result to prevent out-of-range extrapolation.
 #pragma acc routine seq
-template<typename T>
-static double spr_volume_weighted_avg(const Variables &var, const int node,
-                                      const double_vec &elem_volume,
-                                      const T sigma)
+static double spr_volume_weighted_avg_strided(const Variables &var, 
+                                              int node_idx, 
+                                              const double_vec &elem_volume, 
+                                              const double* ptr, 
+                                              int stride) 
 {
     double sum_w = 0.0, sum_ws = 0.0;
-    const int nsup = get_sup_size(var, node);
-    for (int i = 0; i < nsup; ++i) {
-        const int e = get_support(var, node, i);
-        const double w = elem_volume[e];
-        sum_ws += w * sigma[e];
+    int npatch = get_sup_size(var, node_idx);
+    for (int jp = 0; jp < npatch; ++jp) {
+        int e = get_support(var, node_idx, jp);
+        double w = elem_volume[e];
+        sum_ws += w * ptr[e * stride]; 
         sum_w  += w;
     }
     return (sum_w > 0.0) ? sum_ws / sum_w : 0.0;
 }
 
-// Compute SPR nodal value for one scalar field sigma[0..nelem-1].
-template<typename T>
-static void spr_scalar_field(const Variables &var, const T sigma, T out)
+// # of max spr fields, 4 for 2D, 6 for 3D
+#define MAX_SPR_FIELDS (NDIMS*2)
+
+// Compute SPR nodal values
+static void spr_fused_fields(const Variables &var, 
+                             const double* const in_ptrs[], const int in_strides[],
+                             double* const out_ptrs[], const int out_strides[], 
+                             int num_fields)
 {
 #ifdef NPROF_DETAIL
     nvtxRangePush(__FUNCTION__);
 #endif
 
 #ifndef ACC
-    #pragma omp parallel for default(none) shared(var, sigma, out)
+    #pragma omp parallel for default(none) shared(var, in_ptrs, in_strides, out_ptrs, \
+                out_strides, num_fields)
 #endif
-    #pragma acc parallel loop gang vector async
+    #pragma acc parallel loop gang vector async copyin(in_ptrs[0:num_fields], \
+                in_strides[0:num_fields], out_ptrs[0:num_fields], out_strides[0:num_fields])
     for (int i = 0; i < var.nnode; ++i) {
         const int npatch = get_sup_size(var, i);
 
-        const ConstArrayAccessor ci = (*var.coord)[i];
-        const double xi = ci[0];
-        const double yi = ci[1];
-#ifdef THREED
-        const double zi = ci[2];
-#endif
-
-        if (npatch == 0) {
-            out[i] = spr_volume_weighted_avg(var, i, *var.volume, sigma);
-            continue;
-        }
+        double smin[MAX_SPR_FIELDS], smax[MAX_SPR_FIELDS];
+        const int e0 = get_support(var, i, 0);
         
-        double smin = sigma[get_support(var, i, 0)], smax = smin;
+        #pragma acc loop seq
+        for (int f = 0; f < num_fields; ++f) {
+            smin[f] = smax[f] = in_ptrs[f][e0 * in_strides[f]];
+        }
+
         double x0 = 0.0, y0 = 0.0;
 #ifdef THREED
         double z0 = 0.0;
 #endif
 
+        // calculate patch centroid (x0, y0, z0) and field value extrema (smin, smax) for clamping
         #pragma acc loop seq
         for (int jp = 0; jp < npatch; ++jp) {
             const int e = get_support(var, i, jp);
@@ -521,21 +525,22 @@ static void spr_scalar_field(const Variables &var, const T sigma, T out)
             z0 += cz;
 #endif
 
-            const double sj = sigma[e];
-            if (sj < smin) smin = sj;
-            if (sj > smax) smax = sj;
+            #pragma acc loop seq
+            for (int f = 0; f < num_fields; ++f) {
+                double s = in_ptrs[f][e * in_strides[f]]; // use Stride
+                if (s < smin[f]) smin[f] = s;
+                if (s > smax[f]) smax[f] = s;
+            }
         }
-        x0 /= npatch;
-        y0 /= npatch;
+        x0 /= npatch; y0 /= npatch;
 #ifdef THREED
         z0 /= npatch;
-        double A[4][4] = {};
-        double b[4]    = {};
-#else
-        double A[3][3] = {};
-        double b[3]    = {};
 #endif
+        double A[NODES_PER_ELEM][NODES_PER_ELEM] = {};
+        double b_vec[MAX_SPR_FIELDS][NODES_PER_ELEM] = {};
 
+        // build A and b_vec for all fields in the patch, 
+        // with shared loops and Stride-aware access
         #pragma acc loop seq
         for (int jp = 0; jp < npatch; ++jp) {
             const int e = get_support(var, i, jp);
@@ -563,7 +568,6 @@ static void spr_scalar_field(const Variables &var, const T sigma, T out)
 #ifdef THREED
             const double dz = cz - z0;
 #endif
-            const double sj = sigma[e];
 
             A[0][0] += 1.0;
             A[0][1] += dx;    A[1][0] = A[0][1];
@@ -578,32 +582,45 @@ static void spr_scalar_field(const Variables &var, const T sigma, T out)
             A[3][3] += dz*dz;
 #endif
 
-            b[0] += sj;
-            b[1] += dx * sj;
-            b[2] += dy * sj;
+            #pragma acc loop seq
+            for (int f = 0; f < num_fields; ++f) {
+                double s = in_ptrs[f][e * in_strides[f]]; // use Stride
+                b_vec[f][0] += s;
+                b_vec[f][1] += dx * s;
+                b_vec[f][2] += dy * s;
 #ifdef THREED
-            b[3] += dz * sj;
+                b_vec[f][3] += dz * s;
 #endif
+            }
         }
 
-        const double dxi = xi - x0;
-        const double dyi = yi - y0;
+        const ConstArrayAccessor ci = (*var.coord)[i];
+        const double dxi = ci[0] - x0;
+        const double dyi = ci[1] - y0;
 #ifdef THREED
-        const double dzi = zi - z0;
+        const double dzi = ci[2] - z0;
 #endif
 
-        double val;
+        // solve A for all fields in the patch, with fallback and clamping
+        #pragma acc loop seq
+        for (int f = 0; f < num_fields; ++f) {
+            double temp_val;
+
 #ifdef THREED
-        if (!spr_solve_centered_3d(A, b, dxi, dyi, dzi, val)) {
+            bool solve_success = spr_solve_centered_3d(A, b_vec[f], dxi, dyi, dzi, temp_val);
 #else
-        if (!spr_solve_centered(A, b, dxi, dyi, val)) {
+            bool solve_success = spr_solve_centered(A, b_vec[f], dxi, dyi, temp_val);
 #endif
-            val = spr_volume_weighted_avg(var, i, *var.volume, sigma);
-        } else {
-            val = fmax(smin, fmin(smax, val));
-        }
 
-        out[i] = val;
+            temp_val = solve_success ?
+                fmax(smin[f], fmin(smax[f], temp_val)) :
+                // if the matrix is degenerate, the polynomial fit is unreliable. 
+                // Fall back to volume-weighted average, which is stable but less accurate. 
+                // The clamping range is still valid since it's based on the patch values.
+                spr_volume_weighted_avg_strided(var, i, *var.volume, in_ptrs[f], in_strides[f]);
+
+            out_ptrs[f][i * out_strides[f]] = temp_val;
+        }
     }
 #ifdef NPROF_DETAIL
     nvtxRangePop();
@@ -651,15 +668,39 @@ void spr_elem_to_node(const Param &param, const Variables &var,
             (*var.stressyy)[e] += p_ref_old;
     }
 
-    // Compute SPR-recovered nodal stresses from element-centroid stresses on the old mesh.
-    // Uses Zienkiewicz-Zhu superconvergent patch recovery with linear polynomial basis [1, x, y].
-    // nodal_stress_out: flat SoA array, size nnode_old * NSTR, indexed as [d * nnode_old + n]
-    // nodal_stressyy_out: flat array, size nnode_old (plane-strain out-of-plane component)
+    // dynamic registration of all fields involved in SPR
+    const double* in_ptrs[MAX_SPR_FIELDS];
+    int in_strides[MAX_SPR_FIELDS];
+    double* out_ptrs[MAX_SPR_FIELDS];
+    int out_strides[MAX_SPR_FIELDS];
+    int num_fields = 0;
+
+    auto add_field_acc = [&](tensor_t::ConstComponentAccessor in_acc, tensor_t::ComponentAccessor out_acc) {
+        in_ptrs[num_fields]     = in_acc.ptr_;
+        in_strides[num_fields]  = in_acc.stride_;
+        out_ptrs[num_fields]    = out_acc.ptr_;
+        out_strides[num_fields] = out_acc.stride_;
+        num_fields++;
+    };
+
+    auto add_field_ptr = [&](const double* in_p, double* out_p) {
+        in_ptrs[num_fields]     = in_p;
+        in_strides[num_fields]  = 1;
+        out_ptrs[num_fields]    = out_p;
+        out_strides[num_fields] = 1;
+        num_fields++;
+    };
+
     for (int d = 0; d < NSTR; ++d)
-        spr_scalar_field(var, var.stress->component(d), stress_n->component(d));
+        add_field_acc(var.stress->component_const(d), stress_n->component(d));
 
     if (param.mat.is_plane_strain)
-        spr_scalar_field(var, var.stressyy->data(), stressyy_n->data());
+        add_field_ptr(var.stressyy->data(), stressyy_n->data());
+
+    // Compute SPR-recovered nodal stresses from element-centroid stresses on the old mesh.
+    // Uses Zienkiewicz-Zhu superconvergent patch recovery with linear polynomial basis [1, x, y].
+    // call the fused SPR kernel for all registered fields
+    spr_fused_fields(var, in_ptrs, in_strides, out_ptrs, out_strides, num_fields);
 
     #pragma acc wait
 

--- a/geometry.cxx
+++ b/geometry.cxx
@@ -448,13 +448,14 @@ static bool spr_solve_centered_3d(const double A[4][4], const double b[4],
 // clamp range for the polynomial result to prevent out-of-range extrapolation.
 #pragma acc routine seq
 template<typename T>
-static double spr_volume_weighted_avg(const int_vec &patch,
+static double spr_volume_weighted_avg(const Variables &var, const int node,
                                       const double_vec &elem_volume,
                                       const T sigma)
 {
     double sum_w = 0.0, sum_ws = 0.0;
-    for (int i = 0; i < (int)patch.size(); ++i) {
-        const int e = patch[i];
+    const int nsup = get_sup_size(var, node);
+    for (int i = 0; i < nsup; ++i) {
+        const int e = get_support(var, node, i);
         const double w = elem_volume[e];
         sum_ws += w * sigma[e];
         sum_w  += w;
@@ -462,7 +463,6 @@ static double spr_volume_weighted_avg(const int_vec &patch,
     return (sum_w > 0.0) ? sum_ws / sum_w : 0.0;
 }
 
-#define MAX_PATCH_SIZE 128
 // Compute SPR nodal value for one scalar field sigma[0..nelem-1].
 template<typename T>
 static void spr_scalar_field(const Variables &var, const T sigma, T out)
@@ -471,10 +471,12 @@ static void spr_scalar_field(const Variables &var, const T sigma, T out)
     nvtxRangePush(__FUNCTION__);
 #endif
 
+#ifndef ACC
     #pragma omp parallel for default(none) shared(var, sigma, out)
+#endif
+    #pragma acc parallel loop gang vector async
     for (int i = 0; i < var.nnode; ++i) {
-        const int_vec &patch = (*var.support)[i];
-        const int npatch = (int)patch.size();
+        const int npatch = get_sup_size(var, i);
 
         const ConstArrayAccessor ci = (*var.coord)[i];
         const double xi = ci[0];
@@ -483,49 +485,39 @@ static void spr_scalar_field(const Variables &var, const T sigma, T out)
         const double zi = ci[2];
 #endif
 
-        double cx_arr[MAX_PATCH_SIZE];
-        double cy_arr[MAX_PATCH_SIZE];
-#ifdef THREED
-        double cz_arr[MAX_PATCH_SIZE];
-        double z0 = 0.0;
-#endif
-        if (npatch > MAX_PATCH_SIZE) {
-            out[i] = spr_volume_weighted_avg(patch, *var.volume, sigma);
+        if (npatch == 0) {
+            out[i] = spr_volume_weighted_avg(var, i, *var.volume, sigma);
             continue;
         }
-        double smin = sigma[patch[0]], smax = smin;
+        
+        double smin = sigma[get_support(var, i, 0)], smax = smin;
         double x0 = 0.0, y0 = 0.0;
+#ifdef THREED
+        double z0 = 0.0;
+#endif
 
+        #pragma acc loop seq
         for (int jp = 0; jp < npatch; ++jp) {
-            const int e = patch[jp];
-            const ConstConnAccessor conn = (*var.connectivity)[e];
-
+            const int e = get_support(var, i, jp);
+            ConstArrayIndirectAccessor ck = var.coord->view_const((*var.connectivity)[e]);
             double cx = 0.0, cy = 0.0;
 #ifdef THREED
             double cz = 0.0;
 #endif
+            #pragma acc loop seq
             for (int k = 0; k < NODES_PER_ELEM; ++k) {
-                const ConstArrayAccessor ck = (*var.coord)[conn[k]];
-                cx += ck[0];
-                cy += ck[1];
+                cx += ck[k][0];
+                cy += ck[k][1];
 #ifdef THREED
-                cz += ck[2];
+                cz += ck[k][2];
 #endif
             }
             cx /= NODES_PER_ELEM;
             cy /= NODES_PER_ELEM;
-#ifdef THREED
-            cz /= NODES_PER_ELEM;
-#endif
-
-            cx_arr[jp] = cx;
-            cy_arr[jp] = cy;
-#ifdef THREED
-            cz_arr[jp] = cz;
-#endif
             x0 += cx;
             y0 += cy;
 #ifdef THREED
+            cz /= NODES_PER_ELEM;
             z0 += cz;
 #endif
 
@@ -544,13 +536,34 @@ static void spr_scalar_field(const Variables &var, const T sigma, T out)
         double b[3]    = {};
 #endif
 
+        #pragma acc loop seq
         for (int jp = 0; jp < npatch; ++jp) {
-            const double dx = cx_arr[jp] - x0;
-            const double dy = cy_arr[jp] - y0;
+            const int e = get_support(var, i, jp);
+            ConstArrayIndirectAccessor ck = var.coord->view_const((*var.connectivity)[e]);
+            double cx = 0.0, cy = 0.0;
 #ifdef THREED
-            const double dz = cz_arr[jp] - z0;
+            double cz = 0.0;
 #endif
-            const double sj = sigma[patch[jp]];
+            #pragma acc loop seq
+            for (int k = 0; k < NODES_PER_ELEM; ++k) {
+                cx += ck[k][0];
+                cy += ck[k][1];
+#ifdef THREED
+                cz += ck[k][2];
+#endif
+            }
+            cx /= NODES_PER_ELEM;
+            cy /= NODES_PER_ELEM;
+#ifdef THREED
+            cz /= NODES_PER_ELEM;
+#endif
+
+            const double dx = cx - x0;
+            const double dy = cy - y0;
+#ifdef THREED
+            const double dz = cz - z0;
+#endif
+            const double sj = sigma[e];
 
             A[0][0] += 1.0;
             A[0][1] += dx;    A[1][0] = A[0][1];
@@ -585,10 +598,9 @@ static void spr_scalar_field(const Variables &var, const T sigma, T out)
 #else
         if (!spr_solve_centered(A, b, dxi, dyi, val)) {
 #endif
-            val = spr_volume_weighted_avg(patch, *var.volume, sigma);
+            val = spr_volume_weighted_avg(var, i, *var.volume, sigma);
         } else {
-            if (val < smin) val = smin;
-            if (val > smax) val = smax;
+            val = fmax(smin, fmin(smax, val));
         }
 
         out[i] = val;
@@ -639,8 +651,6 @@ void spr_elem_to_node(const Param &param, const Variables &var,
             (*var.stressyy)[e] += p_ref_old;
     }
 
-    #pragma acc wait
-
     // Compute SPR-recovered nodal stresses from element-centroid stresses on the old mesh.
     // Uses Zienkiewicz-Zhu superconvergent patch recovery with linear polynomial basis [1, x, y].
     // nodal_stress_out: flat SoA array, size nnode_old * NSTR, indexed as [d * nnode_old + n]
@@ -650,6 +660,8 @@ void spr_elem_to_node(const Param &param, const Variables &var,
 
     if (param.mat.is_plane_strain)
         spr_scalar_field(var, var.stressyy->data(), stressyy_n->data());
+
+    #pragma acc wait
 
 #ifdef NPROF_DETAIL
     nvtxRangePop();

--- a/geometry.cxx
+++ b/geometry.cxx
@@ -276,48 +276,13 @@ void compute_edvoldt(const Variables &var, double_vec &dvoldt,
 }
 
 
-void NMD_stress(const Param& param, const Variables &var,
-    double_vec &dp_nd, tensor_t& stress, double_vec &etmp)
+void NMD_stress(const Variables &var, tensor_t& stress, double_vec &dp_nd, double_vec &etmp)
 {
 #ifdef NPROF
     nvtxRangePush(__FUNCTION__);
 #endif
     // dp_nd is the pressure change, weighted by the element volume,
     // lumped onto the nodes.
-
-//    double **centroid = elem_center(*var.coord, *var.connectivity); // centroid of elements
-/*
-    // weight with inverse distance
-    if(false) {
-        #pragma omp parallel for default(none) shared(var,centroid,tmp_result)
-        for (int e=0;e<var.nelem;e++) {
-            const auto conn = (*var.connectivity)[e];
-            for (int i=0; i<NODES_PER_ELEM; ++i) {
-                const double *d = (*var.coord)[conn[i]];
-                tmp_result[i][e] = 1. / sqrt( dist2(d, centroid[e])  );
-                tmp_result[i + NODES_PER_ELEM][e] = tmp_result[i][e] * (*var.dpressure)[e];
-            }
-        }
-
-        #pragma omp parallel for default(none) shared(var,dp_nd,tmp_result)
-        for (int n=0;n<var.nnode;n++) {
-            double dist_inv_sum = 0.;
-            for( auto e = (*var.support)[n].begin(); e < (*var.support)[n].end(); ++e) {
-                const auto conn = (*var.connectivity)[*e];
-                for (int i=0;i<NODES_PER_ELEM;i++) {
-                    if (n == conn[i]) {
-                        dist_inv_sum += tmp_result[ i ][*e];
-                        dp_nd[n] += tmp_result[i + NODES_PER_ELEM][*e];
-                        break;
-                    }
-                }
-            }
-            dp_nd[n] /= dist_inv_sum;
-        }
-
-    // weight with volumn
-    } else {
-        */
 
 #ifndef ACC
     #pragma omp parallel for default(none) shared(var,etmp)
@@ -337,30 +302,13 @@ void NMD_stress(const Param& param, const Variables &var,
             dp_nd[n] += etmp[*e];
         dp_nd[n] /= (*var.volume_n)[n];
     }
-//    }
 
-    /* dp_el is the averaged (i.e. smoothed) dp_nd on the element.
-     */
+    // dp_el is the averaged (i.e. smoothed) dp_nd on the element.
 #ifndef ACC
-    #pragma omp parallel for default(none) shared(param, var, dp_nd, stress)
+    #pragma omp parallel for default(none) shared(var, dp_nd, stress)
 #endif
     #pragma acc parallel loop gang vector async
     for (int e=0; e<var.nelem; ++e) {
-
-        double factor;
-        switch (param.mat.rheol_type) {
-        case MatProps::rh_viscous:
-        case MatProps::rh_maxwell:
-        case MatProps::rh_evp:
-            if ((*var.viscosity)[e] < param.control.mixed_stress_reference_viscosity)
-                factor = 0.;
-            else
-                factor = std::min((*var.viscosity)[e] / (param.control.mixed_stress_reference_viscosity * 10.), 1.);
-            break;
-        default:
-            factor = 1;
-        }
-
         ConstConnAccessor conn = (*var.connectivity)[e];
         double dp = 0;
         for (int i=0; i<NODES_PER_ELEM; ++i) {
@@ -371,16 +319,310 @@ void NMD_stress(const Param& param, const Variables &var,
 
     	TensorAccessor s = stress[e];
 
-
 	    double dp_orig = (*var.dpressure)[e];
-        double ddp = ( - dp_orig + dp_el ) / NDIMS * factor;
+        double ddp = ( - dp_orig + dp_el ) / NDIMS;
 	    for (int i=0; i<NDIMS; ++i)
             s[i] += ddp;
     }
 
-//    delete [] centroid[0];
-//    delete [] centroid;
 #ifdef NPROF
+    nvtxRangePop();
+#endif
+}
+
+// ============================================================
+// SPR (Superconvergent Patch Recovery) stress computation
+// ============================================================
+
+// Fit a linear polynomial sigma*(dx, dy) = a0 + a1*dx + a2*dy to the stress
+// values at element centroids in a node's patch, using RELATIVE coordinates
+// (centroid of the patch's element centroids as origin).  Evaluate at the
+// node's relative coordinates.
+//
+// Using relative coordinates reduces the absolute magnitudes from ~50,000 m
+// to ~300 m (one mesh element), dropping the 3×3 normal-matrix condition
+// number from ~2.5e9 to ~2.3e4 — numerically safe for double precision.
+//
+// Returns true if the Cramer solve succeeded; false if degenerate (fallback).
+static bool spr_solve_centered(const double A[3][3], const double b[3],
+                               const double dxi, const double dyi,
+                               double &result)
+{
+    const double M00 = A[1][1]*A[2][2] - A[1][2]*A[1][2];
+    const double M01 = A[0][1]*A[2][2] - A[1][2]*A[0][2];
+    const double M02 = A[0][1]*A[1][2] - A[1][1]*A[0][2];
+    const double det = A[0][0]*M00 - A[0][1]*M01 + A[0][2]*M02;
+
+    // Scale-adaptive singularity threshold: A[1][1] ~ Σdx², A[2][2] ~ Σdz²
+    // both O(h²) with patch-relative coords — well-conditioned.
+    const double scale = A[0][0] * std::max(A[1][1], A[2][2]);
+    if (scale == 0.0 || std::abs(det) < 1e-6 * scale)
+        return false;
+
+    const double inv_det = 1.0 / det;
+
+    const double a0 = inv_det * (
+          b[0]    * M00
+        - A[0][1] * (b[1]*A[2][2] - A[1][2]*b[2])
+        + A[0][2] * (b[1]*A[1][2] - A[1][1]*b[2]));
+
+    const double a1 = inv_det * (
+          A[0][0] * (b[1]*A[2][2] - A[1][2]*b[2])
+        - b[0]    * M01
+        + A[0][2] * (A[0][1]*b[2] - b[1]*A[0][2]));
+
+    const double a2 = inv_det * (
+          A[0][0] * (A[1][1]*b[2] - b[1]*A[1][2])
+        - A[0][1] * (A[0][1]*b[2] - b[1]*A[0][2])
+        + b[0]    * M02);
+
+    result = a0 + a1*dxi + a2*dyi;
+    return true;
+}
+
+// Volume-weighted average of element stress values in the patch.
+// Used as fallback when the SPR normal matrix is near-singular, and as a
+// clamp range for the polynomial result to prevent out-of-range extrapolation.
+template<typename T>
+static double spr_volume_weighted_avg(const int_vec &patch,
+                                      const double_vec &elem_volume,
+                                      const T sigma)
+{
+    double sum_w = 0.0, sum_ws = 0.0;
+    for (int i = 0; i < (int)patch.size(); ++i) {
+        const int e = patch[i];
+        const double w = elem_volume[e];
+        sum_ws += w * sigma[e];
+        sum_w  += w;
+    }
+    return (sum_w > 0.0) ? sum_ws / sum_w : 0.0;
+}
+
+// Compute SPR nodal value for one scalar field sigma[0..nelem-1].
+template<typename T>
+static void spr_scalar_field(const array_t &old_coord,
+                             const conn_t &old_connectivity,
+                             const int_vec2D &old_support,
+                             const T sigma,
+                             const double_vec &elem_volume,
+                             const int nnode_old,
+                             T out)
+{
+#ifdef NPROF_DETAIL
+    nvtxRangePush(__FUNCTION__);
+#endif
+
+    #pragma omp parallel for default(none) \
+            shared(old_coord, old_connectivity, old_support, sigma, elem_volume, nnode_old, out)
+    for (int i = 0; i < nnode_old; ++i) {
+        const int_vec &patch = old_support[i];
+        const int npatch = (int)patch.size();
+
+        const ConstArrayAccessor ci = old_coord[i];
+        const double xi = ci[0];
+        const double yi = ci[1];
+
+        double_vec cx_arr(npatch), cy_arr(npatch);
+        double smin = sigma[patch[0]], smax = smin;
+        double x0 = 0.0, y0 = 0.0;
+
+        for (int jp = 0; jp < npatch; ++jp) {
+            const int e = patch[jp];
+            const ConstConnAccessor conn = old_connectivity[e];
+
+            double cx = 0.0, cy = 0.0;
+            for (int k = 0; k < NODES_PER_ELEM; ++k) {
+                const ConstArrayAccessor ck = old_coord[conn[k]];
+                cx += ck[0];
+                cy += ck[1];
+            }
+            cx /= NODES_PER_ELEM;
+            cy /= NODES_PER_ELEM;
+
+            cx_arr[jp] = cx;
+            cy_arr[jp] = cy;
+            x0 += cx;
+            y0 += cy;
+
+            const double sj = sigma[e];
+            if (sj < smin) smin = sj;
+            if (sj > smax) smax = sj;
+        }
+        x0 /= npatch;
+        y0 /= npatch;
+
+        double A[3][3] = {};
+        double b[3]    = {};
+
+        for (int jp = 0; jp < npatch; ++jp) {
+            const double dx = cx_arr[jp] - x0;
+            const double dy = cy_arr[jp] - y0;
+            const double sj = sigma[patch[jp]];
+
+            A[0][0] += 1.0;
+            A[0][1] += dx;    A[1][0] = A[0][1];
+            A[0][2] += dy;    A[2][0] = A[0][2];
+            A[1][1] += dx*dx;
+            A[1][2] += dx*dy; A[2][1] = A[1][2];
+            A[2][2] += dy*dy;
+
+            b[0] += sj;
+            b[1] += dx * sj;
+            b[2] += dy * sj;
+        }
+
+        const double dxi = xi - x0;
+        const double dyi = yi - y0;
+
+        double val;
+        if (!spr_solve_centered(A, b, dxi, dyi, val)) {
+            val = spr_volume_weighted_avg(patch, elem_volume, sigma);
+        } else {
+            if (val < smin) val = smin;
+            if (val > smax) val = smax;
+        }
+
+        out[i] = val;
+    }
+#ifdef NPROF_DETAIL
+    nvtxRangePop();
+#endif
+}
+
+// Average per-node scalar values to element centroids (simple arithmetic mean over vertices).
+template<typename T>
+static void average_nodal_to_elem(const T nodal, const conn_t &connectivity,
+                                   int nelem, T elem)
+{
+#ifdef NPROF_DETAIL
+    nvtxRangePush(__FUNCTION__);
+#endif
+
+#ifndef ACC
+    #pragma omp parallel for default(none) \
+            shared(nodal, connectivity, nelem, elem)
+#endif
+    #pragma acc parallel loop gang vector async
+    for (int e = 0; e < nelem; ++e) {
+        ConstConnAccessor conn = connectivity[e];
+        double avg = 0.0;
+        for (int k = 0; k < NODES_PER_ELEM; ++k)
+            avg += nodal[conn[k]];
+        elem[e] = avg / NODES_PER_ELEM;
+    }
+#ifdef NPROF_DETAIL
+    nvtxRangePop();
+#endif
+}
+
+void spr_elem_to_node(const Param &param, Variables &var)
+{
+#ifdef NPROF_DETAIL
+    nvtxRangePush(__FUNCTION__);
+#endif
+    // ----------------------------------------------------------------
+    // Step A: SPR — recover smooth nodal stresses on the OLD mesh.
+    // Must happen before prepare_interpolation (reads old var.stress,
+    // *var.support, old_coord, old_connectivity — all still old here).
+    //
+    // Pressure-centering: subtract ref_pressure from each old element's
+    // diagonal stress components before SPR, so the polynomial fits the
+    // small deviatoric residual rather than the large lithostatic pressure.
+    // Without centering, independent polynomial fits for σxx and σzz on a
+    // one-sided surface-node patch differ by the amount of the actual
+    // deviatoric stress, but the large-pressure background amplifies any
+    // extrapolation error at boundary nodes. Cold surface ice (η≈visc_max)
+    // has a Maxwell relaxation time of ~250 Myr, so even a tiny artifact
+    // persists throughout the simulation.
+    // ----------------------------------------------------------------
+
+#ifndef ACC
+    #pragma omp parallel for default(none) shared(param, var)
+#endif
+    #pragma acc parallel loop gang vector async    
+    for (int e = 0; e < var.nelem; ++e) {
+        ConstConnAccessor conn = (*var.connectivity)[e];
+        double z = 0;
+        for (int k = 0; k < NODES_PER_ELEM; ++k)
+            z += (*var.coord)[conn[k]][NDIMS-1];
+        z /= NODES_PER_ELEM;
+        double p_ref_old = ref_pressure(param, z);
+        TensorAccessor s = (*var.stress)[e];
+        // Shift diagonal components: add p_ref so stress becomes small deviatoric
+        for (int d = 0; d < NDIMS; ++d) s[d] += p_ref_old;
+
+        if (param.mat.is_plane_strain)
+            (*var.stressyy)[e] += p_ref_old;
+    }
+
+    var.stress_n = new tensor_t(var.nnode);
+
+    if (param.mat.is_plane_strain)
+        var.stressyy_n = new double_vec(var.nnode);
+
+    #pragma acc wait
+
+    // Compute SPR-recovered nodal stresses from element-centroid stresses on the old mesh.
+    // Uses Zienkiewicz-Zhu superconvergent patch recovery with linear polynomial basis [1, x, y].
+    // nodal_stress_out: flat SoA array, size nnode_old * NSTR, indexed as [d * nnode_old + n]
+    // nodal_stressyy_out: flat array, size nnode_old (plane-strain out-of-plane component)
+    for (int d = 0; d < NSTR; ++d) {
+        spr_scalar_field(*var.coord, *var.connectivity, *var.support,
+                         var.stress->component(d), *var.volume,
+                         var.nnode, var.stress_n->component(d));
+    }
+
+    if (param.mat.is_plane_strain) {
+        spr_scalar_field(*var.coord, *var.connectivity, *var.support,
+                         var.stressyy->data(), *var.volume,
+                         var.nnode, var.stressyy_n->data());
+    }
+#ifdef NPROF_DETAIL
+    nvtxRangePop();
+#endif
+}
+
+void spr_node_to_elem(const Param &param, Variables &var)
+{
+#ifdef NPROF_DETAIL
+    nvtxRangePush(__FUNCTION__);
+#endif
+    // ----------------------------------------------------------------
+    // Step C: Average SPR nodal stresses -> new element stresses.
+    // ----------------------------------------------------------------
+    for (int d = 0; d < NSTR; ++d)
+        average_nodal_to_elem(var.stress_n->component(d), *var.connectivity,
+                              var.nelem, var.stress->component(d));
+
+    if (param.mat.is_plane_strain)
+        average_nodal_to_elem(var.stressyy_n->data(), *var.connectivity, var.nelem, var.stressyy->data());
+
+    // Step C': Restore reference pressure at new element centroids.
+    // The SPR operated on pressure-centered stress; add back p_ref at each
+    // new element's depth to recover the correct total stress.
+#ifndef ACC
+    #pragma omp parallel for default(none) shared(param, var)
+#endif
+    #pragma acc parallel loop gang vector async
+    for (int e = 0; e < var.nelem; ++e) {
+        ConstConnAccessor conn = (*var.connectivity)[e];
+        double z = 0;
+        for (int k = 0; k < NODES_PER_ELEM; ++k)
+            z += (*var.coord)[conn[k]][NDIMS-1];
+        z /= NODES_PER_ELEM;
+        double p_ref = ref_pressure(param, z);
+        TensorAccessor s = (*var.stress)[e];
+        for (int d = 0; d < NDIMS; ++d) s[d] -= p_ref;
+
+        if (param.mat.is_plane_strain)
+            (*var.stressyy)[e] -= p_ref;
+    }
+
+    #pragma acc wait
+
+    delete var.stress_n;
+    delete var.stressyy_n;
+#ifdef NPROF_DETAIL
     nvtxRangePop();
 #endif
 }

--- a/geometry.cxx
+++ b/geometry.cxx
@@ -344,6 +344,7 @@ void NMD_stress(const Variables &var, tensor_t& stress, double_vec &dp_nd, doubl
 // number from ~2.5e9 to ~2.3e4 — numerically safe for double precision.
 //
 // Returns true if the Cramer solve succeeded; false if degenerate (fallback).
+#pragma acc routine seq
 static bool spr_solve_centered(const double A[3][3], const double b[3],
                                const double dxi, const double dyi,
                                double &result)
@@ -355,8 +356,8 @@ static bool spr_solve_centered(const double A[3][3], const double b[3],
 
     // Scale-adaptive singularity threshold: A[1][1] ~ Σdx², A[2][2] ~ Σdz²
     // both O(h²) with patch-relative coords — well-conditioned.
-    const double scale = A[0][0] * std::max(A[1][1], A[2][2]);
-    if (scale == 0.0 || std::abs(det) < 1e-6 * scale)
+    const double scale = A[0][0] * (A[1][1] > A[2][2] ? A[1][1] : A[2][2]);
+    if (scale == 0.0 || fabs(det) < 1e-6 * scale)
         return false;
 
     const double inv_det = 1.0 / det;
@@ -383,6 +384,7 @@ static bool spr_solve_centered(const double A[3][3], const double b[3],
 // Volume-weighted average of element stress values in the patch.
 // Used as fallback when the SPR normal matrix is near-singular, and as a
 // clamp range for the polynomial result to prevent out-of-range extrapolation.
+#pragma acc routine seq
 template<typename T>
 static double spr_volume_weighted_avg(const int_vec &patch,
                                       const double_vec &elem_volume,
@@ -398,41 +400,38 @@ static double spr_volume_weighted_avg(const int_vec &patch,
     return (sum_w > 0.0) ? sum_ws / sum_w : 0.0;
 }
 
+#define MAX_PATCH_SIZE 64
 // Compute SPR nodal value for one scalar field sigma[0..nelem-1].
 template<typename T>
-static void spr_scalar_field(const array_t &old_coord,
-                             const conn_t &old_connectivity,
-                             const int_vec2D &old_support,
-                             const T sigma,
-                             const double_vec &elem_volume,
-                             const int nnode_old,
-                             T out)
+static void spr_scalar_field(const Variables &var, const T sigma, T out)
 {
 #ifdef NPROF_DETAIL
     nvtxRangePush(__FUNCTION__);
 #endif
 
-    #pragma omp parallel for default(none) \
-            shared(old_coord, old_connectivity, old_support, sigma, elem_volume, nnode_old, out)
-    for (int i = 0; i < nnode_old; ++i) {
-        const int_vec &patch = old_support[i];
+    #pragma omp parallel for default(none) shared(var, sigma, out)
+    for (int i = 0; i < var.nnode; ++i) {
+        const int_vec &patch = (*var.support)[i];
         const int npatch = (int)patch.size();
 
-        const ConstArrayAccessor ci = old_coord[i];
+        const ConstArrayAccessor ci = (*var.coord)[i];
         const double xi = ci[0];
         const double yi = ci[1];
 
-        double_vec cx_arr(npatch), cy_arr(npatch);
+        // double_vec cx_arr(npatch), cy_arr(npatch);
+        double cx_arr[MAX_PATCH_SIZE];
+        double cy_arr[MAX_PATCH_SIZE];
+        assert(npatch <= MAX_PATCH_SIZE);
         double smin = sigma[patch[0]], smax = smin;
         double x0 = 0.0, y0 = 0.0;
 
         for (int jp = 0; jp < npatch; ++jp) {
             const int e = patch[jp];
-            const ConstConnAccessor conn = old_connectivity[e];
+            const ConstConnAccessor conn = (*var.connectivity)[e];
 
             double cx = 0.0, cy = 0.0;
             for (int k = 0; k < NODES_PER_ELEM; ++k) {
-                const ConstArrayAccessor ck = old_coord[conn[k]];
+                const ConstArrayAccessor ck = (*var.coord)[conn[k]];
                 cx += ck[0];
                 cy += ck[1];
             }
@@ -476,7 +475,7 @@ static void spr_scalar_field(const array_t &old_coord,
 
         double val;
         if (!spr_solve_centered(A, b, dxi, dyi, val)) {
-            val = spr_volume_weighted_avg(patch, elem_volume, sigma);
+            val = spr_volume_weighted_avg(patch, *var.volume, sigma);
         } else {
             if (val < smin) val = smin;
             if (val > smax) val = smax;
@@ -566,17 +565,12 @@ void spr_elem_to_node(const Param &param, Variables &var)
     // Uses Zienkiewicz-Zhu superconvergent patch recovery with linear polynomial basis [1, x, y].
     // nodal_stress_out: flat SoA array, size nnode_old * NSTR, indexed as [d * nnode_old + n]
     // nodal_stressyy_out: flat array, size nnode_old (plane-strain out-of-plane component)
-    for (int d = 0; d < NSTR; ++d) {
-        spr_scalar_field(*var.coord, *var.connectivity, *var.support,
-                         var.stress->component(d), *var.volume,
-                         var.nnode, var.stress_n->component(d));
-    }
+    for (int d = 0; d < NSTR; ++d)
+        spr_scalar_field(var, var.stress->component(d), var.stress_n->component(d));
 
-    if (param.mat.is_plane_strain) {
-        spr_scalar_field(*var.coord, *var.connectivity, *var.support,
-                         var.stressyy->data(), *var.volume,
-                         var.nnode, var.stressyy_n->data());
-    }
+    if (param.mat.is_plane_strain)
+        spr_scalar_field(var, var.stressyy->data(), var.stressyy_n->data());
+
 #ifdef NPROF_DETAIL
     nvtxRangePop();
 #endif

--- a/geometry.cxx
+++ b/geometry.cxx
@@ -339,9 +339,8 @@ void NMD_stress(const Variables &var, tensor_t& stress, double_vec &dp_nd, doubl
 // (centroid of the patch's element centroids as origin).  Evaluate at the
 // node's relative coordinates.
 //
-// Using relative coordinates reduces the absolute magnitudes from ~50,000 m
-// to ~300 m (one mesh element), dropping the 3×3 normal-matrix condition
-// number from ~2.5e9 to ~2.3e4 — numerically safe for double precision.
+// Use relative coordinates to lower the matrix condition number
+// and prevent numerical precision loss in double precision.
 //
 // Returns true if the Cramer solve succeeded; false if degenerate (fallback).
 #pragma acc routine seq

--- a/geometry.cxx
+++ b/geometry.cxx
@@ -447,16 +447,14 @@ static bool spr_solve_centered_3d(const double A[4][4], const double b[4],
 // Used as fallback when the SPR normal matrix is near-singular, and as a
 // clamp range for the polynomial result to prevent out-of-range extrapolation.
 #pragma acc routine seq
-static double spr_volume_weighted_avg_strided(const Variables &var, 
-                                              int node_idx, 
+static double spr_volume_weighted_avg_strided(const int npatch, const int* patch, 
                                               const double_vec &elem_volume, 
                                               const double* ptr, 
                                               int stride) 
 {
     double sum_w = 0.0, sum_ws = 0.0;
-    int npatch = get_sup_size(var, node_idx);
     for (int jp = 0; jp < npatch; ++jp) {
-        int e = get_support(var, node_idx, jp);
+        int e = patch[jp];
         double w = elem_volume[e];
         sum_ws += w * ptr[e * stride]; 
         sum_w  += w;
@@ -484,10 +482,11 @@ static void spr_fused_fields(const Variables &var,
     #pragma acc parallel loop gang vector async copyin(in_ptrs[0:num_fields], \
                 in_strides[0:num_fields], out_ptrs[0:num_fields], out_strides[0:num_fields])
     for (int i = 0; i < var.nnode; ++i) {
-        const int npatch = get_sup_size(var, i);
+        const int npatch = var.sup.size(i);
 
         double smin[MAX_SPR_FIELDS], smax[MAX_SPR_FIELDS];
-        const int e0 = get_support(var, i, 0);
+        const int* patch = var.sup.patch(i);
+        const int e0 = patch[0];
         
         #pragma acc loop seq
         for (int f = 0; f < num_fields; ++f) {
@@ -502,7 +501,7 @@ static void spr_fused_fields(const Variables &var,
         // calculate patch centroid (x0, y0, z0) and field value extrema (smin, smax) for clamping
         #pragma acc loop seq
         for (int jp = 0; jp < npatch; ++jp) {
-            const int e = get_support(var, i, jp);
+            const int e = patch[jp];
             ConstArrayIndirectAccessor ck = var.coord->view_const((*var.connectivity)[e]);
             double cx = 0.0, cy = 0.0;
 #ifdef THREED
@@ -543,7 +542,7 @@ static void spr_fused_fields(const Variables &var,
         // with shared loops and Stride-aware access
         #pragma acc loop seq
         for (int jp = 0; jp < npatch; ++jp) {
-            const int e = get_support(var, i, jp);
+            const int e = patch[jp];
             ConstArrayIndirectAccessor ck = var.coord->view_const((*var.connectivity)[e]);
             double cx = 0.0, cy = 0.0;
 #ifdef THREED
@@ -617,7 +616,8 @@ static void spr_fused_fields(const Variables &var,
                 // if the matrix is degenerate, the polynomial fit is unreliable. 
                 // Fall back to volume-weighted average, which is stable but less accurate. 
                 // The clamping range is still valid since it's based on the patch values.
-                spr_volume_weighted_avg_strided(var, i, *var.volume, in_ptrs[f], in_strides[f]);
+                spr_volume_weighted_avg_strided(var.sup.size(i), var.sup.patch(i),
+                                                *var.volume, in_ptrs[f], in_strides[f]);
 
             out_ptrs[f][i * out_strides[f]] = temp_val;
         }

--- a/geometry.cxx
+++ b/geometry.cxx
@@ -488,32 +488,6 @@ static void spr_scalar_field(const Variables &var, const T sigma, T out)
 #endif
 }
 
-// Average per-node scalar values to element centroids (simple arithmetic mean over vertices).
-template<typename T>
-static void average_nodal_to_elem(const T nodal, const conn_t &connectivity,
-                                   int nelem, T elem)
-{
-#ifdef NPROF_DETAIL
-    nvtxRangePush(__FUNCTION__);
-#endif
-
-#ifndef ACC
-    #pragma omp parallel for default(none) \
-            shared(nodal, connectivity, nelem, elem)
-#endif
-    #pragma acc parallel loop gang vector async
-    for (int e = 0; e < nelem; ++e) {
-        ConstConnAccessor conn = connectivity[e];
-        double avg = 0.0;
-        for (int k = 0; k < NODES_PER_ELEM; ++k)
-            avg += nodal[conn[k]];
-        elem[e] = avg / NODES_PER_ELEM;
-    }
-#ifdef NPROF_DETAIL
-    nvtxRangePop();
-#endif
-}
-
 void spr_elem_to_node(const Param &param, Variables &var)
 {
 #ifdef NPROF_DETAIL
@@ -585,11 +559,12 @@ void spr_node_to_elem(const Param &param, Variables &var)
     // Step C: Average SPR nodal stresses -> new element stresses.
     // ----------------------------------------------------------------
     for (int d = 0; d < NSTR; ++d)
-        average_nodal_to_elem(var.stress_n->component(d), *var.connectivity,
+        average_nodal_to_elem(var.stress_n->component_const(d), *var.connectivity,
                               var.nelem, var.stress->component(d));
 
     if (param.mat.is_plane_strain)
-        average_nodal_to_elem(var.stressyy_n->data(), *var.connectivity, var.nelem, var.stressyy->data());
+        average_nodal_to_elem(static_cast<const double*>(var.stressyy_n->data()), *var.connectivity,
+                                var.nelem, var.stressyy->data());
 
     // Step C': Restore reference pressure at new element centroids.
     // The SPR operated on pressure-centered stress; add back p_ref at each

--- a/geometry.cxx
+++ b/geometry.cxx
@@ -488,7 +488,8 @@ static void spr_scalar_field(const Variables &var, const T sigma, T out)
 #endif
 }
 
-void spr_elem_to_node(const Param &param, Variables &var)
+void spr_elem_to_node(const Param &param, const Variables &var,
+                      tensor_t *stress_n, double_vec *stressyy_n)
 {
 #ifdef NPROF_DETAIL
     nvtxRangePush(__FUNCTION__);
@@ -528,11 +529,6 @@ void spr_elem_to_node(const Param &param, Variables &var)
             (*var.stressyy)[e] += p_ref_old;
     }
 
-    var.stress_n = new tensor_t(var.nnode);
-
-    if (param.mat.is_plane_strain)
-        var.stressyy_n = new double_vec(var.nnode);
-
     #pragma acc wait
 
     // Compute SPR-recovered nodal stresses from element-centroid stresses on the old mesh.
@@ -540,17 +536,18 @@ void spr_elem_to_node(const Param &param, Variables &var)
     // nodal_stress_out: flat SoA array, size nnode_old * NSTR, indexed as [d * nnode_old + n]
     // nodal_stressyy_out: flat array, size nnode_old (plane-strain out-of-plane component)
     for (int d = 0; d < NSTR; ++d)
-        spr_scalar_field(var, var.stress->component(d), var.stress_n->component(d));
+        spr_scalar_field(var, var.stress->component(d), stress_n->component(d));
 
     if (param.mat.is_plane_strain)
-        spr_scalar_field(var, var.stressyy->data(), var.stressyy_n->data());
+        spr_scalar_field(var, var.stressyy->data(), stressyy_n->data());
 
 #ifdef NPROF_DETAIL
     nvtxRangePop();
 #endif
 }
 
-void spr_node_to_elem(const Param &param, Variables &var)
+void spr_node_to_elem(const Param &param, const Variables &var, 
+                      tensor_t *stress, double_vec *stressyy)
 {
 #ifdef NPROF_DETAIL
     nvtxRangePush(__FUNCTION__);
@@ -560,17 +557,17 @@ void spr_node_to_elem(const Param &param, Variables &var)
     // ----------------------------------------------------------------
     for (int d = 0; d < NSTR; ++d)
         average_nodal_to_elem(var.stress_n->component_const(d), *var.connectivity,
-                              var.nelem, var.stress->component(d));
+                              var.nelem, stress->component(d));
 
     if (param.mat.is_plane_strain)
         average_nodal_to_elem(static_cast<const double*>(var.stressyy_n->data()), *var.connectivity,
-                                var.nelem, var.stressyy->data());
+                                var.nelem, stressyy->data());
 
     // Step C': Restore reference pressure at new element centroids.
     // The SPR operated on pressure-centered stress; add back p_ref at each
     // new element's depth to recover the correct total stress.
 #ifndef ACC
-    #pragma omp parallel for default(none) shared(param, var)
+    #pragma omp parallel for default(none) shared(param, var, stress, stressyy)
 #endif
     #pragma acc parallel loop gang vector async
     for (int e = 0; e < var.nelem; ++e) {
@@ -580,17 +577,15 @@ void spr_node_to_elem(const Param &param, Variables &var)
             z += (*var.coord)[conn[k]][NDIMS-1];
         z /= NODES_PER_ELEM;
         double p_ref = ref_pressure(param, z);
-        TensorAccessor s = (*var.stress)[e];
+        TensorAccessor s = (*stress)[e];
         for (int d = 0; d < NDIMS; ++d) s[d] -= p_ref;
 
         if (param.mat.is_plane_strain)
-            (*var.stressyy)[e] -= p_ref;
+            (*stressyy)[e] -= p_ref;
     }
 
     #pragma acc wait
 
-    delete var.stress_n;
-    delete var.stressyy_n;
 #ifdef NPROF_DETAIL
     nvtxRangePop();
 #endif

--- a/geometry.cxx
+++ b/geometry.cxx
@@ -381,6 +381,68 @@ static bool spr_solve_centered(const double A[3][3], const double b[3],
     return true;
 }
 
+#ifdef THREED
+// Fit linear polynomial sigma*(dx,dy,dz) = a0 + a1*dx + a2*dy + a3*dz to element
+// centroid values in the patch.  Uses Gaussian elimination with partial pivoting
+// on the 4×4 normal system.  Returns true on success; false if the patch is
+// degenerate (fewer than 4 independent directions → fallback).
+#pragma acc routine seq
+static bool spr_solve_centered_3d(const double A[4][4], const double b[4],
+                                   const double dxi, const double dyi, const double dzi,
+                                   double &result)
+{
+    // Per-column ∞-norms of the original A, used as per-step singularity thresholds.
+    // Column 0 scale ~ n (count); columns 1–3 scale ~ n·h² (patch-relative coords).
+    double col_scale[4] = {};
+    for (int i = 0; i < 4; ++i)
+        for (int j = 0; j < 4; ++j) {
+            const double v = fabs(A[i][j]);
+            if (v > col_scale[j]) col_scale[j] = v;
+        }
+    if (col_scale[0] == 0.0) return false;
+
+    // Augmented system [A | b]
+    double M[4][5];
+    for (int i = 0; i < 4; ++i) {
+        for (int j = 0; j < 4; ++j) M[i][j] = A[i][j];
+        M[i][4] = b[i];
+    }
+
+    for (int col = 0; col < 4; ++col) {
+        int pivot_row = col;
+        double pval = fabs(M[col][col]);
+        for (int row = col+1; row < 4; ++row) {
+            const double v = fabs(M[row][col]);
+            if (v > pval) { pval = v; pivot_row = row; }
+        }
+        // col_scale[col]==0 means that entire column of A was zero (degenerate patch,
+        // e.g. all centroids at the same depth) → rank-deficient → fall back.
+        if (col_scale[col] == 0.0 || pval < 1e-6 * col_scale[col]) return false;
+
+        if (pivot_row != col)
+            for (int j = 0; j <= 4; ++j) {
+                double tmp = M[col][j]; M[col][j] = M[pivot_row][j]; M[pivot_row][j] = tmp;
+            }
+
+        const double inv_pivot = 1.0 / M[col][col];
+        for (int row = col+1; row < 4; ++row) {
+            const double factor = M[row][col] * inv_pivot;
+            for (int j = col; j <= 4; ++j) M[row][j] -= factor * M[col][j];
+        }
+    }
+
+    double x[4];
+    for (int i = 3; i >= 0; --i) {
+        double s = M[i][4];
+        for (int j = i+1; j < 4; ++j) s -= M[i][j] * x[j];
+        x[i] = s / M[i][i];
+    }
+
+    result = x[0] + x[1]*dxi + x[2]*dyi + x[3]*dzi;
+    return true;
+}
+#endif // THREED
+
 // Volume-weighted average of element stress values in the patch.
 // Used as fallback when the SPR normal matrix is near-singular, and as a
 // clamp range for the polynomial result to prevent out-of-range extrapolation.
@@ -400,7 +462,7 @@ static double spr_volume_weighted_avg(const int_vec &patch,
     return (sum_w > 0.0) ? sum_ws / sum_w : 0.0;
 }
 
-#define MAX_PATCH_SIZE 64
+#define MAX_PATCH_SIZE 128
 // Compute SPR nodal value for one scalar field sigma[0..nelem-1].
 template<typename T>
 static void spr_scalar_field(const Variables &var, const T sigma, T out)
@@ -417,11 +479,20 @@ static void spr_scalar_field(const Variables &var, const T sigma, T out)
         const ConstArrayAccessor ci = (*var.coord)[i];
         const double xi = ci[0];
         const double yi = ci[1];
+#ifdef THREED
+        const double zi = ci[2];
+#endif
 
-        // double_vec cx_arr(npatch), cy_arr(npatch);
         double cx_arr[MAX_PATCH_SIZE];
         double cy_arr[MAX_PATCH_SIZE];
-        assert(npatch <= MAX_PATCH_SIZE);
+#ifdef THREED
+        double cz_arr[MAX_PATCH_SIZE];
+        double z0 = 0.0;
+#endif
+        if (npatch > MAX_PATCH_SIZE) {
+            out[i] = spr_volume_weighted_avg(patch, *var.volume, sigma);
+            continue;
+        }
         double smin = sigma[patch[0]], smax = smin;
         double x0 = 0.0, y0 = 0.0;
 
@@ -430,18 +501,33 @@ static void spr_scalar_field(const Variables &var, const T sigma, T out)
             const ConstConnAccessor conn = (*var.connectivity)[e];
 
             double cx = 0.0, cy = 0.0;
+#ifdef THREED
+            double cz = 0.0;
+#endif
             for (int k = 0; k < NODES_PER_ELEM; ++k) {
                 const ConstArrayAccessor ck = (*var.coord)[conn[k]];
                 cx += ck[0];
                 cy += ck[1];
+#ifdef THREED
+                cz += ck[2];
+#endif
             }
             cx /= NODES_PER_ELEM;
             cy /= NODES_PER_ELEM;
+#ifdef THREED
+            cz /= NODES_PER_ELEM;
+#endif
 
             cx_arr[jp] = cx;
             cy_arr[jp] = cy;
+#ifdef THREED
+            cz_arr[jp] = cz;
+#endif
             x0 += cx;
             y0 += cy;
+#ifdef THREED
+            z0 += cz;
+#endif
 
             const double sj = sigma[e];
             if (sj < smin) smin = sj;
@@ -449,13 +535,21 @@ static void spr_scalar_field(const Variables &var, const T sigma, T out)
         }
         x0 /= npatch;
         y0 /= npatch;
-
+#ifdef THREED
+        z0 /= npatch;
+        double A[4][4] = {};
+        double b[4]    = {};
+#else
         double A[3][3] = {};
         double b[3]    = {};
+#endif
 
         for (int jp = 0; jp < npatch; ++jp) {
             const double dx = cx_arr[jp] - x0;
             const double dy = cy_arr[jp] - y0;
+#ifdef THREED
+            const double dz = cz_arr[jp] - z0;
+#endif
             const double sj = sigma[patch[jp]];
 
             A[0][0] += 1.0;
@@ -464,17 +558,33 @@ static void spr_scalar_field(const Variables &var, const T sigma, T out)
             A[1][1] += dx*dx;
             A[1][2] += dx*dy; A[2][1] = A[1][2];
             A[2][2] += dy*dy;
+#ifdef THREED
+            A[0][3] += dz;    A[3][0] = A[0][3];
+            A[1][3] += dx*dz; A[3][1] = A[1][3];
+            A[2][3] += dy*dz; A[3][2] = A[2][3];
+            A[3][3] += dz*dz;
+#endif
 
             b[0] += sj;
             b[1] += dx * sj;
             b[2] += dy * sj;
+#ifdef THREED
+            b[3] += dz * sj;
+#endif
         }
 
         const double dxi = xi - x0;
         const double dyi = yi - y0;
+#ifdef THREED
+        const double dzi = zi - z0;
+#endif
 
         double val;
+#ifdef THREED
+        if (!spr_solve_centered_3d(A, b, dxi, dyi, dzi, val)) {
+#else
         if (!spr_solve_centered(A, b, dxi, dyi, val)) {
+#endif
             val = spr_volume_weighted_avg(patch, *var.volume, sigma);
         } else {
             if (val < smin) val = smin;

--- a/geometry.hpp
+++ b/geometry.hpp
@@ -17,8 +17,12 @@ void compute_dvoldt(const Variables &var, double_vec &dvoldt,
 void compute_edvoldt(const Variables &var, double_vec &dvoldt,
                      double_vec &edvoldt);
 
-void NMD_stress(const Param& param, const Variables &var, double_vec &dp_nd,
-                tensor_t& stress, double_vec &etmp);
+void NMD_stress(const Variables &var, tensor_t& stress, double_vec &dp_nd,
+                double_vec &etmp);
+
+void spr_elem_to_node(const Param& param, Variables& var);
+
+void spr_node_to_elem(const Param& param, Variables& var);
 
 double compute_dt(const Param& param, Variables& var);
 // double compute_dt(const Param& param, const Variables& var);

--- a/geometry.hpp
+++ b/geometry.hpp
@@ -20,9 +20,11 @@ void compute_edvoldt(const Variables &var, double_vec &dvoldt,
 void NMD_stress(const Variables &var, tensor_t& stress, double_vec &dp_nd,
                 double_vec &etmp);
 
-void spr_elem_to_node(const Param& param, Variables& var);
+void spr_elem_to_node(const Param& param, const Variables& var,
+                      tensor_t* stress_n, double_vec* stressyy_n);
 
-void spr_node_to_elem(const Param& param, Variables& var);
+void spr_node_to_elem(const Param& param, const Variables& var,
+                      tensor_t* stress, double_vec* stressyy);
 
 double compute_dt(const Param& param, Variables& var);
 // double compute_dt(const Param& param, const Variables& var);

--- a/input.cxx
+++ b/input.cxx
@@ -310,8 +310,6 @@ static void declare_parameters(po::options_description &cfg,
 //         "and force the 1st invariant to zero.")
         ("control.is_using_mixed_stress", po::value<bool>(&p.control.is_using_mixed_stress)->default_value(true),
          "If use Nodal Mixed Discretization For Stress")
-        ("control.mixed_stress_reference_viscosity", po::value<double>(&p.control.mixed_stress_reference_viscosity)->default_value(1.e19),
-         "The reference viscosity for appling mixed stress.")
 
         ("control.surface_process_option", po::value<int>(&p.control.surface_process_option)->default_value(0),
          "What kind of surface processes? 0: no surface processes. "

--- a/markerset.cxx
+++ b/markerset.cxx
@@ -579,7 +579,10 @@ void MarkerSet::regularly_spaced_markers( const Param& param, Variables &var, in
 
     // nearest-neighbor search structure
     array_t centroid(var.nelem);
-    elem_center(*var.coord, *var.connectivity, centroid);
+    for (int d=0; d<NDIMS; d++)
+        average_nodal_to_elem(var.coord->component_const(d), *var.connectivity, var.nelem, centroid.component(d));
+
+    #pragma acc wait
 
     PointCloud cloud(centroid);
     NANOKDTree kdtree(NDIMS, cloud);
@@ -1758,7 +1761,10 @@ void remap_markers(const Param& param, Variables &var, const array_t &old_coord,
 #endif
 
         array_t points(var.nelem);
-        elem_center(*var.coord, *var.connectivity, points); // centroid of elements
+        for (int d = 0; d < NDIMS; d++)
+            average_nodal_to_elem(var.coord->component_const(d), *var.connectivity, var.nelem, points.component(d));
+
+        #pragma acc wait
 
 #ifdef ACC
         array_t point_tmp(1);

--- a/mesh.cxx
+++ b/mesh.cxx
@@ -3462,69 +3462,42 @@ void create_new_mesh(const Param& param, Variables& var)
     // std::cout << '\n';
 }
 
-
-void elem_center(const array_t &coord, const conn_t &connectivity, array_t& center)
+// Average per-node scalar values to element centroids (simple arithmetic mean over vertices).
+template<typename T_in, typename T_out>
+void average_nodal_to_elem(T_in nodal, const conn_t &connectivity,
+                                   int nelem, T_out elem, bool is_surface)
 {
 #ifdef NPROF_DETAIL
     nvtxRangePush(__FUNCTION__);
 #endif
-    int nelem = connectivity.size();
+
+    int nnodes_per_elem = is_surface ? NODES_PER_FACET : NODES_PER_ELEM;
 
 #ifndef ACC
-    #pragma omp parallel for default(none)          \
-        shared(nelem, coord, connectivity, center)
-#endif
-    #pragma acc parallel loop gang vector collapse(2) async
-    for(int e=0; e<nelem; e++) {
-        // const int* conn = connectivity[e];
-        for(int d=0; d<NDIMS; d++) {
-            double sum = 0;
-            for(int k=0; k<NODES_PER_ELEM; k++) {
-                sum += coord[connectivity[e][k]][d];
-            }
-            center[e][d] = sum / NODES_PER_ELEM;
-        }
-    }
-
-    #pragma acc wait
-
-#ifdef NPROF_DETAIL
-    nvtxRangePop();
-#endif
-}
-
-void facet_center(const array_t &coord, const conn_t &connectivity, array_t& center)
-{
-#ifdef NPROF_DETAIL
-    nvtxRangePush(__FUNCTION__);
-#endif
-    int nelem = connectivity.size();
-
-#ifndef ACC
-    #pragma omp parallel for default(none)          \
-        shared(nelem, coord, connectivity, center)
-#endif
-    #pragma acc parallel loop gang vector collapse(2) async
-    for(int e=0; e<nelem; e++) {
-        for(int d=0; d<NDIMS-1; d++) {
-            double sum = 0;
-            for(int k=0; k<NODES_PER_FACET; k++) {
-                sum += coord[connectivity[e][k]][d];
-            }
-            center[e][d] = sum / NODES_PER_FACET;
-        }
-    }
-
-#ifndef ACC
-    #pragma omp parallel for default(none) shared(nelem, center)
+    #pragma omp parallel for default(none) \
+            shared(nodal, connectivity, nelem, elem, nnodes_per_elem)
 #endif
     #pragma acc parallel loop gang vector async
-    for(int e=0; e<nelem; e++)
-        center[e][NDIMS-1] = 0.;
-
-    #pragma acc wait
-
+    for (int e = 0; e < nelem; ++e) {
+        ConstConnAccessor conn = connectivity[e];
+        double avg = 0.0;
+        for (int k = 0; k < nnodes_per_elem; ++k)
+            avg += nodal[conn[k]];
+        elem[e] = avg / nnodes_per_elem;
+    }
 #ifdef NPROF_DETAIL
     nvtxRangePop();
 #endif
 }
+
+template
+void average_nodal_to_elem<array_t::ConstComponentAccessor, array_t::ComponentAccessor>(
+    array_t::ConstComponentAccessor nodal, 
+    const conn_t &connectivity, int nelem, array_t::ComponentAccessor elem, bool);
+template
+void average_nodal_to_elem<tensor_t::ConstComponentAccessor, tensor_t::ComponentAccessor>(
+    tensor_t::ConstComponentAccessor nodal, 
+    const conn_t &connectivity, int nelem, tensor_t::ComponentAccessor elem, bool);
+template
+void average_nodal_to_elem<const double*, double*>(const double* nodal, 
+    const conn_t &connectivity, int nelem, double* elem, bool);

--- a/mesh.cxx
+++ b/mesh.cxx
@@ -3236,19 +3236,6 @@ void create_boundary_facets(Variables& var)
 }
 
 
-int get_support(const Variables& var, const int inode, const int isup)
-{
-    const int start = (inode == 0) ? 0 : (*var.support_idx)[inode-1];
-    return (*var.support_arr)[start + isup];
-}
-
-int get_sup_size(const Variables& var, const int inode)
-{
-    const int start = (inode == 0) ? 0 : (*var.support_idx)[inode-1];
-    const int end = (*var.support_idx)[inode];
-    return end - start;
-}
-
 
 void create_support(Variables& var)
 {
@@ -3256,32 +3243,35 @@ void create_support(Variables& var)
     nvtxRangePush(__FUNCTION__);
 #endif
     var.support = new int_vec2D(var.nnode);
-    var.support_idx = new int_vec(var.nnode, 0);
+    // CSR row-pointer format: size nnode+1, support_idx[n] = start of node n
+    var.support_idx = new int_vec(var.nnode + 1, 0);
 
     // create the inverse mapping of connectivity
     for (int e=0; e<var.nelem; ++e) {
         ConstConnAccessor conn = (*var.connectivity)[e];
         for (int i=0; i<NODES_PER_ELEM; ++i) {
             (*var.support)[conn[i]].push_back(e);
-            (*var.support_idx)[conn[i]]++;
+            (*var.support_idx)[conn[i] + 1]++;
         }
     }
-    // create suppert 1D for ACC
-    for (int n=1; n<var.nnode; ++n)
-        (*var.support_idx)[n] = (*var.support_idx)[n-1] + (*var.support_idx)[n];
+    // prefix-sum counts into start offsets
+    for (int n=1; n<=var.nnode; ++n)
+        (*var.support_idx)[n] += (*var.support_idx)[n-1];
 
-    int nsup = (*var.support_idx)[var.nnode-1];
+    int nsup = (*var.support_idx)[var.nnode];
 
-    var.support_arr = new int_vec((*var.support_idx)[var.nnode-1]);
+    var.support_arr = new int_vec(nsup);
 
     // fill support_arr
     for (int n=0; n<var.nnode; ++n) {
-        int start = (n == 0) ? 0 : (*var.support_idx)[n-1];
-        int end = (*var.support_idx)[n];
+        int start = (*var.support_idx)[n];
+        int end   = (*var.support_idx)[n+1];
         for (int i=start; i<end; ++i) {
             (*var.support_arr)[i] = (*var.support)[n][i-start];
         }
     }
+    var.sup = {var.support_arr->data(), var.support_idx->data()};
+
     // std::cout << "support:\n";
     // print(std::cout, *var.support);
     // std::cout << "\n";

--- a/mesh.hpp
+++ b/mesh.hpp
@@ -32,9 +32,9 @@ int get_sup_size(const Variables& var, const int inode);
 void create_elemmarkers(const Param&, Variables&);
 void create_markers(const Param&, Variables&);
 void create_new_mesh(const Param&, Variables&);
-void elem_center(const array_t &coord, const conn_t &connectivity, array_t& points);
-void facet_center(const array_t &coord, const conn_t &connectivity, array_t& center);
 void create_equilateral_elem(const Variables& var, int *&connectivity);
 void create_equilateral_segments(const Variables& var, int *&segments, int *&segflags);
+template <typename T_in, typename T_out>
+void average_nodal_to_elem(T_in nodal, const conn_t &connectivity, int nelem, T_out elem, bool is_surface=false);
 
 #endif

--- a/mesh.hpp
+++ b/mesh.hpp
@@ -27,8 +27,6 @@ void create_surface_info(const Param& param, const Variables& var, SurfaceInfo& 
 void update_surface_info(const Variables& var, SurfaceInfo& surfinfo);
 void create_support(Variables& var);
 void create_neighbor(Variables& var);
-int get_support(const Variables& var, const int inode, const int isup);
-int get_sup_size(const Variables& var, const int inode);
 void create_elemmarkers(const Param&, Variables&);
 void create_markers(const Param&, Variables&);
 void create_new_mesh(const Param&, Variables&);

--- a/nn-interpolation.cxx
+++ b/nn-interpolation.cxx
@@ -570,14 +570,14 @@ namespace {
 
             #pragma acc wait
 
-            tensor_t *new_stress = new tensor_t(e);
-            inject_field(idx, is_changed, idx_changed, elems_vec, ratios_vec, *var.stress, *new_stress, e);
+            double_vec *new_radiogenic_source = new double_vec(e);
+            inject_field(idx, is_changed, idx_changed, elems_vec, ratios_vec, *var.radiogenic_source, *new_radiogenic_source, e);
 
-            double_vec *new_stressyy = new double_vec(e);
-            inject_field(idx, is_changed, idx_changed, elems_vec, ratios_vec, *var.stressyy, *new_stressyy, e);
+            double_vec *new_dyn_fric_coeff = new double_vec(e);
+            inject_field(idx, is_changed, idx_changed, elems_vec, ratios_vec, *var.dyn_fric_coeff, *new_dyn_fric_coeff, e);
 
-            double_vec *new_old_mean_stress = new double_vec(e);
-            inject_field(idx, is_changed, idx_changed, elems_vec, ratios_vec, *var.old_mean_stress, *new_old_mean_stress, e);
+            double_vec *new_state_variable = new double_vec(e);
+            inject_field(idx, is_changed, idx_changed, elems_vec, ratios_vec, *var.state_variable, *new_state_variable, e);
 
             double_vec *new_volume_old = new double_vec(e);
             inject_field(idx, is_changed, idx_changed, elems_vec, ratios_vec, *var.volume_old, *new_volume_old, e);
@@ -590,26 +590,6 @@ namespace {
 
             delete var.strain;
             var.strain = new_strain;
-
-            #pragma acc wait
-
-            double_vec *new_radiogenic_source = new double_vec(e);
-            inject_field(idx, is_changed, idx_changed, elems_vec, ratios_vec, *var.radiogenic_source, *new_radiogenic_source, e);
-
-            double_vec *new_dyn_fric_coeff = new double_vec(e);
-            inject_field(idx, is_changed, idx_changed, elems_vec, ratios_vec, *var.dyn_fric_coeff, *new_dyn_fric_coeff, e);
-
-            double_vec *new_state_variable = new double_vec(e);
-            inject_field(idx, is_changed, idx_changed, elems_vec, ratios_vec, *var.state_variable, *new_state_variable, e);
-
-            delete var.stress;
-            var.stress = new_stress;
-
-            delete var.stressyy;
-            var.stressyy = new_stressyy;
-
-            delete var.old_mean_stress;
-            var.old_mean_stress = new_old_mean_stress;
 
             #pragma acc wait
 

--- a/nn-interpolation.cxx
+++ b/nn-interpolation.cxx
@@ -579,6 +579,9 @@ namespace {
             double_vec *new_old_mean_stress = new double_vec(e);
             inject_field(idx, is_changed, idx_changed, elems_vec, ratios_vec, *var.old_mean_stress, *new_old_mean_stress, e);
 
+            double_vec *new_volume_old = new double_vec(e);
+            inject_field(idx, is_changed, idx_changed, elems_vec, ratios_vec, *var.volume_old, *new_volume_old, e);
+
             delete var.plstrain;
             var.plstrain = new_plstrain;
 
@@ -618,6 +621,9 @@ namespace {
 
             delete var.state_variable;
             var.state_variable = new_state_variable;
+
+            delete var.volume_old;
+            var.volume_old = new_volume_old;
 
             // b = new tensor_t(e);
             // inject_field(idx, is_changed, elems_vec, ratios_vec, *var.stress_old, *b);

--- a/nn-interpolation.cxx
+++ b/nn-interpolation.cxx
@@ -23,20 +23,18 @@ namespace {
 #endif
 
         double eps = 1e-15;
-        int nqueries;
-
-        if (is_surface)
-            nqueries = var.bfacets[iboundz1]->size();
-        else
-            nqueries = var.nelem;
+        int nqueries = is_surface ? var.bfacets[iboundz1]->size() : var.nelem;
+        int ncomponents = is_surface ? NDIMS-1 : NDIMS;
+        conn_t *connectivity = is_surface ? var.connectivity_surface : var.connectivity;
 
         array_t queries(nqueries);
 
-        if (is_surface) {
-            facet_center(*var.coord, *var.connectivity_surface, queries);
-        } else {
-            elem_center(*var.coord, *var.connectivity, queries);
-        }
+        for (int d= 0; d < ncomponents; d++)
+            average_nodal_to_elem(var.coord->component_const(d), *connectivity, nqueries, queries.component(d), is_surface);
+
+        if (is_surface) queries.zero_component(NDIMS-1);
+
+        #pragma acc wait
 
         {
             printf(is_surface ? "    Top surface:      "
@@ -350,13 +348,17 @@ namespace {
 #ifdef NPROF_DETAIL
         nvtxRangePush("create kdtree for old elements");
 #endif
+        int ncomponents = is_surface ? NDIMS-1 : NDIMS;
 
         array_t points(old_npoint);
-        if (is_surface) {
-            facet_center(old_coord, old_connectivity, points);
-        } else {
-            elem_center(old_coord, old_connectivity, points);
-        }
+
+        for (int d= 0; d < ncomponents; d++)
+            average_nodal_to_elem(old_coord.component_const(d), old_connectivity,
+                                  old_npoint, points.component(d), is_surface);
+
+        if (is_surface) points.zero_component(NDIMS-1);
+
+        #pragma acc wait
 
 #ifdef ACC
         array_t point_tmp(1);

--- a/parameters.hpp
+++ b/parameters.hpp
@@ -215,7 +215,6 @@ struct Control {
     int ref_pressure_option;
 //    bool surface_pressure_correction;
     bool is_using_mixed_stress;
-    double mixed_stress_reference_viscosity;
 
     int surface_process_option;
     double surface_diffusivity;
@@ -743,6 +742,10 @@ struct Variables {
     elem_cache *tmp_result;
     double_vec *etmp;
     int_vec *etmp_int;
+
+    // For remeshing
+    tensor_t *stress_n;
+    double_vec *stressyy_n;
 
     // tensor_t *stress_old;
 

--- a/parameters.hpp
+++ b/parameters.hpp
@@ -626,6 +626,19 @@ struct SurfaceInfo {
 };
 
 //
+// Non-owning view over the flattened (CSR) node-support arrays.
+// idx[n] = start of node n's entries in arr; idx[n+1]-idx[n] = count.
+struct SupportView {
+    const int* arr;  // flat element IDs
+    const int* idx;  // CSR row-pointers (size nnode+1)
+
+    #pragma acc routine seq
+    int size(int inode) const { return idx[inode+1] - idx[inode]; }
+
+    #pragma acc routine seq
+    const int* patch(int inode) const { return arr + idx[inode]; }
+};
+
 // Structures for model variables
 //
 class MatProps;
@@ -700,6 +713,7 @@ struct Variables {
     int_vec2D *support;
     int_vec *support_arr;
     int_vec *support_idx;
+    SupportView sup;
     conn_t *neighbor; // neighboring elements for each element
     int_pair_vec *contact; // contact elements for each element
     double_vec *ctmp; // temporary array for contact elements

--- a/remeshing.cxx
+++ b/remeshing.cxx
@@ -2891,6 +2891,14 @@ void remesh(const Param &param, Variables &var, int bad_quality)
         (*var.surfinfo.edvacc_surf)[i] *= inv_volume;
     }
 
+    // convert volume_old to dv = volume/volume_old - 1 for NN interpolation.
+#ifndef ACC
+    #pragma omp parallel for default(none) shared(var)
+#endif
+    #pragma acc parallel loop gang vector async
+    for (int e = 0; e < var.nelem; ++e)
+        (*var.volume_old)[e] = (*var.volume)[e] / (*var.volume_old)[e] - 1.0;
+
     #pragma acc wait
 
     {
@@ -3049,13 +3057,13 @@ void remesh(const Param &param, Variables &var, int bad_quality)
         (*var.surfinfo.edvacc_surf)[i] *= surface_area[i];
     }
 
-    // TODO: using edvoldt and volume to get volume_old
+    // convert dv back to actual old volume using the new mesh volumes.
 #ifndef ACC
     #pragma omp parallel for default(none) shared(var)
 #endif
     #pragma acc parallel loop gang vector async
     for (int e=0; e<var.nelem; ++e)
-        (*var.volume_old)[e] = (*var.volume)[e];
+        (*var.volume_old)[e] = (*var.volume)[e] / (1.0 + (*var.volume_old)[e]);
 
     if(param.control.use_global_velocity_scaling)
         var.dt = compute_dt(param, var);

--- a/remeshing.cxx
+++ b/remeshing.cxx
@@ -2860,7 +2860,6 @@ void remesh(const Param &param, Variables &var, int bad_quality)
     int64_t time_tmp = get_nanoseconds();
 
     std::cout << "  Remeshing starts...\n";
-
 #ifdef ACC
     {
         size_t free_bytes, total_bytes;
@@ -2899,10 +2898,12 @@ void remesh(const Param &param, Variables &var, int bad_quality)
     for (int e = 0; e < var.nelem; ++e)
         (*var.volume_old)[e] = (*var.volume)[e] / (*var.volume_old)[e] - 1.0;
 
-    #pragma acc wait
-
     // superconvergen patch recovery for stress before remeshing
-    spr_elem_to_node(param, var);
+    var.stress_n = new tensor_t(var.nnode);
+    if (param.mat.is_plane_strain)
+        var.stressyy_n = new double_vec(var.nnode);
+
+    spr_elem_to_node(param, var, var.stress_n, var.stressyy_n);
 
     {
         // creating a "copy" of mesh pointer so that they are not deleted
@@ -3038,7 +3039,11 @@ void remesh(const Param &param, Variables &var, int bad_quality)
      * create_support(var);
      */
 
-    spr_node_to_elem(param, var);
+    spr_node_to_elem(param, var, var.stress, var.stressyy);
+
+    delete var.stress_n;
+    if (param.mat.is_plane_strain)
+        delete var.stressyy_n;
 
     compute_volume(*var.coord, *var.connectivity, *var.volume);
 

--- a/remeshing.cxx
+++ b/remeshing.cxx
@@ -2901,6 +2901,9 @@ void remesh(const Param &param, Variables &var, int bad_quality)
 
     #pragma acc wait
 
+    // superconvergen patch recovery for stress before remeshing
+    spr_elem_to_node(param, var);
+
     {
         // creating a "copy" of mesh pointer so that they are not deleted
         array_t old_coord;
@@ -3034,6 +3037,8 @@ void remesh(const Param &param, Variables &var, int bad_quality)
      * delete var.support;
      * create_support(var);
      */
+
+    spr_node_to_elem(param, var);
 
     compute_volume(*var.coord, *var.connectivity, *var.volume);
 

--- a/rheology.cxx
+++ b/rheology.cxx
@@ -875,7 +875,7 @@ void update_stress(const Param& param, Variables& var, tensor_t& stress,
                     for (int i=0; i<NSTR; ++i) s[i] = sp[i];
                     plstrain[e] += depls;
                     delta_plstrain[e] = depls;
-                    syy = spyy;
+                    if (var.mat->is_plane_strain) syy = spyy;
                 }
             }
             break;
@@ -970,7 +970,7 @@ void update_stress(const Param& param, Variables& var, tensor_t& stress,
                     for (int i=0; i<NSTR; ++i) s[i] = sp[i];
                     plstrain[e] += depls;
                     delta_plstrain[e] = depls;
-                    syy = spyy;
+                    if (var.mat->is_plane_strain) syy = spyy;
                 }
             }
             break;


### PR DESCRIPTION
## Summary

Implements **Superconvergent Patch Recovery (SPR)** for interpolating stress and strain fields across remeshing steps, replacing barycentric-only interpolation. SPR fits a linear polynomial to element centroid values within each node's patch using patch-relative coordinates for numerical stability, then evaluates it at the node position. Also, this change removes the viscosity-dependent scaling factor from NMD_stress() (and the control.mixed_stress_reference_viscosity parameter), so mixed-stress correction is now always applied at full strength.

Zienkiewicz, O. C., & Zhu, J. Z. (1992). The superconvergent patch recovery and a posteriori error estimates. Part 1: The recovery technique. International Journal for Numerical Methods in Engineering, 33(7), 1331–1364. https://doi.org/10.1002/nme.1620330702

Key changes:
- `geometry.cxx`: `spr_scalar_field()` with 2D (Cramer's rule) and 3D (Gaussian elimination with partial pivoting) solvers; degeneracy fallback to element-centroid average
- `mesh.hpp`, `mesh.cxx`, `nn-interpolation.cxx`: `SupportView` struct refactoring of support-patch indexing for GPU/SYCL readiness
- `remeshing.cxx`: SPR applied to stress; scratch tensor memory managed here
- `array2d.hpp`: `ComponentAccessor`/`ConstComponentAccessor` for 1-D strided views into 2-D arrays
- `rheology.cxx`: fix plane-strain `syy` update guard
- `brc-interpolation.cxx`: fix `volume_old` handling in barycentric remesh interpolation

## Comparison

First output at 10 kyr from `examples/rifting-2d.cfg`. Top: w/o SPR (spurious velocity spikes after remeshing). Bottom: with SPR (smooth stress recovery, no artifacts).

<img width="1329" height="827" alt="SPR-comparison" src="https://github.com/user-attachments/assets/f7a88689-ebb9-4c11-beb4-98e00123146b" />

## Test plan
- `has_superconvergent_patch_recovery` is provided in sub-branch [spr-switch](https://github.com/GeoFLAC/DynEarthSol/tree/spr-switch)  for test 
- [ ] `make ndims=2` — builds clean
- [ ] `make` (3D) — builds clean
- [ ] `rifting-2d.cfg` run through several remesh steps; nodal stress fields smooth in Paraview (no checkerboard)
- [ ] `core-complex.cfg` run through several remesh steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)
