### PR TITLE
ci: notify des-inputgen when input.cxx changes

### DIFF
--- a/.github/workflows/notify-inputgen.yml
+++ b/.github/workflows/notify-inputgen.yml
@@ -1,0 +1,27 @@
+name: Notify des-inputgen when input.cxx changes
+
+on:
+  push:
+    branches: [master, main]
+    paths:
+      - 'input.cxx'
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch event to des-inputgen
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.INPUTGEN_REPO_TOKEN }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: 'GeoFLAC',
+              repo: 'des-inputgen',
+              event_type: 'input-cxx-changed',
+              client_payload: {
+                sha: context.sha,
+                ref: context.ref,
+                commit_url: `https://github.com/GeoFLAC/DynEarthSol/commit/${context.sha}`,
+              },
+            });


### PR DESCRIPTION
## Summary
- Adds a workflow that fires on push to `master`/`main` when `input.cxx` is modified
- Sends a `repository_dispatch` event to `GeoFLAC/des-inputgen`, which automatically opens a maintenance issue prompting an update to `parameters.js`

## Setup required
The `INPUTGEN_REPO_TOKEN` secret must be set in this repository's Actions secrets — a fine-grained PAT with **Actions: Write** permission on `des-inputgen`.

## Test plan
- [ ] Merge this PR
- [ ] Make a trivial change to `input.cxx` and push to `master`
- [ ] Confirm an issue is opened in `GeoFLAC/des-inputgen`

🤖 Generated with [Claude Code](https://claude.com/claude-code)