### PR TITLE
Remeshing stress remap: free-surface pin, surface-relative reference, Deborah blend, untouched-element carry-through

### DIFF
--- a/bc.cxx
+++ b/bc.cxx
@@ -726,8 +726,7 @@ void apply_stress_bcs(const Param& param, const Variables& var, array_t& force)
                     p = 0;
                     if (zcenter < param.control.surf_base_level) {
                         // below sea level
-                        const double sea_water_density = 1030;
-                        p = sea_water_density * param.control.gravity * (param.control.surf_base_level - zcenter);
+                        p = param.bc.sea_water_density * param.control.gravity * (param.control.surf_base_level - zcenter);
                     }
                 }
                 else {

--- a/brc-interpolation.cxx
+++ b/brc-interpolation.cxx
@@ -373,8 +373,18 @@ void barycentric_node_interpolation(const Param& param, Variables &var,
     array_t *new_coord0 = new array_t(n);
     interpolate_field(brc, el, old_connectivity, *var.coord0, *new_coord0, n);
 
-    tensor_t *new_stress_n = new tensor_t(n);
-    interpolate_field(brc, el, old_connectivity, *var.stress_n, *new_stress_n, n);
+    // Null when remesh() switched the SPR chain off: nothing to carry across.
+    tensor_t *new_stress_n = nullptr;
+    if (var.stress_n) {
+        new_stress_n = new tensor_t(n);
+        interpolate_field(brc, el, old_connectivity, *var.stress_n, *new_stress_n, n);
+    }
+
+    double_vec *new_stressyy_n = nullptr;
+    if (var.stressyy_n) {
+        new_stressyy_n = new double_vec(n);
+        interpolate_field(brc, el, old_connectivity, *var.stressyy_n, *new_stressyy_n, n);
+    }
 
     delete var.temperature;
     var.temperature = new_temperature;
@@ -401,16 +411,8 @@ void barycentric_node_interpolation(const Param& param, Variables &var,
     delete var.stress_n;
     var.stress_n = new_stress_n;
 
-    if (param.mat.is_plane_strain) {
-        double_vec *new_stressyy_n = new double_vec(n);
-        interpolate_field(brc, el, old_connectivity,
-                          *var.stressyy_n, *new_stressyy_n, n);
-
-        #pragma acc wait
-
-        delete var.stressyy_n;
-        var.stressyy_n = new_stressyy_n;
-    }
+    delete var.stressyy_n;
+    var.stressyy_n = new_stressyy_n;
 
 #ifdef NPROF_DETAIL
     nvtxRangePop();

--- a/dynearthsol.cxx
+++ b/dynearthsol.cxx
@@ -36,6 +36,7 @@ namespace std { using ::snprintf; }
 void init_var(const Param& param, Variables& var)
 {
     var.time = 0;
+    var.last_remesh_time = 0;
     var.steps = 0;
     var.nremesh = 0;
     var.noutput = 0;
@@ -353,6 +354,15 @@ void restart(const Param& param, Variables& var)
     if (var.steps % param.mesh.quality_check_step_interval == 0 &&
         var.steps >= var.info_display_next_step)
         var.info_display_next_step = var.steps + param.sim.info_display_step_interval;
+
+    // Restore the last remesh time (sets the Deborah blend weight at the next
+    // remesh). Old checkpoints lack the field: fall back to var.time, which
+    // shortens the first post-restart interval and biases the blend toward the
+    // NN stress -- the conservative direction.
+    if (bin_chkpt.has_array("last_remesh_time"))
+        bin_chkpt.read_scalar(var.last_remesh_time, "last_remesh_time");
+    else
+        var.last_remesh_time = var.time;
 
     // Initializing field variables
     {

--- a/dynearthsol.cxx
+++ b/dynearthsol.cxx
@@ -349,20 +349,12 @@ void restart(const Param& param, Variables& var)
         bin_chkpt.read_scalar(var.dt, "dt");
         bin_chkpt.read_scalar(var.max_global_vel_mag, "max_global_vel_mag");
         bin_chkpt.read_scalar(var.reference_frame_time, "reference_frame_time");
+        bin_chkpt.read_scalar(var.last_remesh_time, "last_remesh_time");
     }
 
     if (var.steps % param.mesh.quality_check_step_interval == 0 &&
         var.steps >= var.info_display_next_step)
         var.info_display_next_step = var.steps + param.sim.info_display_step_interval;
-
-    // Restore the last remesh time (sets the Deborah blend weight at the next
-    // remesh). Old checkpoints lack the field: fall back to var.time, which
-    // shortens the first post-restart interval and biases the blend toward the
-    // NN stress -- the conservative direction.
-    if (bin_chkpt.has_array("last_remesh_time"))
-        bin_chkpt.read_scalar(var.last_remesh_time, "last_remesh_time");
-    else
-        var.last_remesh_time = var.time;
 
     // Initializing field variables
     {

--- a/examples/defaults.cfg
+++ b/examples/defaults.cfg
@@ -170,6 +170,7 @@ resolution = 30e3
 #elastic_foundation_constant = 1e11
 
 #has_water_loading = yes
+#sea_water_density = 1030
 
 ### Hydraulic boundary conditions
 #hbc_x0 = 0

--- a/examples/defaults.cfg
+++ b/examples/defaults.cfg
@@ -89,6 +89,8 @@ resolution = 30e3
 ### (smooths noise in weak/viscous regions) per element, by
 ### De = (viscosity / shear modulus) / (time since last remesh). The weight is a
 ### smoothstep (the cubic 3t^2 - 2t^3, flat at both ends) in log10(De) between them.
+### De = 1 is where the Maxwell time equals the remesh interval; the defaults put
+### the pure-SPR and pure-NN limits two decades apart, clear of that crossover.
 #remesh_deborah_min = 1     # De <= min: pure SPR
 #remesh_deborah_max = 100   # De >= max: pure NN
 

--- a/examples/defaults.cfg
+++ b/examples/defaults.cfg
@@ -87,7 +87,8 @@ resolution = 30e3
 ### Deborah-number-weighted stress remap: blend the NN-remapped stress (preserves
 ### elastic stress memory in cold/stiff regions) with the SPR-recovered stress
 ### (smooths noise in weak/viscous regions) per element, by
-### De = (viscosity / shear modulus) / (time since last remesh).
+### De = (viscosity / shear modulus) / (time since last remesh). The weight is a
+### smoothstep (the cubic 3t^2 - 2t^3, flat at both ends) in log10(De) between them.
 #remesh_deborah_min = 1     # De <= min: pure SPR
 #remesh_deborah_max = 100   # De >= max: pure NN
 

--- a/examples/defaults.cfg
+++ b/examples/defaults.cfg
@@ -84,6 +84,13 @@ resolution = 30e3
 #remeshing_option = 0
 #is_discarding_internal_segments = yes
 
+### Deborah-number-weighted stress remap: blend the NN-remapped stress (preserves
+### elastic stress memory in cold/stiff regions) with the SPR-recovered stress
+### (smooths noise in weak/viscous regions) per element, by
+### De = (viscosity / shear modulus) / (time since last remesh).
+#remesh_deborah_min = 1     # De <= min: pure SPR
+#remesh_deborah_max = 100   # De >= max: pure NN
+
 #mmg_debug = 0
 #mmg_verbose = 0
 #mmg_hmax_factor = 2.0

--- a/fields.cxx
+++ b/fields.cxx
@@ -67,12 +67,12 @@ void allocate_variables(const Param &param, Variables& var)
     var.ymass = new double_vec(n);
     var.edvoldt = new double_vec(e);
 
-    var.stress = new tensor_t(e, 0);
-    var.stressyy = new double_vec(e, 0);
     var.old_mean_stress = new double_vec(e, 0);
 
     {
         // these fields are reallocated during remeshing interpolation
+        var.stress = new tensor_t(e, 0);
+        var.stressyy = new double_vec(e, 0);
         var.volume_old = new double_vec(e); // for dv remeshing interpolation
         var.temperature = new double_vec(n);
         var.ppressure = new double_vec(n);
@@ -176,13 +176,9 @@ void reallocate_variables(const Param& param, Variables& var)
     delete var.strain_rate;
     var.strain_rate = new tensor_t(e, 0);
 
-    // var.stress is NOT reallocated here: the NN interpolation already swapped
-    // in a remapped copy sized to the new mesh, which spr_node_to_elem reads
-    // before overwriting with the SPR average.
-
-    // TODO: keep this reallocation because rheology always reads double& syy
-    delete var.stressyy;
-    var.stressyy = new double_vec(var.nelem);
+    // var.stress and var.stressyy are NOT reallocated here: the NN interpolation
+    // already swapped in remapped copies sized to the new mesh, which
+    // spr_node_to_elem reads before overwriting with the SPR average.
 
     if (param.control.has_hydraulic_diffusion) {
         delete var.old_mean_stress;

--- a/fields.cxx
+++ b/fields.cxx
@@ -176,8 +176,9 @@ void reallocate_variables(const Param& param, Variables& var)
     delete var.strain_rate;
     var.strain_rate = new tensor_t(e, 0);
 
-    delete var.stress;
-    var.stress = new tensor_t(e);
+    // var.stress is NOT reallocated here: the NN interpolation already swapped
+    // in a remapped copy sized to the new mesh, which spr_node_to_elem reads
+    // before overwriting with the SPR average.
 
     // TODO: keep this reallocation because rheology always reads double& syy
     delete var.stressyy;

--- a/geometry.cxx
+++ b/geometry.cxx
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cmath>
 #include <limits>
 #include <iostream>
@@ -626,6 +627,355 @@ static void spr_fused_fields(const Variables &var,
 #endif
 }
 
+void SurfaceTopo::build(const Param& param, const Variables& var)
+{
+    on = false;
+    atten = false;
+    x.clear();
+    z.clear();
+    heff.clear();
+    mg = ndg = 0;
+#ifdef THREED
+    mgy = 0;
+    gh.clear();
+#endif
+#ifndef THREED
+    // Source the top nodes from var.bnodes[iboundz1] (valid in the init, restart
+    // AND remesh flows -- surfinfo.top_nodes' x-sort is only refreshed at remesh).
+    // Sort a local copy by x: nodes move with the Lagrangian mesh between remeshes.
+    const int_vec& top = *var.bnodes[iboundz1];
+    const int ntop = top.size();
+    if (ntop < 2) return;
+    int_vec order(top);
+    std::sort(order.begin(), order.end(), [&](int a, int b) {
+        return (*var.coord)[a][0] < (*var.coord)[b][0];
+    });
+    x.resize(ntop);
+    z.resize(ntop);
+    for (int i = 0; i < ntop; ++i) {
+        x[i] = (*var.coord)[order[i]][0];
+        z[i] = (*var.coord)[order[i]][NDIMS-1];
+    }
+    on = true;
+
+    // Attenuation table: resample z_surf onto a uniform grid (Nyquist for the
+    // surface nodes, capped), take its DCT-I cosine series, and tabulate
+    //     h_eff(x_i, d_j) = sum_m w_m a_m e^{-k_m d_j} cos(k_m (x_i - x0))
+    // (w halves the end modes -- the DCT-I inverse convention). Cost ~ mg^2*ndg
+    // multiply-adds once per build; queries are O(1) bilinear lookups.
+    if (ntop < 3) return;                       // no meaningful profile: stay columnar
+    x0g = x.front();
+    Lg  = x.back() - x.front();
+    if (Lg <= 0.0) return;
+    int M = 2 * (ntop - 1) + 1;                 // >= Nyquist for the node spacing
+    if (M < 65)  M = 65;
+    if (M > 257) M = 257;
+    const int ND = 65;
+    double_vec s(M);
+    double hmax = 0.0;
+    for (int i = 0; i < M; ++i) {
+        const double q[NDIMS] = {x0g + Lg * i / (M - 1), 0.0};
+        s[i] = elev(q);
+        hmax = std::max(hmax, std::abs(s[i]));
+    }
+    // DCT-I forward: a_m = 2/(M-1) * sum''_i s_i cos(pi m i/(M-1))  (half end samples)
+    const double pn = M_PI / (M - 1);
+    double_vec a(M);
+    for (int m = 0; m < M; ++m) {
+        double sum = 0.5 * (s[0] + ((m % 2) ? -s[M-1] : s[M-1]));
+        for (int i = 1; i < M - 1; ++i) sum += s[i] * std::cos(pn * m * i);
+        a[m] = 2.0 * sum / (M - 1);
+    }
+    dmax = param.mesh.zlength + hmax;           // deepest element depth below any surface
+    mg = M;
+    ndg = ND;
+    heff.assign((size_t)M * ND, 0.0);
+    double_vec cmi((size_t)M * M);              // cos(pi m i/(M-1)) reused for every depth
+    for (int m = 0; m < M; ++m)
+        for (int i = 0; i < M; ++i)
+            cmi[(size_t)m * M + i] = std::cos(pn * m * i);
+    for (int j = 0; j < ND; ++j) {
+        const double u = double(j) / (ND - 1);
+        const double d = dmax * u * u;
+        for (int m = 0; m < M; ++m) {
+            const double w  = (m == 0 || m == M - 1) ? 0.5 : 1.0;
+            const double am = w * a[m] * std::exp(-(M_PI * m / Lg) * d);
+            if (std::abs(am) < 1e-30) continue;   // mode fully decayed at this depth
+            const double* c = &cmi[(size_t)m * M];
+            for (int i = 0; i < M; ++i)
+                heff[(size_t)i * ND + j] += am * c[i];
+        }
+    }
+    atten = true;
+#else  // THREED
+    // ----------------------------------------------------------------
+    // 3-D: rasterize the triangulated top boundary onto a uniform (x,y)
+    // grid, then tabulate the attenuated load via a separable 2-D DCT-I
+    // with kernel e^{-|k| d}, |k| = pi*sqrt((m/Lx)^2 + (n/Ly)^2). Same
+    // lifecycle as 2-D: derived data, rebuilt from the current mesh on
+    // every build.
+    // ----------------------------------------------------------------
+    const int_vec& top = *var.bnodes[iboundz1];
+    if (top.size() < 3) return;
+    const std::vector< std::pair<int,int> >& facets = *var.bfacets[iboundz1];
+    const int nfacet = facets.size();
+    if (nfacet < 1) return;
+
+    double xmin = std::numeric_limits<double>::max(), xmax = -xmin;
+    double ymin = xmin, ymax = -xmin;
+    for (std::size_t i = 0; i < top.size(); ++i) {
+        const double xi = (*var.coord)[top[i]][0];
+        const double yi = (*var.coord)[top[i]][1];
+        xmin = std::min(xmin, xi); xmax = std::max(xmax, xi);
+        ymin = std::min(ymin, yi); ymax = std::max(ymax, yi);
+    }
+    x0g = xmin; Lg  = xmax - xmin;
+    y0g = ymin; Lyg = ymax - ymin;
+    if (Lg <= 0.0 || Lyg <= 0.0) return;
+
+    // Grid count ~ Nyquist for the surface-node spacing (ntop ~ nside^2), capped:
+    // the DCT table cost scales as M^3 * ndg.
+    int M = 2 * (int)std::ceil(std::sqrt((double)top.size())) + 1;
+    if (M < 33) M = 33;
+    if (M > 97) M = 97;
+    mg = M; mgy = M;
+    const double dxg = Lg / (M - 1), dyg = Lyg / (M - 1);
+    const double qnan = std::numeric_limits<double>::quiet_NaN();
+    gh.assign((size_t)M * M, qnan);
+    for (int fi = 0; fi < nfacet; ++fi) {
+        const int e = facets[fi].first;
+        const int f = facets[fi].second;
+        double px[NODES_PER_FACET], py[NODES_PER_FACET], pz[NODES_PER_FACET];
+        for (int k = 0; k < NODES_PER_FACET; ++k) {
+            const int n = (*var.connectivity)[e][NODE_OF_FACET[f][k]];
+            px[k] = (*var.coord)[n][0];
+            py[k] = (*var.coord)[n][1];
+            pz[k] = (*var.coord)[n][2];
+        }
+        const double det = (px[1]-px[0])*(py[2]-py[0]) - (px[2]-px[0])*(py[1]-py[0]);
+        if (std::abs(det) < 1e-12 * dxg * dyg) continue;    // degenerate in xy projection
+        int i0 = (int)std::ceil ((std::min(px[0], std::min(px[1], px[2])) - x0g) / dxg - 1e-9);
+        int i1 = (int)std::floor((std::max(px[0], std::max(px[1], px[2])) - x0g) / dxg + 1e-9);
+        int j0 = (int)std::ceil ((std::min(py[0], std::min(py[1], py[2])) - y0g) / dyg - 1e-9);
+        int j1 = (int)std::floor((std::max(py[0], std::max(py[1], py[2])) - y0g) / dyg + 1e-9);
+        i0 = std::max(i0, 0); i1 = std::min(i1, M - 1);
+        j0 = std::max(j0, 0); j1 = std::min(j1, M - 1);
+        const double inv_det = 1.0 / det;
+        for (int gi = i0; gi <= i1; ++gi)
+            for (int gj = j0; gj <= j1; ++gj) {
+                const double qx = x0g + gi * dxg - px[0];
+                const double qy = y0g + gj * dyg - py[0];
+                const double l1 = (qx*(py[2]-py[0]) - qy*(px[2]-px[0])) * inv_det;
+                const double l2 = (qy*(px[1]-px[0]) - qx*(py[1]-py[0])) * inv_det;
+                const double l0 = 1.0 - l1 - l2;
+                if (l0 < -1e-6 || l1 < -1e-6 || l2 < -1e-6) continue;
+                gh[(size_t)gi * M + gj] = l0*pz[0] + l1*pz[1] + l2*pz[2];
+            }
+    }
+    // Fill grid points the rasterization missed (hull-edge roundoff): nearest valid
+    // value along each row, then along each column for fully-missed rows.
+    for (int gi = 0; gi < M; ++gi) {
+        double last = qnan;
+        for (int gj = 0; gj < M; ++gj) {
+            double& v = gh[(size_t)gi * M + gj];
+            if (v == v) last = v; else if (last == last) v = last;
+        }
+        last = qnan;
+        for (int gj = M - 1; gj >= 0; --gj) {
+            double& v = gh[(size_t)gi * M + gj];
+            if (v == v) last = v; else if (last == last) v = last;
+        }
+    }
+    for (int gj = 0; gj < M; ++gj) {
+        double last = qnan;
+        for (int gi = 0; gi < M; ++gi) {
+            double& v = gh[(size_t)gi * M + gj];
+            if (v == v) last = v; else if (last == last) v = last;
+        }
+        last = qnan;
+        for (int gi = M - 1; gi >= 0; --gi) {
+            double& v = gh[(size_t)gi * M + gj];
+            if (v == v) last = v; else if (last == last) v = last;
+        }
+    }
+    double hmax = 0.0;
+    for (std::size_t i = 0; i < gh.size(); ++i) {
+        if (gh[i] != gh[i]) { gh.clear(); return; }   // no surface data at all: stay off
+        hmax = std::max(hmax, std::abs(gh[i]));
+    }
+    on = true;
+
+    // --- separable 2-D DCT-I attenuation table h_eff(x_i, y_j, d_l) ---
+    // forward: A[m][n] = (2/(M-1))^2 sum''_i sum''_j gh[i][j] cos(pn m i) cos(pn n j)
+    // (sum'' = half-weight end samples; square grid so one cos table serves both axes)
+    const double pn = M_PI / (M - 1);
+    double_vec cmi((size_t)M * M);
+    for (int m = 0; m < M; ++m)
+        for (int i = 0; i < M; ++i)
+            cmi[(size_t)m * M + i] = std::cos(pn * m * i);
+    double_vec T((size_t)M * M, 0.0), A((size_t)M * M, 0.0);
+    for (int i = 0; i < M; ++i)
+        for (int n = 0; n < M; ++n) {
+            double s = 0.0;
+            for (int j = 0; j < M; ++j) {
+                const double w = (j == 0 || j == M - 1) ? 0.5 : 1.0;
+                s += w * gh[(size_t)i * M + j] * cmi[(size_t)n * M + j];
+            }
+            T[(size_t)i * M + n] = 2.0 * s / (M - 1);
+        }
+    for (int m = 0; m < M; ++m)
+        for (int n = 0; n < M; ++n) {
+            double s = 0.0;
+            for (int i = 0; i < M; ++i) {
+                const double w = (i == 0 || i == M - 1) ? 0.5 : 1.0;
+                s += w * T[(size_t)i * M + n] * cmi[(size_t)m * M + i];
+            }
+            A[(size_t)m * M + n] = 2.0 * s / (M - 1);
+        }
+    dmax = param.mesh.zlength + hmax;           // deepest element depth below any surface
+    const int ND = 65;
+    ndg = ND;
+    heff.assign((size_t)M * M * ND, 0.0);
+    double_vec B((size_t)M * M), U((size_t)M * M);
+    for (int l = 0; l < ND; ++l) {
+        const double u = double(l) / (ND - 1);
+        const double d = dmax * u * u;
+        for (int m = 0; m < M; ++m)
+            for (int n = 0; n < M; ++n) {
+                const double km = M_PI * m / Lg, kn = M_PI * n / Lyg;
+                const double wm = (m == 0 || m == M - 1) ? 0.5 : 1.0;
+                const double wn = (n == 0 || n == M - 1) ? 0.5 : 1.0;
+                B[(size_t)m * M + n] = wm * wn * A[(size_t)m * M + n]
+                                     * std::exp(-std::sqrt(km*km + kn*kn) * d);
+            }
+        // inverse, pass over n: U[m][j] = sum_n B[m][n] cos(pn n j)
+        for (int m = 0; m < M; ++m)
+            for (int j = 0; j < M; ++j) {
+                double s = 0.0;
+                for (int n = 0; n < M; ++n) {
+                    const double b = B[(size_t)m * M + n];
+                    if (std::abs(b) < 1e-30) continue;   // mode fully decayed at this depth
+                    s += b * cmi[(size_t)n * M + j];
+                }
+                U[(size_t)m * M + j] = s;
+            }
+        // inverse, pass over m into the table
+        for (int gi = 0; gi < M; ++gi)
+            for (int gj = 0; gj < M; ++gj) {
+                double s = 0.0;
+                for (int m = 0; m < M; ++m)
+                    s += U[(size_t)m * M + gj] * cmi[(size_t)m * M + gi];
+                heff[((size_t)gi * M + gj) * ND + l] = s;
+            }
+    }
+    atten = true;
+#endif
+}
+
+double SurfaceTopo::elev(const double* p) const
+{
+    if (!on) return 0.0;
+#ifndef THREED
+    const double xq = p[0];
+    if (xq <= x.front()) return z.front();
+    if (xq >= x.back())  return z.back();
+    const std::size_t i = std::upper_bound(x.begin(), x.end(), xq) - x.begin();
+    const double dx = x[i] - x[i-1];
+    if (dx <= 0.0) return z[i];   // coincident nodes (degenerate surface): no interpolation
+    return z[i-1] + (z[i] - z[i-1]) * (xq - x[i-1]) / dx;
+#else
+    double tx = (p[0] - x0g) / Lg * (mg - 1);
+    if (tx < 0.0) tx = 0.0;
+    if (tx > mg - 1) tx = mg - 1;
+    int i = (int)tx;
+    if (i > mg - 2) i = mg - 2;
+    const double fx = tx - i;
+    double ty = (p[1] - y0g) / Lyg * (mgy - 1);
+    if (ty < 0.0) ty = 0.0;
+    if (ty > mgy - 1) ty = mgy - 1;
+    int j = (int)ty;
+    if (j > mgy - 2) j = mgy - 2;
+    const double fy = ty - j;
+    const double* r0 = &gh[(size_t)i * mgy + j];
+    const double* r1 = r0 + mgy;
+    return (1.0 - fx) * ((1.0 - fy) * r0[0] + fy * r0[1])
+         + fx         * ((1.0 - fy) * r1[0] + fy * r1[1]);
+#endif
+}
+
+double SurfaceTopo::heff_at(const double* p, double d) const
+{
+    // 2-D: bilinear on (x, depth); 3-D: trilinear on (x, y, depth). Depth is sqrt-spaced.
+    double tx = (p[0] - x0g) / Lg * (mg - 1);
+    if (tx < 0.0) tx = 0.0;
+    if (tx > mg - 1) tx = mg - 1;
+    int i = (int)tx;
+    if (i > mg - 2) i = mg - 2;
+    const double fx = tx - i;
+    if (d < 0.0) d = 0.0;
+    if (d > dmax) d = dmax;
+    double tu = std::sqrt(d / dmax) * (ndg - 1);
+    int l = (int)tu;
+    if (l > ndg - 2) l = ndg - 2;
+    const double fu = tu - l;
+#ifndef THREED
+    const double* r0 = &heff[(size_t)i * ndg + l];
+    const double* r1 = r0 + ndg;
+    return (1.0 - fx) * ((1.0 - fu) * r0[0] + fu * r0[1])
+         + fx         * ((1.0 - fu) * r1[0] + fu * r1[1]);
+#else
+    double ty = (p[1] - y0g) / Lyg * (mgy - 1);
+    if (ty < 0.0) ty = 0.0;
+    if (ty > mgy - 1) ty = mgy - 1;
+    int j = (int)ty;
+    if (j > mgy - 2) j = mgy - 2;
+    const double fy = ty - j;
+    const double* r00 = &heff[((size_t)i * mgy + j) * ndg + l];
+    const double* r01 = r00 + ndg;
+    const double* r10 = r00 + (size_t)mgy * ndg;
+    const double* r11 = r10 + ndg;
+    const double v00 = (1.0 - fu) * r00[0] + fu * r00[1];
+    const double v01 = (1.0 - fu) * r01[0] + fu * r01[1];
+    const double v10 = (1.0 - fu) * r10[0] + fu * r10[1];
+    const double v11 = (1.0 - fu) * r11[0] + fu * r11[1];
+    return (1.0 - fx) * ((1.0 - fy) * v00 + fy * v01)
+         + fx         * ((1.0 - fy) * v10 + fy * v11);
+#endif
+}
+
+double SurfaceTopo::zeff(const double* p) const
+{
+    const double zq = p[NDIMS-1];
+    if (!on) return zq;                 // fixed-datum behavior, bit-exact
+    const double h = elev(p);
+    if (!atten) return zq - h;          // columnar (rigid-support end-member)
+    const double d = h - zq;            // depth below the LOCAL surface
+    if (d <= 0.0) return zq - h;        // at/above the surface: full load (kernel -> 1)
+    return zq - heff_at(p, d);
+}
+
+// Strided array_t rows are not contiguous doubles: copy to a local coordinate first.
+double SurfaceTopo::elev(ConstArrayAccessor p) const
+{
+    double c[NDIMS];
+    for (int d = 0; d < NDIMS; ++d) c[d] = p[d];
+    return elev(c);
+}
+
+double SurfaceTopo::zeff(ConstArrayAccessor p) const
+{
+    double c[NDIMS];
+    for (int d = 0; d < NDIMS; ++d) c[d] = p[d];
+    return zeff(c);
+}
+
+double SurfaceTopo::heff_at(ConstArrayAccessor p, double d) const
+{
+    double c[NDIMS];
+    for (int dd = 0; dd < NDIMS; ++dd) c[dd] = p[dd];
+    return heff_at(c, d);
+}
+
 void spr_elem_to_node(const Param &param, const Variables &var,
                       tensor_t *stress_n, double_vec *stressyy_n)
 {
@@ -646,19 +996,26 @@ void spr_elem_to_node(const Param &param, const Variables &var,
     // extrapolation error at boundary nodes. Cold surface ice (η≈visc_max)
     // has a Maxwell relaxation time of ~250 Myr, so even a tiny artifact
     // persists throughout the simulation.
+    //
+    // The centering reference is the lithostat below the current (old-mesh)
+    // surface; spr_node_to_elem restores with the same rule on the new mesh.
     // ----------------------------------------------------------------
+    SurfaceTopo topo;
+    topo.build(param, var);   // old mesh: coord/bnodes still pre-remesh here
 
 #ifndef ACC
-    #pragma omp parallel for default(none) shared(param, var)
+    #pragma omp parallel for default(none) shared(param, var, topo)
 #endif
-    #pragma acc parallel loop gang vector async    
+    #pragma acc parallel loop gang vector async
     for (int e = 0; e < var.nelem; ++e) {
         ConstConnAccessor conn = (*var.connectivity)[e];
-        double z = 0;
+        double c[NDIMS] = {0.0};
         for (int k = 0; k < NODES_PER_ELEM; ++k)
-            z += (*var.coord)[conn[k]][NDIMS-1];
-        z /= NODES_PER_ELEM;
-        double p_ref_old = ref_pressure(param, z);
+            for (int d = 0; d < NDIMS; ++d)
+                c[d] += (*var.coord)[conn[k]][d];
+        for (int d = 0; d < NDIMS; ++d)
+            c[d] /= NODES_PER_ELEM;
+        double p_ref_old = ref_pressure(param, topo.zeff(c));
         TensorAccessor s = (*var.stress)[e];
         // Shift diagonal components: add p_ref so stress becomes small deviatoric
         for (int d = 0; d < NDIMS; ++d) s[d] += p_ref_old;
@@ -714,16 +1071,21 @@ void spr_node_to_elem(const Param &param, const Variables &var,
 #ifdef NPROF_DETAIL
     nvtxRangePush(__FUNCTION__);
 #endif
+    // Surface-relative reference, mirror of spr_elem_to_node on the NEW-mesh
+    // surface (create_boundary_nodes already ran in the remesh flow).
+    SurfaceTopo topo;
+    topo.build(param, var);
+
     // Pin the free-surface nodal stress before averaging back to elements: the SPR
     // patch fit is one-sided at surface nodes, its least reliable spot, while the
     // free-surface condition is known exactly (total sigma_zz = 0, zero shear).
-    // In the pressure-centered variable sigma_zz = 0 maps to stress_n = +p_ref.
-    #pragma omp parallel for default(none) shared(param, var)
+    // In the pressure-centered variable sigma_zz = 0 maps to stress_n = +p_ref,
+    // and z - z_surf = 0 at a top node makes the pin exact, ref_pressure(0) = 0.
+    #pragma omp parallel for default(none) shared(param, var, topo)
     for (int i = 0; i < var.surfinfo.ntop; ++i) {
         int n = (*var.surfinfo.top_nodes)[i];
 
-        double z_node = (*var.coord)[n][NDIMS-1];
-        double p_ref_node = ref_pressure(param, z_node);
+        double p_ref_node = ref_pressure(param, topo.zeff((*var.coord)[n]));
 
         (*var.stress_n)[n][NDIMS-1] = p_ref_node;
         (*var.stress_n)[n][(NDIMS-1)*2] = 0.0;
@@ -775,18 +1137,20 @@ void spr_node_to_elem(const Param &param, const Variables &var,
 
     // Step C': Restore reference pressure at new element centroids.
     // The SPR operated on pressure-centered stress; add back p_ref at each
-    // new element's depth to recover the correct total stress.
+    // new element's depth (below the NEW surface) to recover the total stress.
 #ifndef ACC
-    #pragma omp parallel for default(none) shared(param, var, stress, stressyy)
+    #pragma omp parallel for default(none) shared(param, var, stress, stressyy, topo)
 #endif
     #pragma acc parallel loop gang vector async
     for (int e = 0; e < var.nelem; ++e) {
         ConstConnAccessor conn = (*var.connectivity)[e];
-        double z = 0;
+        double c[NDIMS] = {0.0};
         for (int k = 0; k < NODES_PER_ELEM; ++k)
-            z += (*var.coord)[conn[k]][NDIMS-1];
-        z /= NODES_PER_ELEM;
-        double p_ref = ref_pressure(param, z);
+            for (int d = 0; d < NDIMS; ++d)
+                c[d] += (*var.coord)[conn[k]][d];
+        for (int d = 0; d < NDIMS; ++d)
+            c[d] /= NODES_PER_ELEM;
+        double p_ref = ref_pressure(param, topo.zeff(c));
         TensorAccessor s = (*stress)[e];
         for (int d = 0; d < NDIMS; ++d) s[d] -= p_ref;
 

--- a/geometry.cxx
+++ b/geometry.cxx
@@ -663,19 +663,66 @@ void SurfaceTopo::build(const Param& param, const Variables& var)
     //     h_eff(x_i, d_j) = sum_m w_m a_m e^{-k_m d_j} cos(k_m (x_i - x0))
     // (w halves the end modes -- the DCT-I inverse convention). Cost ~ mg^2*ndg
     // multiply-adds once per build; queries are O(1) bilinear lookups.
+    //
+    // Grid count M: the DCT-I is evaluated directly (no FFT), so M carries no
+    // radix or power-of-two constraint -- it only trades surface resolution
+    // against the O(M^2 * ND) build cost, and the two bounds below are that
+    // trade, not properties of the transform:
+    //   NG_MIN -- floor for the bilinearly-queried grid. A surface with few nodes
+    //     needs no modes beyond its own Nyquist count, but the floor costs < 1 %
+    //     of the cap and keeps queries off a coarse staircase.
+    //   NG_MAX -- cost bound. At Nyquist a 10^4-node surface would ask for
+    //     M ~ 2*10^4, i.e. O(10^10) flops at every remesh. Truncating the series
+    //     there is benign at depth: a dropped mode m > M-1 carries
+    //     e^{-pi m d / Lg}, so it only survives in a boundary layer of order
+    //     Lg/(pi*M) below the surface, and at or above the surface (d <= 0)
+    //     zeff() bypasses the table for the exact profile, keeping the
+    //     free-surface pin exact. Aliasing is the part that is NOT benign --
+    //     point-sampling relief finer than the grid folds it onto low-k modes,
+    //     which never attenuate, so the h_eff error stops decaying with depth --
+    //     hence the cell average once the cap bites. Against a 4x-Nyquist
+    //     reference on a +-10 km sawtooth at ntop = 193 (M_nyquist 385, capped to
+    //     257) it removes a 0.4 m (13 kPa) floor below 10 km depth, and costs a
+    //     ~3x smoother h_eff for d under one grid spacing -- shallower than the
+    //     first element centroid, and d <= 0 does not use the table at all.
+    //     That floor is in the REFERENCE, not directly in the stress: an element
+    //     the remesh leaves unchanged cancels it either way, because Step C' of
+    //     spr_node_to_elem subtracts the reference it recorded rather than
+    //     re-evaluating it, so only remeshed elements see the difference.
     if (ntop < 3) return;                       // no meaningful profile: stay columnar
     x0g = x.front();
     Lg  = x.back() - x.front();
     if (Lg <= 0.0) return;
-    int M = 2 * (ntop - 1) + 1;                 // >= Nyquist for the node spacing
-    if (M < 65)  M = 65;
-    if (M > 257) M = 257;
+    const int NG_MIN = 65;                      // ~0.3 Mflop with ND below
+    const int NG_MAX = 257;                     // ~4.3 Mflop with ND below
+    // Depth rows, sqrt-spaced so they crowd the surface where the high-k modes
+    // die. Cost is only linear in ND, so this one is untuned -- cheap to raise.
     const int ND = 65;
+    int M = 2 * (ntop - 1) + 1;                 // >= Nyquist for the node spacing
+    const int M_nyquist = M;
+    if (M < NG_MIN) M = NG_MIN;
+    if (M > NG_MAX) M = NG_MAX;
     double_vec s(M);
     double hmax = 0.0;
+    // Cell-average only where the cap made the grid coarser than the nodes:
+    // at or above Nyquist there is nothing to alias, and point sampling keeps
+    // the reference field of every such mesh unchanged. Where it does average,
+    // hmax -- and so dmax, the table's depth extent -- follows the resampled
+    // profile rather than the node maximum.
+    const bool antialias = (M_nyquist > M);
+    const double dxg = Lg / (M - 1);
     for (int i = 0; i < M; ++i) {
-        const double q[NDIMS] = {x0g + Lg * i / (M - 1), 0.0};
-        s[i] = elev(q);
+        const double xi = x0g + Lg * i / (M - 1);
+        if (antialias) {
+            // The DCT-I samples include both endpoints, so the end cells are half
+            // as wide as the interior ones.
+            s[i] = elev_avg(std::max(xi - 0.5 * dxg, x0g),
+                            std::min(xi + 0.5 * dxg, x0g + Lg));
+        }
+        else {
+            const double q[NDIMS] = {xi, 0.0};
+            s[i] = elev(q);
+        }
         hmax = std::max(hmax, std::abs(s[i]));
     }
     // DCT-I forward: a_m = 2/(M-1) * sum''_i s_i cos(pi m i/(M-1))  (half end samples)
@@ -733,11 +780,20 @@ void SurfaceTopo::build(const Param& param, const Variables& var)
     y0g = ymin; Lyg = ymax - ymin;
     if (Lg <= 0.0 || Lyg <= 0.0) return;
 
-    // Grid count ~ Nyquist for the surface-node spacing (ntop ~ nside^2), capped:
-    // the DCT table cost scales as M^3 * ndg.
+    // Grid count ~ Nyquist for the surface-node spacing (ntop ~ nside^2), capped.
+    // Same trade as in 2-D above -- the separable DCT-I needs no particular M, the
+    // bounds are a cost window -- but here the table costs O(M^3 * ND), so the cap
+    // is much tighter: 97^3 * 65 ~ 6e7 multiply-adds per remesh (2-D: ~4e6). The
+    // caveat at the cap is also the same, minus the cure: a surface finer than the
+    // grid is point-sampled by the rasterization below, so its short-wavelength
+    // relief aliases onto low-k modes. The 2-D cell average has no cheap
+    // triangle-rasterizing analogue, so 3-D keeps point sampling; if this ever
+    // matters, accumulate area-weighted facet means per cell instead.
+    const int NG_MIN = 33;                      // ~2 Mflop with ND below
+    const int NG_MAX = 97;                      // ~6e7 flop with ND below
     int M = 2 * (int)std::ceil(std::sqrt((double)top.size())) + 1;
-    if (M < 33) M = 33;
-    if (M > 97) M = 97;
+    if (M < NG_MIN) M = NG_MIN;
+    if (M > NG_MAX) M = NG_MAX;
     mg = M; mgy = M;
     const double dxg = Lg / (M - 1), dyg = Lyg / (M - 1);
     const double qnan = std::numeric_limits<double>::quiet_NaN();
@@ -833,7 +889,7 @@ void SurfaceTopo::build(const Param& param, const Variables& var)
             A[(size_t)m * M + n] = 2.0 * s / (M - 1);
         }
     dmax = param.mesh.zlength + hmax;           // deepest element depth below any surface
-    const int ND = 65;
+    const int ND = 65;                          // depth rows, as in the 2-D branch
     ndg = ND;
     heff.assign((size_t)M * M * ND, 0.0);
     double_vec B((size_t)M * M), U((size_t)M * M);
@@ -902,6 +958,36 @@ double SurfaceTopo::elev(const double* p) const
          + fx         * ((1.0 - fy) * r1[0] + fy * r1[1]);
 #endif
 }
+
+#ifndef THREED
+double SurfaceTopo::elev_avg(double xa, double xb) const
+{
+    if (!on) return 0.0;
+    const double len = xb - xa;
+    if (len <= 0.0) {
+        const double q[NDIMS] = {xa, 0.0};
+        return elev(q);
+    }
+    // Trapezoid over every profile segment clipped to [xa, xb]: exact, because
+    // elev() is linear between surface nodes and clamped constant outside them.
+    double area = 0.0;
+    if (xa < x.front()) area += z.front() * (std::min(xb, x.front()) - xa);
+    if (xb > x.back())  area += z.back()  * (xb - std::max(xa, x.back()));
+    std::size_t k = std::upper_bound(x.begin(), x.end(), xa) - x.begin();
+    if (k == 0) k = 1;                        // segment (0,1) is the first one
+    for (; k < x.size() && x[k-1] < xb; ++k) {
+        const double xl = x[k-1], xr = x[k];
+        const double dx = xr - xl;
+        if (dx <= 0.0) continue;              // coincident nodes: zero-width segment
+        const double a = std::max(xa, xl), b = std::min(xb, xr);
+        if (b <= a) continue;
+        const double slope = (z[k] - z[k-1]) / dx;
+        area += 0.5 * ((z[k-1] + slope * (a - xl)) + (z[k-1] + slope * (b - xl)))
+                    * (b - a);
+    }
+    return area / len;
+}
+#endif
 
 double SurfaceTopo::heff_at(const double* p, double d) const
 {
@@ -1020,9 +1106,19 @@ void spr_elem_to_node(const Param &param, const Variables &var,
 #endif
         for (int e = 0; e < var.nelem; ++e) {
             const double t_maxwell = var.mat->visc(e) / var.mat->shearm(e);
+            // t: position within [De_min, De_max], linear in log10(De) because De
+            // spans decades and neither bound is a physical threshold -- only the
+            // decade between them is meaningful.
             double t = (std::log10(t_maxwell / dt_remesh) - lde0) / (lde1 - lde0);
             t = std::min(std::max(t, 0.0), 1.0);
-            (*var.spr_blend_weight)[e] = t * t * (3.0 - 2.0 * t);  // smoothstep
+            // smoothstep: the cubic 3t^2 - 2t^3, i.e. the Hermite interpolant of
+            // (0,0) and (1,1) with w'(0) = w'(1) = 0, so an element
+            // drifting across either bound between remeshes sees the weight change
+            // continuously in value AND rate. A linear ramp kinks at the bounds,
+            // switching remap operator abruptly for elements sitting on one; a
+            // steeper S-curve (e.g. quintic) would need a wider De window to keep
+            // the same mid-range sensitivity. Monotone, and w(t=1/2) = 1/2.
+            (*var.spr_blend_weight)[e] = t * t * (3.0 - 2.0 * t);
         }
     }
 

--- a/geometry.cxx
+++ b/geometry.cxx
@@ -708,12 +708,43 @@ void spr_elem_to_node(const Param &param, const Variables &var,
 #endif
 }
 
-void spr_node_to_elem(const Param &param, const Variables &var, 
+void spr_node_to_elem(const Param &param, const Variables &var,
                       tensor_t *stress, double_vec *stressyy)
 {
 #ifdef NPROF_DETAIL
     nvtxRangePush(__FUNCTION__);
 #endif
+    // Pin the free-surface nodal stress before averaging back to elements: the SPR
+    // patch fit is one-sided at surface nodes, its least reliable spot, while the
+    // free-surface condition is known exactly (total sigma_zz = 0, zero shear).
+    // In the pressure-centered variable sigma_zz = 0 maps to stress_n = +p_ref.
+    #pragma omp parallel for default(none) shared(param, var)
+    for (int i = 0; i < var.surfinfo.ntop; ++i) {
+        int n = (*var.surfinfo.top_nodes)[i];
+
+        double z_node = (*var.coord)[n][NDIMS-1];
+        double p_ref_node = ref_pressure(param, z_node);
+
+        (*var.stress_n)[n][NDIMS-1] = p_ref_node;
+        (*var.stress_n)[n][(NDIMS-1)*2] = 0.0;
+#ifdef THREED
+        (*var.stress_n)[n][5] = 0.0;
+#endif
+    }
+
+    // Snapshot the NN-remapped stress before the SPR average overwrites it. On
+    // entry *stress holds the NN-remapped copy (nn_interpolate_elem_fields),
+    // already pressure-centered on the old mesh, so the snapshot, the SPR average
+    // and the p_ref restore (Step C') all live in the same centered variable.
+    // Consumer: the surface fallback below.
+    tensor_t stress_nn(var.nelem);
+    for (int e = 0; e < var.nelem; ++e) {
+        ConstTensorAccessor s = (*stress)[e];
+        TensorAccessor s_nn = stress_nn[e];
+        for (int d = 0; d < NSTR; ++d)
+            s_nn[d] = s[d];
+    }
+
     // ----------------------------------------------------------------
     // Step C: Average SPR nodal stresses -> new element stresses.
     // ----------------------------------------------------------------
@@ -723,7 +754,24 @@ void spr_node_to_elem(const Param &param, const Variables &var,
 
     if (param.mat.is_plane_strain)
         average_nodal_to_elem(static_cast<const double*>(var.stressyy_n->data()), *var.connectivity,
-                                var.nelem, stressyy->data());
+                              var.nelem, stressyy->data());
+
+    // Fallback: where the SPR average left a surface element LESS compressive
+    // (spurious tension) than before the remesh, restore the pre-remesh stress.
+    // The measure is the mean stress (trace).
+    for (int i = 0; i < var.ntop_elems; ++i) {
+        int e = (*var.top_elems)[i];
+        TensorAccessor s = (*stress)[e];
+        ConstTensorAccessor s_nn = stress_nn[e];
+        double p = 0.0, p_spr = 0.0;
+        for (int d = 0; d < NDIMS; ++d) {
+            p_spr += s[d];
+            p += s_nn[d];
+        }
+        if (p < p_spr) {
+            for (int d = 0; d < NSTR; ++d) s[d] = s_nn[d];
+        }
+    }
 
     // Step C': Restore reference pressure at new element centroids.
     // The SPR operated on pressure-centered stress; add back p_ref at each

--- a/geometry.cxx
+++ b/geometry.cxx
@@ -1126,38 +1126,17 @@ double SurfaceTopo::heff_at(ConstArrayAccessor p, double d) const
     return heff_at(c, d);
 }
 
-void spr_elem_to_node(const Param &param, const Variables &var,
-                      tensor_t *stress_n, double_vec *stressyy_n)
+void compute_spr_blend_weight(const Param &param, const Variables &var)
 {
 #ifdef NPROF_DETAIL
     nvtxRangePush(__FUNCTION__);
 #endif
-    // ----------------------------------------------------------------
-    // Step A: SPR — recover smooth nodal stresses on the OLD mesh.
-    // Must happen before prepare_interpolation (reads old var.stress,
-    // *var.support, old_coord, old_connectivity — all still old here).
-    //
-    // Pressure-centering: subtract ref_pressure from each old element's
-    // diagonal stress components before SPR, so the polynomial fits the
-    // small deviatoric residual rather than the large lithostatic pressure.
-    // Without centering, independent polynomial fits for σxx and σzz on a
-    // one-sided surface-node patch differ by the amount of the actual
-    // deviatoric stress, but the large-pressure background amplifies any
-    // extrapolation error at boundary nodes. Cold surface ice (η≈visc_max)
-    // has a Maxwell relaxation time of ~250 Myr, so even a tiny artifact
-    // persists throughout the simulation.
-    //
-    // The centering reference is the lithostat below the current (old-mesh)
-    // surface; spr_node_to_elem restores with the same rule on the new mesh.
-    // ----------------------------------------------------------------
-    SurfaceTopo topo;
-    topo.build(param, var);   // old mesh: coord/bnodes still pre-remesh here
-
     // Deborah-number blend weight toward the NN-remapped stress: w = 1 keeps NN
     // (high De, elastic stress memory), w = 0 takes the SPR average (low De,
-    // smoothing). Evaluated on the OLD mesh; visc() reads the stress trace, so
-    // this must precede the pressure-centering below. The weight rides through
-    // the remesh with the other element fields and is consumed in spr_node_to_elem.
+    // smoothing). Evaluated on the OLD mesh, and BEFORE center_stress_to_ref:
+    // visc() reads the stress trace, so centering would change its answer. The
+    // weight rides through the remesh with the other element fields and is
+    // consumed in spr_node_to_elem.
     {
         // De is measured against the time the stress evolved since the last remesh.
         const double dt_remesh = std::max(var.time - var.last_remesh_time, var.dt);
@@ -1185,7 +1164,40 @@ void spr_elem_to_node(const Param &param, const Variables &var,
             (*var.spr_blend_weight)[e] = t * t * (3.0 - 2.0 * t);
         }
     }
+#ifdef NPROF_DETAIL
+    nvtxRangePop();
+#endif
+}
 
+
+void center_stress_to_ref(const Param &param, const Variables &var,
+                          const SurfaceTopo &topo)
+{
+#ifdef NPROF_DETAIL
+    nvtxRangePush(__FUNCTION__);
+#endif
+    // ----------------------------------------------------------------
+    // Reference the stress to the lithostat on the OLD mesh: add ref_pressure to
+    // each element's diagonal components, and record what was added.
+    //
+    // This serves the whole remap, not just the SPR fit that follows it:
+    //  - for the SPR fit, the polynomial then fits the small deviatoric residual
+    //    instead of the steep lithostatic background. Independent fits for σxx and
+    //    σzz on a one-sided surface-node patch differ by the deviatoric stress, and
+    //    a large pressure background amplifies any extrapolation error at boundary
+    //    nodes. Cold surface ice (η≈visc_max) has a Maxwell time of ~250 Myr, so
+    //    even a tiny artifact persists for the whole simulation.
+    //  - for the NN remap, which is the entire stress remap when the SPR chain is
+    //    off, it is what makes the copy depth-aware: a CHANGED element takes stress
+    //    from a source at another depth, and restore_stress_from_ref subtracting
+    //    p_ref at the DESTINATION centroid supplies the lithostat difference.
+    //    Without it the copy carries the source's lithostat and lands ~rho*g*dz
+    //    wrong.
+    //
+    // Must run before prepare_interpolation (reads old var.stress, *var.support,
+    // old_coord, old_connectivity — all still old here). Undone by
+    // restore_stress_from_ref on the new mesh.
+    // ----------------------------------------------------------------
 #ifndef ACC
     #pragma omp parallel for default(none) shared(param, var, topo)
 #endif
@@ -1207,9 +1219,28 @@ void spr_elem_to_node(const Param &param, const Variables &var,
             (*var.stressyy)[e] += p_ref_old;
 
         // Record the reference ADDED here so an unchanged element can subtract the
-        // identical value in Step C' (the new-mesh topo table differs globally).
+        // identical value in restore_stress_from_ref (the new-mesh topo table
+        // differs globally).
         (*var.spr_p_ref_old)[e] = p_ref_old;
     }
+
+    #pragma acc wait
+
+#ifdef NPROF_DETAIL
+    nvtxRangePop();
+#endif
+}
+
+
+void spr_elem_to_node(const Param &param, const Variables &var,
+                      tensor_t *stress_n, double_vec *stressyy_n)
+{
+#ifdef NPROF_DETAIL
+    nvtxRangePush(__FUNCTION__);
+#endif
+    // Step A: recover smooth NODAL stresses from the element-centroid stresses of
+    // the OLD mesh, which center_stress_to_ref has already referenced to the
+    // lithostat. Same old-mesh preconditions as that function.
 
     // dynamic registration of all fields involved in SPR
     const double* in_ptrs[MAX_SPR_FIELDS];
@@ -1253,15 +1284,15 @@ void spr_elem_to_node(const Param &param, const Variables &var,
 }
 
 void spr_node_to_elem(const Param &param, const Variables &var,
+                      const SurfaceTopo &topo,
                       tensor_t *stress, double_vec *stressyy)
 {
 #ifdef NPROF_DETAIL
     nvtxRangePush(__FUNCTION__);
 #endif
-    // Surface-relative reference, mirror of spr_elem_to_node on the NEW-mesh
-    // surface (create_boundary_nodes already ran in the remesh flow).
-    SurfaceTopo topo;
-    topo.build(param, var);
+    // Step B: nodal SPR stresses -> new element stresses, then reconcile with the
+    // NN remap. topo is the NEW-mesh surface, built by the caller and shared with
+    // restore_stress_from_ref (rasterising it twice would cost ~14 ms in 3-D).
 
     // Pin the top-boundary nodal stress before averaging back to elements: the SPR
     // patch fit is one-sided at surface nodes, its least reliable spot, while the
@@ -1379,7 +1410,24 @@ void spr_node_to_elem(const Param &param, const Variables &var,
         }
     }
 
-    // Step C': Restore reference pressure at new element centroids.
+#ifdef NPROF_DETAIL
+    nvtxRangePop();
+#endif
+}
+
+
+void restore_stress_from_ref(const Param &param, const Variables &var,
+                             const SurfaceTopo &topo,
+                             tensor_t *stress, double_vec *stressyy)
+{
+#ifdef NPROF_DETAIL
+    nvtxRangePush(__FUNCTION__);
+#endif
+    // Undo center_stress_to_ref on the NEW mesh, whatever produced the centered
+    // stress that arrives here: the Deborah blend of NN and SPR, or -- when the SPR
+    // chain is off -- the NN remap alone. Runs last either way.
+    //
+    // Restore reference pressure at new element centroids.
     // The SPR operated on pressure-centered stress; add back p_ref at each
     // new element's depth (below the NEW surface) to recover the total stress.
 #ifndef ACC

--- a/geometry.cxx
+++ b/geometry.cxx
@@ -1003,6 +1003,29 @@ void spr_elem_to_node(const Param &param, const Variables &var,
     SurfaceTopo topo;
     topo.build(param, var);   // old mesh: coord/bnodes still pre-remesh here
 
+    // Deborah-number blend weight toward the NN-remapped stress: w = 1 keeps NN
+    // (high De, elastic stress memory), w = 0 takes the SPR average (low De,
+    // smoothing). Evaluated on the OLD mesh; visc() reads the stress trace, so
+    // this must precede the pressure-centering below. The weight rides through
+    // the remesh with the other element fields and is consumed in spr_node_to_elem.
+    {
+        // De is measured against the time the stress evolved since the last remesh.
+        const double dt_remesh = std::max(var.time - var.last_remesh_time, var.dt);
+        const double lde0 = std::log10(param.mesh.remesh_deborah_min);
+        const double lde1 = std::log10(param.mesh.remesh_deborah_max);
+        // Host loop: visc()/shearm() read the host-side MatProps.
+        #pragma acc wait
+#ifndef ACC
+        #pragma omp parallel for default(none) shared(param, var, dt_remesh, lde0, lde1)
+#endif
+        for (int e = 0; e < var.nelem; ++e) {
+            const double t_maxwell = var.mat->visc(e) / var.mat->shearm(e);
+            double t = (std::log10(t_maxwell / dt_remesh) - lde0) / (lde1 - lde0);
+            t = std::min(std::max(t, 0.0), 1.0);
+            (*var.spr_blend_weight)[e] = t * t * (3.0 - 2.0 * t);  // smoothstep
+        }
+    }
+
 #ifndef ACC
     #pragma omp parallel for default(none) shared(param, var, topo)
 #endif
@@ -1022,6 +1045,7 @@ void spr_elem_to_node(const Param &param, const Variables &var,
 
         if (param.mat.is_plane_strain)
             (*var.stressyy)[e] += p_ref_old;
+
     }
 
     // dynamic registration of all fields involved in SPR
@@ -1101,7 +1125,7 @@ void spr_node_to_elem(const Param &param, const Variables &var,
     // entry *stress holds the NN-remapped copy (nn_interpolate_elem_fields),
     // already pressure-centered on the old mesh, so the snapshot, the SPR average
     // and the p_ref restore (Step C') all live in the same centered variable.
-    // Consumer: the surface fallback below.
+    // Consumers: the surface fallback and the Deborah blend below.
     tensor_t stress_nn(var.nelem);
     double_vec stressyy_nn(param.mat.is_plane_strain ? var.nelem : 0);
 #ifndef ACC
@@ -1155,6 +1179,24 @@ void spr_node_to_elem(const Param &param, const Variables &var,
             for (int d = 0; d < NSTR; ++d) s[d] = s_nn[d];
             if (param.mat.is_plane_strain) (*stressyy)[e] = stressyy_nn[e];
         }
+    }
+
+    // Deborah blend of NN (w: elastic stress memory) vs the SPR average
+    // (1 - w: smooths element-scale noise in low-viscosity regions). Runs after
+    // the surface fallback: where the fallback restored the NN stress the blend
+    // is a no-op, never making a surface element less compressive again.
+#ifndef ACC
+    #pragma omp parallel for default(none) shared(param, var, stress, stressyy, stress_nn, stressyy_nn)
+#endif
+    #pragma acc parallel loop gang vector async
+    for (int e = 0; e < var.nelem; ++e) {
+        const double w = (*var.spr_blend_weight)[e];
+        TensorAccessor s = (*stress)[e];
+        ConstTensorAccessor s_nn = stress_nn[e];
+        for (int d = 0; d < NSTR; ++d)
+            s[d] = w * s_nn[d] + (1.0 - w) * s[d];
+        if (param.mat.is_plane_strain)
+            (*stressyy)[e] = w * stressyy_nn[e] + (1.0 - w) * (*stressyy)[e];
     }
 
     // Step C': Restore reference pressure at new element centroids.

--- a/geometry.cxx
+++ b/geometry.cxx
@@ -711,6 +711,8 @@ void SurfaceTopo::build(const Param& param, const Variables& var)
     // profile rather than the node maximum.
     const bool antialias = (M_nyquist > M);
     const double dxg = Lg / (M - 1);
+    #pragma omp parallel for default(none) \
+        shared(s, M, dxg, antialias) reduction(max:hmax)
     for (int i = 0; i < M; ++i) {
         const double xi = x0g + Lg * i / (M - 1);
         if (antialias) {
@@ -725,32 +727,64 @@ void SurfaceTopo::build(const Param& param, const Variables& var)
         }
         hmax = std::max(hmax, std::abs(s[i]));
     }
-    // DCT-I forward: a_m = 2/(M-1) * sum''_i s_i cos(pi m i/(M-1))  (half end samples)
-    const double pn = M_PI / (M - 1);
-    double_vec a(M);
-    for (int m = 0; m < M; ++m) {
-        double sum = 0.5 * (s[0] + ((m % 2) ? -s[M-1] : s[M-1]));
-        for (int i = 1; i < M - 1; ++i) sum += s[i] * std::cos(pn * m * i);
-        a[m] = 2.0 * sum / (M - 1);
-    }
     dmax = param.mesh.zlength + hmax;           // deepest element depth below any surface
     mg = M;
     ndg = ND;
     heff.assign((size_t)M * ND, 0.0);
-    double_vec cmi((size_t)M * M);              // cos(pi m i/(M-1)) reused for every depth
-    for (int m = 0; m < M; ++m)
-        for (int i = 0; i < M; ++i)
-            cmi[(size_t)m * M + i] = std::cos(pn * m * i);
-    for (int j = 0; j < ND; ++j) {
-        const double u = double(j) / (ND - 1);
-        const double d = dmax * u * u;
+    const double pn = M_PI / (M - 1);
+    double_vec a(M);
+    // cos(pi m i/(M-1)) for every (point, mode), stored point-major: the table below
+    // walks the modes of one point, and the cosines are not symmetric to the last
+    // bit ((pn*m)*i vs (pn*i)*m), so the layout has to match the traversal rather
+    // than transposing the indices at the read.
+    double_vec cmiT((size_t)M * M);
+    double_vec am((size_t)M * ND);              // mode amplitude at each depth
+    // Threaded per point: a point owns a contiguous row of the table, and the sum
+    // over modes keeps serial order, so the table is bit-identical to a serial build
+    // at the default opt=2. Only there: opt=3 adds -ffast-math, which lets the
+    // compiler reassociate that sum, and this traversal then lands ~3 ulp from the
+    // serial one. Same reason there is no `#ifndef ACC` as in the 3-D branch.
+    // Only locals are listed: members (heff, dmax, Lg, ...) reach the region through
+    // `this`, which default(none) does not police, so naming them would not check
+    // anything.
+    #pragma omp parallel default(none) \
+        shared(s, a, am, cmiT, M, ND, pn)
+    {
+        // DCT-I forward: a_m = 2/(M-1) * sum''_i s_i cos(pi m i/(M-1))  (half ends)
+        #pragma omp for
         for (int m = 0; m < M; ++m) {
-            const double w  = (m == 0 || m == M - 1) ? 0.5 : 1.0;
-            const double am = w * a[m] * std::exp(-(M_PI * m / Lg) * d);
-            if (std::abs(am) < 1e-30) continue;   // mode fully decayed at this depth
-            const double* c = &cmi[(size_t)m * M];
-            for (int i = 0; i < M; ++i)
-                heff[(size_t)i * ND + j] += am * c[i];
+            double sum = 0.5 * (s[0] + ((m % 2) ? -s[M-1] : s[M-1]));
+            for (int i = 1; i < M - 1; ++i)
+                sum += s[i] * std::cos(pn * m * i);
+            a[m] = 2.0 * sum / (M - 1);
+        }
+        #pragma omp for
+        for (int i = 0; i < M; ++i) {
+            for (int m = 0; m < M; ++m)
+                cmiT[(size_t)i * M + m] = std::cos(pn * m * i);
+        }
+        // e^{-k_m d_j}, folded together with the DCT-I end weights
+        #pragma omp for
+        for (int m = 0; m < M; ++m) {
+            const double w = (m == 0 || m == M - 1) ? 0.5 : 1.0;
+            for (int j = 0; j < ND; ++j) {
+                const double u = double(j) / (ND - 1);
+                const double d = dmax * u * u;
+                am[(size_t)m * ND + j] = w * a[m] * std::exp(-(M_PI * m / Lg) * d);
+            }
+        }
+        #pragma omp for
+        for (int i = 0; i < M; ++i) {
+            double* row = &heff[(size_t)i * ND];
+            const double* crow = &cmiT[(size_t)i * M];
+            for (int m = 0; m < M; ++m) {
+                const double c = crow[m];
+                const double* amr = &am[(size_t)m * ND];
+                for (int j = 0; j < ND; ++j) {
+                    if (std::abs(amr[j]) < 1e-30) continue;  // mode decayed at this depth
+                    row[j] += amr[j] * c;
+                }
+            }
         }
     }
     atten = true;
@@ -798,6 +832,9 @@ void SurfaceTopo::build(const Param& param, const Variables& var)
     const double dxg = Lg / (M - 1), dyg = Lyg / (M - 1);
     const double qnan = std::numeric_limits<double>::quiet_NaN();
     gh.assign((size_t)M * M, qnan);
+    // Facets sharing an edge can both cover a grid point, since the barycentric test
+    // carries a tolerance, so the value left there is whichever facet wrote it last:
+    // an order-dependent result, and the reason this rasterization stays serial.
     for (int fi = 0; fi < nfacet; ++fi) {
         const int e = facets[fi].first;
         const int f = facets[fi].second;
@@ -817,7 +854,7 @@ void SurfaceTopo::build(const Param& param, const Variables& var)
         i0 = std::max(i0, 0); i1 = std::min(i1, M - 1);
         j0 = std::max(j0, 0); j1 = std::min(j1, M - 1);
         const double inv_det = 1.0 / det;
-        for (int gi = i0; gi <= i1; ++gi)
+        for (int gi = i0; gi <= i1; ++gi) {
             for (int gj = j0; gj <= j1; ++gj) {
                 const double qx = x0g + gi * dxg - px[0];
                 const double qy = y0g + gj * dyg - py[0];
@@ -827,6 +864,7 @@ void SurfaceTopo::build(const Param& param, const Variables& var)
                 if (l0 < -1e-6 || l1 < -1e-6 || l2 < -1e-6) continue;
                 gh[(size_t)gi * M + gj] = l0*pz[0] + l1*pz[1] + l2*pz[2];
             }
+        }
     }
     // Fill grid points the rasterization missed (hull-edge roundoff): nearest valid
     // value along each row, then along each column for fully-missed rows.
@@ -864,66 +902,92 @@ void SurfaceTopo::build(const Param& param, const Variables& var)
     // --- separable 2-D DCT-I attenuation table h_eff(x_i, y_j, d_l) ---
     // forward: A[m][n] = (2/(M-1))^2 sum''_i sum''_j gh[i][j] cos(pn m i) cos(pn n j)
     // (sum'' = half-weight end samples; square grid so one cos table serves both axes)
+    // Then, at each tabulated depth, attenuate every mode by e^{-|k| d} and run the
+    // inverse back to (x, y) as two cosine passes: over n into U, then over m into
+    // the table. Cost is O(M^3) for the forward pair, O(M^3 * ND) for the inverse.
+    //
+    // Threaded as one region: each loop splits the axis that owns its output and the
+    // inner sums keep serial order, so the table is bit-identical to a serial build.
+    // No `#ifndef ACC` -- that guard belongs where a paired `acc parallel loop`
+    // takes over on the device, and this is host-only STL called from serial code.
     const double pn = M_PI / (M - 1);
-    double_vec cmi((size_t)M * M);
-    for (int m = 0; m < M; ++m)
-        for (int i = 0; i < M; ++i)
-            cmi[(size_t)m * M + i] = std::cos(pn * m * i);
-    double_vec T((size_t)M * M, 0.0), A((size_t)M * M, 0.0);
-    for (int i = 0; i < M; ++i)
-        for (int n = 0; n < M; ++n) {
-            double s = 0.0;
-            for (int j = 0; j < M; ++j) {
-                const double w = (j == 0 || j == M - 1) ? 0.5 : 1.0;
-                s += w * gh[(size_t)i * M + j] * cmi[(size_t)n * M + j];
-            }
-            T[(size_t)i * M + n] = 2.0 * s / (M - 1);
-        }
-    for (int m = 0; m < M; ++m)
-        for (int n = 0; n < M; ++n) {
-            double s = 0.0;
-            for (int i = 0; i < M; ++i) {
-                const double w = (i == 0 || i == M - 1) ? 0.5 : 1.0;
-                s += w * T[(size_t)i * M + n] * cmi[(size_t)m * M + i];
-            }
-            A[(size_t)m * M + n] = 2.0 * s / (M - 1);
-        }
     dmax = param.mesh.zlength + hmax;           // deepest element depth below any surface
     const int ND = 65;                          // depth rows, as in the 2-D branch
     ndg = ND;
+    double_vec cmi((size_t)M * M);
+    double_vec T((size_t)M * M, 0.0), A((size_t)M * M, 0.0);
     heff.assign((size_t)M * M * ND, 0.0);
-    double_vec B((size_t)M * M), U((size_t)M * M);
-    for (int l = 0; l < ND; ++l) {
-        const double u = double(l) / (ND - 1);
-        const double d = dmax * u * u;
-        for (int m = 0; m < M; ++m)
+    #pragma omp parallel default(none) \
+        shared(cmi, T, A, M, ND, pn)
+    {
+        #pragma omp for
+        for (int m = 0; m < M; ++m) {
+            for (int i = 0; i < M; ++i)
+                cmi[(size_t)m * M + i] = std::cos(pn * m * i);
+        }
+        #pragma omp for
+        for (int i = 0; i < M; ++i) {
             for (int n = 0; n < M; ++n) {
-                const double km = M_PI * m / Lg, kn = M_PI * n / Lyg;
-                const double wm = (m == 0 || m == M - 1) ? 0.5 : 1.0;
-                const double wn = (n == 0 || n == M - 1) ? 0.5 : 1.0;
-                B[(size_t)m * M + n] = wm * wn * A[(size_t)m * M + n]
-                                     * std::exp(-std::sqrt(km*km + kn*kn) * d);
-            }
-        // inverse, pass over n: U[m][j] = sum_n B[m][n] cos(pn n j)
-        for (int m = 0; m < M; ++m)
-            for (int j = 0; j < M; ++j) {
                 double s = 0.0;
-                for (int n = 0; n < M; ++n) {
-                    const double b = B[(size_t)m * M + n];
-                    if (std::abs(b) < 1e-30) continue;   // mode fully decayed at this depth
-                    s += b * cmi[(size_t)n * M + j];
+                for (int j = 0; j < M; ++j) {
+                    const double w = (j == 0 || j == M - 1) ? 0.5 : 1.0;
+                    s += w * gh[(size_t)i * M + j] * cmi[(size_t)n * M + j];
                 }
-                U[(size_t)m * M + j] = s;
+                T[(size_t)i * M + n] = 2.0 * s / (M - 1);
             }
-        // inverse, pass over m into the table
-        for (int gi = 0; gi < M; ++gi)
-            for (int gj = 0; gj < M; ++gj) {
+        }
+        #pragma omp for
+        for (int m = 0; m < M; ++m) {
+            for (int n = 0; n < M; ++n) {
                 double s = 0.0;
-                for (int m = 0; m < M; ++m)
-                    s += U[(size_t)m * M + gj] * cmi[(size_t)m * M + gi];
-                heff[((size_t)gi * M + gj) * ND + l] = s;
+                for (int i = 0; i < M; ++i) {
+                    const double w = (i == 0 || i == M - 1) ? 0.5 : 1.0;
+                    s += w * T[(size_t)i * M + n] * cmi[(size_t)m * M + i];
+                }
+                A[(size_t)m * M + n] = 2.0 * s / (M - 1);
             }
-    }
+        }
+        // The depths share nothing once A is built, so each is done start to finish
+        // by one thread -- hence a B/U scratch pair per thread, declared here and
+        // built once on entry. dynamic: the pass over n skips modes that have already
+        // decayed, so the deeper the tabulated depth the cheaper it is.
+        double_vec B((size_t)M * M), U((size_t)M * M);
+        #pragma omp for schedule(dynamic)
+        for (int l = 0; l < ND; ++l) {
+            const double u = double(l) / (ND - 1);
+            const double d = dmax * u * u;
+            for (int m = 0; m < M; ++m) {
+                for (int n = 0; n < M; ++n) {
+                    const double km = M_PI * m / Lg, kn = M_PI * n / Lyg;
+                    const double wm = (m == 0 || m == M - 1) ? 0.5 : 1.0;
+                    const double wn = (n == 0 || n == M - 1) ? 0.5 : 1.0;
+                    B[(size_t)m * M + n] = wm * wn * A[(size_t)m * M + n]
+                                         * std::exp(-std::sqrt(km*km + kn*kn) * d);
+                }
+            }
+            // inverse, pass over n: U[m][j] = sum_n B[m][n] cos(pn n j)
+            for (int m = 0; m < M; ++m) {
+                for (int j = 0; j < M; ++j) {
+                    double s = 0.0;
+                    for (int n = 0; n < M; ++n) {
+                        const double b = B[(size_t)m * M + n];
+                        if (std::abs(b) < 1e-30) continue;   // mode fully decayed at this depth
+                        s += b * cmi[(size_t)n * M + j];
+                    }
+                    U[(size_t)m * M + j] = s;
+                }
+            }
+            // inverse, pass over m into the table
+            for (int gi = 0; gi < M; ++gi) {
+                for (int gj = 0; gj < M; ++gj) {
+                    double s = 0.0;
+                    for (int m = 0; m < M; ++m)
+                        s += U[(size_t)m * M + gj] * cmi[(size_t)m * M + gi];
+                    heff[((size_t)gi * M + gj) * ND + l] = s;
+                }
+            }
+        }
+    }   // end of the single parallel region
     atten = true;
 #endif
 }

--- a/geometry.cxx
+++ b/geometry.cxx
@@ -1103,8 +1103,9 @@ void spr_node_to_elem(const Param &param, const Variables &var,
     // and the p_ref restore (Step C') all live in the same centered variable.
     // Consumer: the surface fallback below.
     tensor_t stress_nn(var.nelem);
+    double_vec stressyy_nn(param.mat.is_plane_strain ? var.nelem : 0);
 #ifndef ACC
-    #pragma omp parallel for default(none) shared(var, stress, stress_nn)
+    #pragma omp parallel for default(none) shared(param, var, stress, stressyy, stress_nn, stressyy_nn)
 #endif
     #pragma acc parallel loop gang vector async
     for (int e = 0; e < var.nelem; ++e) {
@@ -1112,10 +1113,14 @@ void spr_node_to_elem(const Param &param, const Variables &var,
         TensorAccessor s_nn = stress_nn[e];
         for (int d = 0; d < NSTR; ++d)
             s_nn[d] = s[d];
+        if (param.mat.is_plane_strain)
+            stressyy_nn[e] = (*stressyy)[e];
     }
 
     // ----------------------------------------------------------------
     // Step C: Average SPR nodal stresses -> new element stresses.
+    // In plane strain the out-of-plane sigma_yy is part of the mean stress and
+    // enters the compressiveness test below, so it is averaged here too.
     // ----------------------------------------------------------------
     for (int d = 0; d < NSTR; ++d)
         average_nodal_to_elem(var.stress_n->component_const(d), *var.connectivity,
@@ -1127,9 +1132,10 @@ void spr_node_to_elem(const Param &param, const Variables &var,
 
     // Fallback: where the SPR average left a surface element LESS compressive
     // (spurious tension) than before the remesh, restore the pre-remesh stress.
-    // The measure is the mean stress (trace).
+    // The measure is the mean stress (trace); sigma_yy is reverted atomically
+    // with the in-plane tensor so the element is never left in a mixed state.
 #ifndef ACC
-    #pragma omp parallel for default(none) shared(var, stress, stress_nn)
+    #pragma omp parallel for default(none) shared(param, var, stress, stressyy, stress_nn, stressyy_nn)
 #endif
     #pragma acc parallel loop gang vector async
     for (int i = 0; i < var.ntop_elems; ++i) {
@@ -1141,8 +1147,13 @@ void spr_node_to_elem(const Param &param, const Variables &var,
             p_spr += s[d];
             p += s_nn[d];
         }
+        if (param.mat.is_plane_strain) {
+            p_spr += (*stressyy)[e];
+            p += stressyy_nn[e];
+        }
         if (p < p_spr) {
             for (int d = 0; d < NSTR; ++d) s[d] = s_nn[d];
+            if (param.mat.is_plane_strain) (*stressyy)[e] = stressyy_nn[e];
         }
     }
 

--- a/geometry.cxx
+++ b/geometry.cxx
@@ -1046,6 +1046,9 @@ void spr_elem_to_node(const Param &param, const Variables &var,
         if (param.mat.is_plane_strain)
             (*var.stressyy)[e] += p_ref_old;
 
+        // Record the reference ADDED here so an unchanged element can subtract the
+        // identical value in Step C' (the new-mesh topo table differs globally).
+        (*var.spr_p_ref_old)[e] = p_ref_old;
     }
 
     // dynamic registration of all fields involved in SPR
@@ -1125,7 +1128,8 @@ void spr_node_to_elem(const Param &param, const Variables &var,
     // entry *stress holds the NN-remapped copy (nn_interpolate_elem_fields),
     // already pressure-centered on the old mesh, so the snapshot, the SPR average
     // and the p_ref restore (Step C') all live in the same centered variable.
-    // Consumers: the surface fallback and the Deborah blend below.
+    // Consumers: the surface fallback, the Deborah blend and the untouched-element
+    // carry-through below.
     tensor_t stress_nn(var.nelem);
     double_vec stressyy_nn(param.mat.is_plane_strain ? var.nelem : 0);
 #ifndef ACC
@@ -1181,22 +1185,33 @@ void spr_node_to_elem(const Param &param, const Variables &var,
         }
     }
 
-    // Deborah blend of NN (w: elastic stress memory) vs the SPR average
-    // (1 - w: smooths element-scale noise in low-viscosity regions). Runs after
-    // the surface fallback: where the fallback restored the NN stress the blend
-    // is a no-op, never making a surface element less compressive again.
+    // Untouched elements (STRICTLY is_changed == 0: -1 = ACM-failed nearest-copy
+    // is NOT an identity map) keep the pre-remesh stress verbatim (bit-exact), the
+    // same treatment every other element field gets from inject_field; the remaining
+    // elements take the Deborah blend of NN (w: elastic stress memory) vs the SPR
+    // average (1 - w: smooths element-scale noise in low-viscosity regions).
+    // Runs after the surface fallback: where the fallback restored the NN stress
+    // the blend is a no-op, never making a surface element less compressive again.
 #ifndef ACC
     #pragma omp parallel for default(none) shared(param, var, stress, stressyy, stress_nn, stressyy_nn)
 #endif
     #pragma acc parallel loop gang vector async
     for (int e = 0; e < var.nelem; ++e) {
-        const double w = (*var.spr_blend_weight)[e];
         TensorAccessor s = (*stress)[e];
         ConstTensorAccessor s_nn = stress_nn[e];
-        for (int d = 0; d < NSTR; ++d)
-            s[d] = w * s_nn[d] + (1.0 - w) * s[d];
-        if (param.mat.is_plane_strain)
-            (*stressyy)[e] = w * stressyy_nn[e] + (1.0 - w) * (*stressyy)[e];
+        if ((*var.remesh_is_changed)[e] == 0) {
+            for (int d = 0; d < NSTR; ++d)
+                s[d] = s_nn[d];
+            if (param.mat.is_plane_strain)
+                (*stressyy)[e] = stressyy_nn[e];
+        }
+        else {
+            const double w = (*var.spr_blend_weight)[e];
+            for (int d = 0; d < NSTR; ++d)
+                s[d] = w * s_nn[d] + (1.0 - w) * s[d];
+            if (param.mat.is_plane_strain)
+                (*stressyy)[e] = w * stressyy_nn[e] + (1.0 - w) * (*stressyy)[e];
+        }
     }
 
     // Step C': Restore reference pressure at new element centroids.
@@ -1207,14 +1222,21 @@ void spr_node_to_elem(const Param &param, const Variables &var,
 #endif
     #pragma acc parallel loop gang vector async
     for (int e = 0; e < var.nelem; ++e) {
-        ConstConnAccessor conn = (*var.connectivity)[e];
-        double c[NDIMS] = {0.0};
-        for (int k = 0; k < NODES_PER_ELEM; ++k)
+        double p_ref;
+        if ((*var.remesh_is_changed)[e] == 0) {
+            // Untouched element: subtract exactly what spr_elem_to_node added, so
+            // the round trip is a bit-exact no-op (the new topo table differs).
+            p_ref = (*var.spr_p_ref_old)[e];
+        } else {
+            ConstConnAccessor conn = (*var.connectivity)[e];
+            double c[NDIMS] = {0.0};
+            for (int k = 0; k < NODES_PER_ELEM; ++k)
+                for (int d = 0; d < NDIMS; ++d)
+                    c[d] += (*var.coord)[conn[k]][d];
             for (int d = 0; d < NDIMS; ++d)
-                c[d] += (*var.coord)[conn[k]][d];
-        for (int d = 0; d < NDIMS; ++d)
-            c[d] /= NODES_PER_ELEM;
-        double p_ref = ref_pressure(param, topo.zeff(c));
+                c[d] /= NODES_PER_ELEM;
+            p_ref = ref_pressure(param, topo.zeff(c));
+        }
         TensorAccessor s = (*stress)[e];
         for (int d = 0; d < NDIMS; ++d) s[d] -= p_ref;
 

--- a/geometry.cxx
+++ b/geometry.cxx
@@ -1103,21 +1103,26 @@ void spr_node_to_elem(const Param &param, const Variables &var,
     SurfaceTopo topo;
     topo.build(param, var);
 
-    // Pin the free-surface nodal stress before averaging back to elements: the SPR
+    // Pin the top-boundary nodal stress before averaging back to elements: the SPR
     // patch fit is one-sided at surface nodes, its least reliable spot, while the
-    // free-surface condition is known exactly (total sigma_zz = 0, zero shear).
-    // In the pressure-centered variable sigma_zz = 0 maps to stress_n = +p_ref,
-    // and z - z_surf = 0 at a top node makes the pin exact, ref_pressure(0) = 0.
+    // traction there is known exactly -- sigma.n = -p_water n, mirroring the load
+    // apply_stress_bcs puts on this boundary. Centered that is p_ref - p_water,
+    // with p_ref exact because z_eff = 0 at a top node.
+    const double sea_level = param.control.surf_base_level;
+    const double rho_w_g = param.bc.has_water_loading
+                         ? param.bc.sea_water_density * param.control.gravity : 0.0;
 #ifndef ACC
-    #pragma omp parallel for default(none) shared(param, var, topo)
+    #pragma omp parallel for default(none) shared(param, var, topo, sea_level, rho_w_g)
 #endif
     #pragma acc parallel loop gang vector async
     for (int i = 0; i < var.surfinfo.ntop; ++i) {
         int n = (*var.surfinfo.top_nodes)[i];
+        double z = (*var.coord)[n][NDIMS-1];
+        double p_water = (z < sea_level) ? rho_w_g * (sea_level - z) : 0.0;
 
         double p_ref_node = ref_pressure(param, topo.zeff((*var.coord)[n]));
 
-        (*var.stress_n)[n][NDIMS-1] = p_ref_node;
+        (*var.stress_n)[n][NDIMS-1] = p_ref_node - p_water;
         (*var.stress_n)[n][(NDIMS-1)*2] = 0.0;
 #ifdef THREED
         (*var.stress_n)[n][5] = 0.0;

--- a/geometry.cxx
+++ b/geometry.cxx
@@ -1081,7 +1081,10 @@ void spr_node_to_elem(const Param &param, const Variables &var,
     // free-surface condition is known exactly (total sigma_zz = 0, zero shear).
     // In the pressure-centered variable sigma_zz = 0 maps to stress_n = +p_ref,
     // and z - z_surf = 0 at a top node makes the pin exact, ref_pressure(0) = 0.
+#ifndef ACC
     #pragma omp parallel for default(none) shared(param, var, topo)
+#endif
+    #pragma acc parallel loop gang vector async
     for (int i = 0; i < var.surfinfo.ntop; ++i) {
         int n = (*var.surfinfo.top_nodes)[i];
 
@@ -1100,6 +1103,10 @@ void spr_node_to_elem(const Param &param, const Variables &var,
     // and the p_ref restore (Step C') all live in the same centered variable.
     // Consumer: the surface fallback below.
     tensor_t stress_nn(var.nelem);
+#ifndef ACC
+    #pragma omp parallel for default(none) shared(var, stress, stress_nn)
+#endif
+    #pragma acc parallel loop gang vector async
     for (int e = 0; e < var.nelem; ++e) {
         ConstTensorAccessor s = (*stress)[e];
         TensorAccessor s_nn = stress_nn[e];
@@ -1121,6 +1128,10 @@ void spr_node_to_elem(const Param &param, const Variables &var,
     // Fallback: where the SPR average left a surface element LESS compressive
     // (spurious tension) than before the remesh, restore the pre-remesh stress.
     // The measure is the mean stress (trace).
+#ifndef ACC
+    #pragma omp parallel for default(none) shared(var, stress, stress_nn)
+#endif
+    #pragma acc parallel loop gang vector async
     for (int i = 0; i < var.ntop_elems; ++i) {
         int e = (*var.top_elems)[i];
         TensorAccessor s = (*stress)[e];

--- a/geometry.hpp
+++ b/geometry.hpp
@@ -57,6 +57,12 @@ struct SurfaceTopo {
     double elev(ConstArrayAccessor p) const;
     double zeff(ConstArrayAccessor p) const;
     double heff_at(ConstArrayAccessor p, double d) const;
+#ifndef THREED
+    // Mean z_surf over [xa, xb], exact for the piecewise-linear profile. build()
+    // resamples with this instead of elev() when the DCT grid is coarser than the
+    // surface nodes, so unresolved relief is averaged rather than aliased.
+    double elev_avg(double xa, double xb) const;
+#endif
 };
 
 void spr_elem_to_node(const Param& param, const Variables& var,

--- a/geometry.hpp
+++ b/geometry.hpp
@@ -65,11 +65,33 @@ struct SurfaceTopo {
 #endif
 };
 
+// The remesh stress remap, in call order. center_/restore_ are the reference
+// round trip and always run; the spr_* pair is the recovery and is skipped when
+// the rheology has no viscous component (then the remap is the NN interpolation
+// plus the round trip, which is what an infinite Maxwell time asks for).
+//
+// Two orderings the compiler cannot enforce:
+//  1. compute_spr_blend_weight BEFORE center_stress_to_ref -- visc() reads the
+//     stress trace, so centering changes the weight it would produce.
+//  2. restore_stress_from_ref LAST -- it undoes the centering for whatever
+//     produced the final centered stress (the blend, or the NN remap alone).
+// Each takes the SurfaceTopo of its own mesh, built once by the caller: old mesh
+// for the weight/centering pair, new mesh for the recovery/restore pair.
+void compute_spr_blend_weight(const Param& param, const Variables& var);
+
+void center_stress_to_ref(const Param& param, const Variables& var,
+                          const SurfaceTopo& topo);
+
 void spr_elem_to_node(const Param& param, const Variables& var,
                       tensor_t* stress_n, double_vec* stressyy_n);
 
 void spr_node_to_elem(const Param& param, const Variables& var,
+                      const SurfaceTopo& topo,
                       tensor_t* stress, double_vec* stressyy);
+
+void restore_stress_from_ref(const Param& param, const Variables& var,
+                             const SurfaceTopo& topo,
+                             tensor_t* stress, double_vec* stressyy);
 
 double compute_dt(const Param& param, Variables& var);
 

--- a/geometry.hpp
+++ b/geometry.hpp
@@ -20,6 +20,45 @@ void compute_edvoldt(const Variables &var, double_vec &dvoldt,
 void NMD_stress(const Variables &var, tensor_t& stress, double_vec &dp_nd,
                 double_vec &etmp);
 
+// Surface-relative reference pressure for SPR remeshing: ref_pressure is evaluated
+// at the effective depth below the CURRENT surface instead of the fixed datum z = 0,
+//     zeff(x,z) = z - h_eff(x,d),   h_eff = sum_m w_m a_m e^{-k_m d},
+// where {a_m} is the DCT-I cosine series of the surface elevation z_surf(x)
+// (k_m = pi*m/L) and d is the depth below the local surface. e^{-k d} is the
+// mean-stress kernel of a harmonic load on an elastic half-space: the k = 0 mode
+// (uniform shift) never attenuates, and d <= 0 keeps the full h(x) so the
+// free-surface pin at ref_pressure(0) = 0 stays exact. The 3-D build rasterizes the
+// top boundary onto a uniform (x,y) grid and uses a separable 2-D DCT-I with
+// kernel e^{-|k| d}, |k| = pi*sqrt((m/Lx)^2 + (n/Ly)^2).
+// No persistent state: consumers build local instances from the current mesh, so
+// remeshing and restart need no extra plumbing. When inactive (no top nodes),
+// elev() returns 0.0 and zeff() returns z -- fixed-datum behavior, bit-exact.
+struct SurfaceTopo {
+    bool on = false;
+    bool atten = false;           // attenuation table below is filled
+    double_vec x, z;              // 2-D: top-boundary node coordinates, sorted by x
+    // h_eff table: 2-D on (x_i, d_j) [i*ndg + j]; 3-D on (x_i, y_j, d_l)
+    // [(i*mgy + j)*ndg + l]. x, y uniform; depth sqrt-spaced d = dmax*(l/(ndg-1))^2
+    // (fine near the surface, where the high-k modes die).
+    int mg = 0, ndg = 0;
+    double x0g = 0.0, Lg = 0.0, dmax = 0.0;
+    double_vec heff;
+#ifdef THREED
+    int mgy = 0;
+    double y0g = 0.0, Lyg = 0.0;
+    double_vec gh;                // 3-D: rasterized surface elevation grid [i*mgy + j]
+#endif
+    void build(const Param& param, const Variables& var);
+    // p is the full coordinate: double[NDIMS] or an array_t row (accessor overloads).
+    // The 2-D/3-D branch is compile-time, so call sites are dimension-agnostic.
+    double elev(const double* p) const;             // z_surf at p; 0.0 when !on
+    double zeff(const double* p) const;             // reference-depth coordinate
+    double heff_at(const double* p, double d) const;  // attenuation-table lookup
+    double elev(ConstArrayAccessor p) const;
+    double zeff(ConstArrayAccessor p) const;
+    double heff_at(ConstArrayAccessor p, double d) const;
+};
+
 void spr_elem_to_node(const Param& param, const Variables& var,
                       tensor_t* stress_n, double_vec* stressyy_n);
 

--- a/input.cxx
+++ b/input.cxx
@@ -244,7 +244,11 @@ static void declare_parameters(po::options_description &cfg,
          "stress is purely the SPR recovery.")
 
         ("mesh.remesh_deborah_max", po::value<double>(&p.mesh.remesh_deborah_max)->default_value(1e2),
-         "De at or above which the remeshed stress is purely the NN-remapped stress.")
+         "De at or above which the remeshed stress is purely the NN-remapped stress. "
+         "The default puts the two limits two decades apart, which keeps them clear of "
+         "the De = 1 crossover while remesh intervals themselves vary by a factor of a "
+         "few between events; widen it to blend more of the domain, narrow it to make "
+         "the switch sharper. The window width is otherwise untuned.")
 
         ("mesh.is_discarding_internal_segments", po::value<bool>(&p.mesh.is_discarding_internal_segments)->default_value(true),
          "Discarding internal segments after initial mesh is created? "

--- a/input.cxx
+++ b/input.cxx
@@ -433,6 +433,10 @@ static void declare_parameters(po::options_description &cfg,
         ("bc.has_water_loading", po::value<bool>(&p.bc.has_water_loading)->default_value(true),
          "Applying water loading for top boundary that is below sea level?")
 
+        ("bc.sea_water_density", po::value<double>(&p.bc.sea_water_density)->default_value(1030),
+         "Density of the loading water (in kg/m^3). Used for the top-boundary "
+         "water load and for the free-surface stress pin that must match it.")
+
          // pore pressure boundary condition
         ("bc.hbc_x0", po::value<int>(&p.bc.hbc_x0)->default_value(0),
          "Type of boundary condition for the left/western side"

--- a/input.cxx
+++ b/input.cxx
@@ -236,7 +236,8 @@ static void declare_parameters(po::options_description &cfg,
         ("mesh.remesh_deborah_min", po::value<double>(&p.mesh.remesh_deborah_min)->default_value(1e0),
          "During remeshing the element stress is a Deborah-number-weighted blend of "
          "the NN-remapped stress and the SPR recovery, De = Maxwell time / time since "
-         "the last remesh, smoothstep in log10(De): high-De (cold, effectively "
+         "the last remesh. The weight is a smoothstep -- the cubic 3t^2 - 2t^3, flat "
+         "at both ends -- in log10(De): high-De (cold, effectively "
          "elastic) elements keep the NN stress, preserving elastic stress memory; "
          "low-De (weak, viscous) elements take the SPR average, which suppresses "
          "element-scale noise. This sets the De at or below which the remeshed "

--- a/input.cxx
+++ b/input.cxx
@@ -233,6 +233,18 @@ static void declare_parameters(po::options_description &cfg,
          "12: flatten x0 when using fixed bottom boundary.\n"
          "13: move all bottom, left, and right nodes to initial dimensions.\n")
 
+        ("mesh.remesh_deborah_min", po::value<double>(&p.mesh.remesh_deborah_min)->default_value(1e0),
+         "During remeshing the element stress is a Deborah-number-weighted blend of "
+         "the NN-remapped stress and the SPR recovery, De = Maxwell time / time since "
+         "the last remesh, smoothstep in log10(De): high-De (cold, effectively "
+         "elastic) elements keep the NN stress, preserving elastic stress memory; "
+         "low-De (weak, viscous) elements take the SPR average, which suppresses "
+         "element-scale noise. This sets the De at or below which the remeshed "
+         "stress is purely the SPR recovery.")
+
+        ("mesh.remesh_deborah_max", po::value<double>(&p.mesh.remesh_deborah_max)->default_value(1e2),
+         "De at or above which the remeshed stress is purely the NN-remapped stress.")
+
         ("mesh.is_discarding_internal_segments", po::value<bool>(&p.mesh.is_discarding_internal_segments)->default_value(true),
          "Discarding internal segments after initial mesh is created? "
          "Using it when remeshing process can modify segments (e.g. remeshing_option=11).")
@@ -1113,6 +1125,12 @@ static void validate_parameters(const po::variables_map &vm, Param &p)
 
     if (p.mesh.smallest_size > p.mesh.largest_size) {
         std::cerr << "Error: mesh.smallest_size is greater than mesh.largest_size.\n";
+        std::exit(1);
+    }
+
+    if (p.mesh.remesh_deborah_min <= 0 ||
+        p.mesh.remesh_deborah_min >= p.mesh.remesh_deborah_max) {
+        std::cerr << "Error: mesh.remesh_deborah_min must be positive and less than mesh.remesh_deborah_max.\n";
         std::exit(1);
     }
 

--- a/nn-interpolation.cxx
+++ b/nn-interpolation.cxx
@@ -604,9 +604,13 @@ namespace {
             inject_field(idx, is_changed, idx_changed, elems_vec, ratios_vec, *var.stressyy, *new_stressyy, e);
 
             // Deborah-blend weight (computed on the old mesh in spr_elem_to_node):
-            // ride it through the remesh so spr_node_to_elem can blend per new element.
-            double_vec *new_blend_w = new double_vec(e);
-            inject_field(idx, is_changed, idx_changed, elems_vec, ratios_vec, *var.spr_blend_weight, *new_blend_w, e);
+            // ride it through the remesh so spr_node_to_elem can blend per new
+            // element. Null when remesh() switched the SPR chain off.
+            double_vec *new_blend_w = nullptr;
+            if (var.spr_blend_weight) {
+                new_blend_w = new double_vec(e);
+                inject_field(idx, is_changed, idx_changed, elems_vec, ratios_vec, *var.spr_blend_weight, *new_blend_w, e);
+            }
 
             // Untouched-stress carry-through: ride the centering reference through
             // the remesh (verbatim for unchanged elements); is_changed here IS

--- a/nn-interpolation.cxx
+++ b/nn-interpolation.cxx
@@ -608,6 +608,11 @@ namespace {
             double_vec *new_blend_w = new double_vec(e);
             inject_field(idx, is_changed, idx_changed, elems_vec, ratios_vec, *var.spr_blend_weight, *new_blend_w, e);
 
+            // Untouched-stress carry-through: ride the centering reference through
+            // the remesh (verbatim for unchanged elements); is_changed here IS
+            // var.remesh_is_changed, which spr_node_to_elem consumes.
+            double_vec *new_p_ref_old = new double_vec(e);
+            inject_field(idx, is_changed, idx_changed, elems_vec, ratios_vec, *var.spr_p_ref_old, *new_p_ref_old, e);
 
             delete var.radiogenic_source;
             var.radiogenic_source = new_radiogenic_source;
@@ -631,6 +636,9 @@ namespace {
 
             delete var.spr_blend_weight;
             var.spr_blend_weight = new_blend_w;
+
+            delete var.spr_p_ref_old;
+            var.spr_p_ref_old = new_p_ref_old;
 
             // b = new tensor_t(e);
             // inject_field(idx, is_changed, elems_vec, ratios_vec, *var.stress_old, *b);
@@ -665,8 +673,14 @@ void nearest_neighbor_interpolation(const Param& param, Variables &var,
         }
 
         int_vec idx(nqueries); // nearest element
-        int_vec is_changed(nqueries); // is the element changed during remeshing?
         int_vec idx_changed(nqueries);
+
+        // Is the element changed during remeshing? The element pass fills
+        // var.remesh_is_changed (allocated by remesh(), read by spr_node_to_elem
+        // to keep the stress of unchanged elements verbatim); the surface pass
+        // uses a local.
+        int_vec is_changed_surf(is_surface ? nqueries : 0);
+        int_vec &is_changed = is_surface ? is_changed_surf : *var.remesh_is_changed;
 
         nn_t elems_vec;
         ratio_t ratios_vec;

--- a/nn-interpolation.cxx
+++ b/nn-interpolation.cxx
@@ -584,6 +584,11 @@ namespace {
             double_vec *new_volume_old = new double_vec(e);
             inject_field(idx, is_changed, idx_changed, elems_vec, ratios_vec, *var.volume_old, *new_volume_old, e);
 
+            // NN-remap the element stress alongside the other element fields;
+            // spr_node_to_elem still owns the final stress on the new mesh.
+            tensor_t *new_stress = new tensor_t(e);
+            inject_field(idx, is_changed, idx_changed, elems_vec, ratios_vec, *var.stress, *new_stress, e);
+
             delete var.plstrain;
             var.plstrain = new_plstrain;
 
@@ -606,6 +611,9 @@ namespace {
 
             delete var.volume_old;
             var.volume_old = new_volume_old;
+
+            delete var.stress;
+            var.stress = new_stress;
 
             // b = new tensor_t(e);
             // inject_field(idx, is_changed, elems_vec, ratios_vec, *var.stress_old, *b);

--- a/nn-interpolation.cxx
+++ b/nn-interpolation.cxx
@@ -584,11 +584,6 @@ namespace {
             double_vec *new_volume_old = new double_vec(e);
             inject_field(idx, is_changed, idx_changed, elems_vec, ratios_vec, *var.volume_old, *new_volume_old, e);
 
-            // NN-remap the element stress alongside the other element fields;
-            // spr_node_to_elem still owns the final stress on the new mesh.
-            tensor_t *new_stress = new tensor_t(e);
-            inject_field(idx, is_changed, idx_changed, elems_vec, ratios_vec, *var.stress, *new_stress, e);
-
             delete var.plstrain;
             var.plstrain = new_plstrain;
 
@@ -599,6 +594,11 @@ namespace {
             var.strain = new_strain;
 
             #pragma acc wait
+
+            // NN-remap the element stress alongside the other element fields;
+            // spr_node_to_elem still owns the final stress on the new mesh.
+            tensor_t *new_stress = new tensor_t(e);
+            inject_field(idx, is_changed, idx_changed, elems_vec, ratios_vec, *var.stress, *new_stress, e);
 
             delete var.radiogenic_source;
             var.radiogenic_source = new_radiogenic_source;
@@ -611,6 +611,8 @@ namespace {
 
             delete var.volume_old;
             var.volume_old = new_volume_old;
+
+            #pragma acc wait
 
             delete var.stress;
             var.stress = new_stress;

--- a/nn-interpolation.cxx
+++ b/nn-interpolation.cxx
@@ -603,6 +603,12 @@ namespace {
             double_vec *new_stressyy = new double_vec(e);
             inject_field(idx, is_changed, idx_changed, elems_vec, ratios_vec, *var.stressyy, *new_stressyy, e);
 
+            // Deborah-blend weight (computed on the old mesh in spr_elem_to_node):
+            // ride it through the remesh so spr_node_to_elem can blend per new element.
+            double_vec *new_blend_w = new double_vec(e);
+            inject_field(idx, is_changed, idx_changed, elems_vec, ratios_vec, *var.spr_blend_weight, *new_blend_w, e);
+
+
             delete var.radiogenic_source;
             var.radiogenic_source = new_radiogenic_source;
 
@@ -622,6 +628,9 @@ namespace {
 
             delete var.stressyy;
             var.stressyy = new_stressyy;
+
+            delete var.spr_blend_weight;
+            var.spr_blend_weight = new_blend_w;
 
             // b = new tensor_t(e);
             // inject_field(idx, is_changed, elems_vec, ratios_vec, *var.stress_old, *b);

--- a/nn-interpolation.cxx
+++ b/nn-interpolation.cxx
@@ -600,6 +600,9 @@ namespace {
             tensor_t *new_stress = new tensor_t(e);
             inject_field(idx, is_changed, idx_changed, elems_vec, ratios_vec, *var.stress, *new_stress, e);
 
+            double_vec *new_stressyy = new double_vec(e);
+            inject_field(idx, is_changed, idx_changed, elems_vec, ratios_vec, *var.stressyy, *new_stressyy, e);
+
             delete var.radiogenic_source;
             var.radiogenic_source = new_radiogenic_source;
 
@@ -616,6 +619,9 @@ namespace {
 
             delete var.stress;
             var.stress = new_stress;
+
+            delete var.stressyy;
+            var.stressyy = new_stressyy;
 
             // b = new tensor_t(e);
             // inject_field(idx, is_changed, elems_vec, ratios_vec, *var.stress_old, *b);

--- a/output.cxx
+++ b/output.cxx
@@ -377,6 +377,8 @@ void Output::write_checkpoint(const Param& param, const Variables& var)
     bin.write_scalar(var.max_global_vel_mag, "max_global_vel_mag");
     bin.write_scalar(var.reference_frame_time, "reference_frame_time");
 
+    bin.write_scalar(var.last_remesh_time, "last_remesh_time");
+
     bin.write_array(*var.segment, "segment", var.segment->size());
     bin.write_array(*var.segflag, "segflag", var.segflag->size());
     // Note: regattr is not needed for restarting

--- a/parameters.hpp
+++ b/parameters.hpp
@@ -274,6 +274,7 @@ struct BC {
     bool has_elastic_foundation;
 
     bool has_water_loading;
+    double sea_water_density;
 
     int vbc_x0;
     int vbc_x1;

--- a/parameters.hpp
+++ b/parameters.hpp
@@ -195,6 +195,10 @@ struct Mesh {
     bool is_discarding_internal_segments;
     int remeshing_option;
 
+    // Deborah-number-weighted blend of NN-remapped vs SPR-recovered stress at remeshing
+    double remesh_deborah_min;
+    double remesh_deborah_max;
+
     // Parameters for mesh optimizer MMG
     int mmg_debug;
     int mmg_verbose;
@@ -646,6 +650,7 @@ class MatProps;
 class MarkerSet;
 struct Variables {
     double time;
+    double last_remesh_time; // Deborah-number timescale for the remesh stress blend
     double dt;
     // double dt_PT;
     double l2_residual;
@@ -763,6 +768,9 @@ struct Variables {
     // For remeshing
     tensor_t *stress_n;
     double_vec *stressyy_n;
+    // Remesh-only stress-remap transients, allocated per remesh(), nullptr otherwise:
+    // - spr_blend_weight: Deborah weight toward the NN-remapped stress (1 = NN, 0 = SPR)
+    double_vec *spr_blend_weight;
 
     // tensor_t *stress_old;
 
@@ -776,6 +784,7 @@ struct Variables {
 
     Variables()
     {
+        spr_blend_weight = nullptr;
         vbc_vertical_div_x0.resize(4);
         vbc_vertical_div_x1.resize(4);
         vbc_vertical_ratio_x0.resize(4);

--- a/parameters.hpp
+++ b/parameters.hpp
@@ -766,14 +766,17 @@ struct Variables {
     double_vec *etmp;
     int_vec *etmp_int;
 
-    // For remeshing
-    tensor_t *stress_n;
-    double_vec *stressyy_n;
-    // Remesh-only stress-remap transients, allocated per remesh(), nullptr otherwise:
+    // Remesh-only stress-remap transients, allocated per remesh(), nullptr otherwise.
+    // stress_n and spr_blend_weight double as the switch for the SPR recovery:
+    // remesh() leaves them null when the rheology has no viscous component, and each
+    // consumer skips its part of the chain on that.
+    // - stress_n, stressyy_n: SPR-recovered nodal stress
     // - spr_blend_weight: Deborah weight toward the NN-remapped stress (1 = NN, 0 = SPR)
     // - spr_p_ref_old: reference pressure added at pressure-centering, per element
     // - remesh_is_changed: the NN pass's per-NEW-element is_changed mapping
     //   (0 = geometry identical to an old element, 1 = remapped, -1 = ACM failed)
+    tensor_t *stress_n;
+    double_vec *stressyy_n;
     double_vec *spr_blend_weight;
     double_vec *spr_p_ref_old;
     int_vec *remesh_is_changed;
@@ -790,6 +793,8 @@ struct Variables {
 
     Variables()
     {
+        stress_n = nullptr;
+        stressyy_n = nullptr;
         spr_blend_weight = nullptr;
         spr_p_ref_old = nullptr;
         remesh_is_changed = nullptr;

--- a/parameters.hpp
+++ b/parameters.hpp
@@ -770,7 +770,12 @@ struct Variables {
     double_vec *stressyy_n;
     // Remesh-only stress-remap transients, allocated per remesh(), nullptr otherwise:
     // - spr_blend_weight: Deborah weight toward the NN-remapped stress (1 = NN, 0 = SPR)
+    // - spr_p_ref_old: reference pressure added at pressure-centering, per element
+    // - remesh_is_changed: the NN pass's per-NEW-element is_changed mapping
+    //   (0 = geometry identical to an old element, 1 = remapped, -1 = ACM failed)
     double_vec *spr_blend_weight;
+    double_vec *spr_p_ref_old;
+    int_vec *remesh_is_changed;
 
     // tensor_t *stress_old;
 
@@ -785,6 +790,8 @@ struct Variables {
     Variables()
     {
         spr_blend_weight = nullptr;
+        spr_p_ref_old = nullptr;
+        remesh_is_changed = nullptr;
         vbc_vertical_div_x0.resize(4);
         vbc_vertical_div_x1.resize(4);
         vbc_vertical_ratio_x0.resize(4);

--- a/remeshing.cxx
+++ b/remeshing.cxx
@@ -2920,18 +2920,23 @@ void remesh(const Param &param, Variables &var, int bad_quality)
     // rheology, clamping the viscous law into [min_viscosity, max_viscosity], so
     // those two knobs would have picked the remap operator for a run that otherwise
     // never touches them.
-    var.stress_n = new tensor_t(var.nnode);
-    if (param.mat.is_plane_strain)
-        var.stressyy_n = new double_vec(var.nnode);
-    var.spr_blend_weight = new double_vec(var.nelem);
+    const bool spr_stress = (var.mat->rheol_type & MatProps::rh_viscous) != 0;
+    if (spr_stress) {
+        var.stress_n = new tensor_t(var.nnode);
+        if (param.mat.is_plane_strain)
+            var.stressyy_n = new double_vec(var.nnode);
+        var.spr_blend_weight = new double_vec(var.nelem);
+    }
     var.spr_p_ref_old = new double_vec(var.nelem);
 
     {
         SurfaceTopo topo_old;
         topo_old.build(param, var);   // old mesh: coord/bnodes still pre-remesh here
-        compute_spr_blend_weight(param, var);   // before centering: visc() reads the trace
+        if (spr_stress)
+            compute_spr_blend_weight(param, var);   // before centering: visc() reads the trace
         center_stress_to_ref(param, var, topo_old);
-        spr_elem_to_node(param, var, var.stress_n, var.stressyy_n);
+        if (spr_stress)
+            spr_elem_to_node(param, var, var.stress_n, var.stressyy_n);
     }
 
     {
@@ -3076,13 +3081,15 @@ void remesh(const Param &param, Variables &var, int bad_quality)
     {
         SurfaceTopo topo_new;
         topo_new.build(param, var);   // new mesh: create_boundary_nodes already ran
-        spr_node_to_elem(param, var, topo_new, var.stress, var.stressyy);
+        if (spr_stress)
+            spr_node_to_elem(param, var, topo_new, var.stress, var.stressyy);
         restore_stress_from_ref(param, var, topo_new, var.stress, var.stressyy);
     }
 
     delete var.stress_n;
-    if (param.mat.is_plane_strain)
-        delete var.stressyy_n;
+    var.stress_n = nullptr;
+    delete var.stressyy_n;
+    var.stressyy_n = nullptr;
     delete var.spr_blend_weight;
     var.spr_blend_weight = nullptr;
     delete var.spr_p_ref_old;

--- a/remeshing.cxx
+++ b/remeshing.cxx
@@ -2915,6 +2915,7 @@ void remesh(const Param &param, Variables &var, int bad_quality)
     if (param.mat.is_plane_strain)
         var.stressyy_n = new double_vec(var.nnode);
     var.spr_blend_weight = new double_vec(var.nelem);
+    var.spr_p_ref_old = new double_vec(var.nelem);
 
     spr_elem_to_node(param, var, var.stress_n, var.stressyy_n);
 
@@ -2979,6 +2980,11 @@ void remesh(const Param &param, Variables &var, int bad_quality)
         }
 #endif
         reallocate_tmp(param, var);
+
+        // Per-NEW-element is_changed mapping, filled by the element NN pass
+        // and consumed by spr_node_to_elem; freed with the other stress-remap
+        // transients below.
+        var.remesh_is_changed = new int_vec(var.nelem);
 
         if (param.mesh.meshing_elem_shape == 0) {
             // renumbering mesh
@@ -3059,6 +3065,10 @@ void remesh(const Param &param, Variables &var, int bad_quality)
         delete var.stressyy_n;
     delete var.spr_blend_weight;
     var.spr_blend_weight = nullptr;
+    delete var.spr_p_ref_old;
+    var.spr_p_ref_old = nullptr;
+    delete var.remesh_is_changed;
+    var.remesh_is_changed = nullptr;
 
     // Timescale reference for the next remesh's Deborah-number stress blend.
     var.last_remesh_time = var.time;

--- a/remeshing.cxx
+++ b/remeshing.cxx
@@ -2914,6 +2914,7 @@ void remesh(const Param &param, Variables &var, int bad_quality)
     var.stress_n = new tensor_t(var.nnode);
     if (param.mat.is_plane_strain)
         var.stressyy_n = new double_vec(var.nnode);
+    var.spr_blend_weight = new double_vec(var.nelem);
 
     spr_elem_to_node(param, var, var.stress_n, var.stressyy_n);
 
@@ -3056,6 +3057,11 @@ void remesh(const Param &param, Variables &var, int bad_quality)
     delete var.stress_n;
     if (param.mat.is_plane_strain)
         delete var.stressyy_n;
+    delete var.spr_blend_weight;
+    var.spr_blend_weight = nullptr;
+
+    // Timescale reference for the next remesh's Deborah-number stress blend.
+    var.last_remesh_time = var.time;
 
     compute_volume(*var.coord, *var.connectivity, *var.volume);
 

--- a/remeshing.cxx
+++ b/remeshing.cxx
@@ -2910,14 +2910,29 @@ void remesh(const Param &param, Variables &var, int bad_quality)
     for (int e = 0; e < var.nelem; ++e)
         (*var.volume_old)[e] = (*var.volume)[e] / (*var.volume_old)[e] - 1.0;
 
-    // superconvergen patch recovery for stress before remeshing
+    // Superconvergent patch recovery for stress before remeshing -- but only where
+    // an element can actually take the SPR average. A rheology with no viscous
+    // component never relaxes stress, so its Maxwell time is infinite, De = inf and
+    // every element keeps the NN stress: the recovery, its nodal transfer across the
+    // remesh, the free-surface pin and the Deborah blend are then all dead work.
+    // Leaving these pointers null is what switches them off; each consumer tests the
+    // one it uses. Note visc() would not have revealed this -- it answers for every
+    // rheology, clamping the viscous law into [min_viscosity, max_viscosity], so
+    // those two knobs would have picked the remap operator for a run that otherwise
+    // never touches them.
     var.stress_n = new tensor_t(var.nnode);
     if (param.mat.is_plane_strain)
         var.stressyy_n = new double_vec(var.nnode);
     var.spr_blend_weight = new double_vec(var.nelem);
     var.spr_p_ref_old = new double_vec(var.nelem);
 
-    spr_elem_to_node(param, var, var.stress_n, var.stressyy_n);
+    {
+        SurfaceTopo topo_old;
+        topo_old.build(param, var);   // old mesh: coord/bnodes still pre-remesh here
+        compute_spr_blend_weight(param, var);   // before centering: visc() reads the trace
+        center_stress_to_ref(param, var, topo_old);
+        spr_elem_to_node(param, var, var.stress_n, var.stressyy_n);
+    }
 
     {
         // creating a "copy" of mesh pointer so that they are not deleted
@@ -3058,7 +3073,12 @@ void remesh(const Param &param, Variables &var, int bad_quality)
      * create_support(var);
      */
 
-    spr_node_to_elem(param, var, var.stress, var.stressyy);
+    {
+        SurfaceTopo topo_new;
+        topo_new.build(param, var);   // new mesh: create_boundary_nodes already ran
+        spr_node_to_elem(param, var, topo_new, var.stress, var.stressyy);
+        restore_stress_from_ref(param, var, topo_new, var.stress, var.stressyy);
+    }
 
     delete var.stress_n;
     if (param.mat.is_plane_strain)


### PR DESCRIPTION
### Update (2026-08-12)

Six commits: the review's unexplained constants, plus two things answering it surfaced.

- Grid bounds derived. [65, 257] and [33, 97] are a cost window (O(M^2 * ND), O(M^3 * ND)), not DCT degrees or a radix constraint — the floor keeps the queried grid smooth, the cap stops a 10^4-node surface asking for O(10^10) flops per remesh. ND = 65, the blend's t^2 (3 - 2t) and remesh_deborah_max = 100 now carry their reasoning too, the last in --help and defaults.cfg.
- Aliasing fixed. Point-sampling relief finer than the capped grid folds it onto low-k modes, which never attenuate, leaving a 0.4 m (13 kPa) h_eff floor that does not decay with depth. Cell-average the resample once the cap binds. The floor is in the reference, which unchanged elements cancel either way, so only remeshed elements move.
- Centering separated from SPR. The two spr_* functions also owned the reference round trip, which serves the whole remap rather than the fit — for a changed element it is what makes the NN copy depth-aware, and it therefore cannot be skipped with the recovery. Five functions now, with the two orderings a compiler cannot check stated on the declarations.
- The rheology picks the remap. visc() answers for every rheology, clamped into [min_viscosity, max_viscosity], so those knobs were selecting the remap for rh_elastic/rh_ep/rh_ep_rsf, which never relax. remesh() decides once on rh_viscous and skips the recovery, leaving NN interpolation plus the round trip.
- Tables threaded. 5.0x at the 3-D cap, 2.6x at the 2-D cap.

---

### Summary

Six commits that change how element stress crosses a remesh. Stress is the one field for which remeshing is not a passive interpolation problem: it carries elastic memory in the cold lid, it must satisfy the free-surface condition exactly, and it sits on a steep lithostatic background that any smoothing operation will corrupt. This PR treats those three facts as design principles instead of accepting the remap error they otherwise produce.

## Method: how stress crosses a remesh

DES remaps element stress through a superconvergent patch recovery (SPR) round trip: element → nodal least-squares fit on the old mesh → interpolation to the new nodes → node → element average. To keep the fitted quantity small, the stress is first pressure-centered (the lithostatic reference is added on the old mesh and subtracted at the new element centroids). Every commit in this series is a correction to one link of that chain, each derived from a principle rather than a symptom fix.

The diagram tags every step with the principle it follows; each is spelled out with its commits in the next section:

- **P1** — exact information beats extrapolation: pin the free surface
- **P2** — reference states must follow the current geometry: `SurfaceTopo`
- **P3** — choose the remap by the physics timescale: the Deborah blend
- **P4** — identity geometry ⇒ identity remap: untouched elements keep their stress

```mermaid
flowchart TB
    subgraph OLD["ON THE OLD MESH — spr_elem_to_node"]
        T([remesh triggered]) --> W["P3 : compute blend weight per element<br/>De = (η/G) / Δt_rm , w = smoothstep(log₁₀ De)"]
        W --> CTR["P2 : pressure-center at the ELEMENT CENTROID,<br/>relative to the CURRENT surface:<br/>σ += p_ref(z_eff(centroid)) , z_eff from SurfaceTopo<br/>P4 : record the added p_ref per element"]
        CTR --> SPR1["SPR patch fit: element → nodal σ_n"]
    end

    subgraph MID["MESH REGENERATION + TRANSFER"]
        SPR1 --> NEWM([new mesh built])
        NEWM --> BARY["nodal transfer: σ_n → new nodes<br/>(barycentric interpolation)"]
        NEWM --> NN["NN element transfer: σ, σ_yy, w, p_ref_old<br/>(verbatim copy where the element is unchanged)<br/>P4 : flag unchanged elements (is_changed == 0)"]
    end

    subgraph NEW["ON THE NEW MESH — spr_node_to_elem"]
        BARY --> PIN["P1 : pin the free surface at each TOP NODE:<br/>total σ_zz = 0, zero shear — in the centered variable<br/>σ_n = p_ref(z_eff(node)), and z_eff = 0 at the surface<br/>→ the pin is exact, independent of topography"]
        NN -.NN snapshot.-> FB
        PIN --> AVG["Step C: nodal → element average<br/>(the SPR-recovered stress, all elements)"]
        AVG --> FB{"P1 : surface element left<br/>LESS compressive than<br/>before the remesh?"}
        FB -- yes --> REV["revert to NN stress<br/>(σ and σ_yy atomically)"]
        FB -- no --> UNT
        REV --> UNT{"P4 : element<br/>unchanged?"}
        UNT -- "yes (~93%)" --> KEEP["keep pre-remesh stress verbatim:<br/>restore the NN snapshot"]
        UNT -- no --> BL["P3 : Deborah blend<br/>σ = w·σ_NN + (1−w)·σ_SPR"]
        BL --> DEC["P2 : de-center at the NEW ELEMENT CENTROID:<br/>σ −= p_ref(z_eff(new centroid))"]
        KEEP --> DEC2["P4 : de-center with the CARRIED reference:<br/>σ −= recorded p_ref_old (bit-exact round trip)"]
    end

    DEC --> DONE([remapped stress on the new mesh])
    DEC2 --> DONE
```

## Principles and commits

**1. Exact information beats extrapolation — pin the free surface.**
The SPR patch fit is one-sided at surface nodes, its least reliable place in the mesh, while the free-surface condition (total σ_zz = 0, zero shear) is known exactly. Pin it before the node→element average, keep an NN-remapped fallback for any surface element the SPR average would leave *less compressive* than before the remesh (the spurious-tension direction), and stop `reallocate_variables` from clobbering the remapped stress the fallback needs.
- `fix: preserve surface-element stress through remeshing (SPR pin + NN fallback)`
- `fix: OpenACC coverage and async ordering for the surface-stress remap` —
  device pragmas for the new loops; the NN stress injection is ordered after the async barrier so the old tensor is never freed mid-flight.
- `fix: include out-of-plane sigma_yy in the surface-stress remap fallback` —
  in plane strain σ_yy is a third of the mean stress; it joins the same compressiveness test and reverts atomically with the in-plane tensor, so an element is never left in a mixed SPR / pre-remesh state.

**2. Reference states must follow the current geometry.**
Pressure-centering against the fixed datum z = 0 breaks down as soon as topography exists: the "small deviatoric residual" the SPR relies on grows by ρg × relief, and the surface pin lands at the wrong lithostat. `SurfaceTopo` rebuilds the surface from the current top boundary at every remesh (no persistent state, 2-D and 3-D) and evaluates the reference at the depth below the *local* surface, with a DCT-I depth-attenuation kernel (e^{−|k|d}, the harmonic-load half-space decay) so short-wavelength relief does not project undamped to depth. On a flat surface the behavior is bit-exact unchanged.
- `feat: topography-corrected reference pressure in SPR remeshing (SurfaceTopo)`

**3. Choose the remap by the physics timescale.**
The two transfer operators fail in opposite regimes: SPR's smoothing stabilizes the weak, fast-deforming region (the no-SPR variant cascades and dies) but artificially relaxes elastic stress in the cold lid, whose Maxwell time dwarfs the remesh interval; plain NN preserves memory but also preserves element-scale noise. The Deborah number is exactly the ratio that separates the regimes. Per element $e$, with viscosity $\eta_e$, shear modulus $G_e$ and the time since the previous remesh as the loading timescale,

```math
\mathrm{De}_e = \frac{t_{M,e}}{\Delta t_{\mathrm{rm}}},\qquad
t_{M,e} = \frac{\eta_e}{G_e},\qquad
\Delta t_{\mathrm{rm}} = \max\!\big(t - t_{\mathrm{last\,remesh}},\ \Delta t\big),
```

the blend weight is a smoothstep in $\log_{10}\mathrm{De}$ between the two bounds (`remesh_deborah_min` = 1, `remesh_deborah_max` = 100 by default),

```math
s_e = \mathrm{clip}\!\left(
\frac{\log_{10}\mathrm{De}_e - \log_{10}\mathrm{De}_{\min}}
     {\log_{10}\mathrm{De}_{\max} - \log_{10}\mathrm{De}_{\min}},\ 0,\ 1\right),
\qquad w_e = s_e^{2}\,(3 - 2 s_e),
```

and the remapped stress is the convex combination of the two transfers, applied in the pressure-centered variable (so the blend is exact for the lithostatic background) and after the surface fallback (so a surface element is never made less compressive again):

```math
\boldsymbol{\sigma}_e \leftarrow w_e\,\boldsymbol{\sigma}_e^{\mathrm{NN}}
 + (1 - w_e)\,\boldsymbol{\sigma}_e^{\mathrm{SPR}},
\qquad \sigma_{yy,e} \ \text{likewise in plane strain.}
```

$w_e$ is evaluated on the **old** mesh — where strain rate, temperature and element markers are still mutually consistent, and before the centering, since the viscosity law reads the stress trace — and rides through the remesh with the other element fields. The blend is unconditional; `remesh_deborah_min` and `remesh_deborah_max` are its only knobs.
- `feat: Deborah-number-weighted blend of NN and SPR stress remap at remeshing`

**4. Identity geometry ⇒ identity remap.**
Most elements are not changed by a typical remesh, yet SPR rewrote every one of them at every event. Every other element field already crosses a remesh verbatim when the element is unchanged (`inject_field`); this commit gives stress the same guarantee. Unchanged elements — strictly `is_changed == 0` in the NN pass, since `-1` (an ACM-failed nearest copy) is *not* an identity map — keep stress and σ_yy bit-exactly. The loop that follows the surface fallback overwrites the Step C average with the NN snapshot for them: an explicit copy, never the blend's `w·σ_NN + (1−w)·σ_SPR`, which is an identity only in exact arithmetic. Step C' then subtracts the *recorded* reference added at centering rather than the new-topo value — the attenuation table is global, so the add/subtract pair only cancels bit-exactly with the carried number. (The fallback may also fire on such an element, but it restores that same snapshot, so the guarantee is unaffected.) A remesh that changes nothing is now a stress no-op.
- `feat: keep pre-remesh stress verbatim in elements the remesh did not change`

## Benchmark: EVP rifting, five remap variants, 800 kyr

Same protocol as before (derived from `examples/rifting-2d.cfg`, natural remeshing, `has_output_during_remeshing = yes` so every event writes a before/after frame pair at the same physical time. Variants:

| | stress remap across a remesh |
|---|---|
| **A** | nearest-neighbor only, no SPR (the two `spr_*` calls disabled) |
| **B** | SPR, fixed-datum reference (`force_topo` off at both SPR sites) |
| **C** | SPR, topography-corrected reference (this branch, blend off, untouched off) |
| **D** | + Deborah blend (blend on, untouched off) |
| **E** | + untouched-element carry-through (branch defaults) |

### What the method decides, where

*(figure slot: `figE_method_anatomy.png`)*
<img width="1430" height="1100" alt="figE_method_anatomy" src="https://github.com/user-attachments/assets/d09b0f3b-4993-4fe8-a7c1-d5c2d5438c97" />

The implementation made visible, at one representative remesh event (Δt_rm = 19 kyr): **(a)** the reconstructed blend-weight field splits the domain exactly along the regime boundary — area-weighted mean w = **0.96** in the near-surface band (cold lid keeps NN memory), **0.000** in the low-viscosity band (pure SPR keeps the stabilizing smoothing), 0.30 over the whole domain. **(b)** the changed/unchanged mask of the same event: **93 % of elements are left geometrically unchanged** — the untouched carry-through keeps all of them bit-exact — and the changed ones are the rift interior plus the bottom-boundary strip, which the floor re-discretization rebuilds at every event. **(c)** that 91–97 % unchanged fraction holds at every event of every variant: a typical remesh touches less than a tenth of the mesh, which is why principle 4 removes most of the remap footprint.

### Setup and dynamical stability

*(figure slot: `figE_setup_stability.png`)*
<img width="1650" height="1210" alt="figE_setup_stability" src="https://github.com/user-attachments/assets/333414d2-68e3-4cbb-a0c3-6364210cdf2f" />

The benchmark develops rift topography and a deep low-viscosity band under natural remeshing. A no longer crashes — the branch's remeshing-robustness fixes turn the old 25 kyr `triangulation failed` death into a graceful permanent cascade (381 remesh events in 87 kyr, low-viscosity band 280 → 3300+ elements, stopped deliberately) — but the physics verdict against NN-only is unchanged. All four SPR variants ran quietly to the 800 kyr time limit with no terminal cascade.

### Per-event remap error

**RMS over the common window t ≤ 779 kyr (MPa):**

| variant | ΔP domain | Δτ_II domain | ΔP surf (<15 km) | Δτ_II surf | ΔP low-η band | Δτ_II low-η |
|---|---|---|---|---|---|---|
| A (died 87 kyr) | 5.95 | 0.93 | ~0 | ~0 | 7.47 | 1.16 |
| B | 11.39 | 11.02 | 7.38 | 5.00 | 1.94 | 0.11 |
| C | 9.94 | 9.73 | 5.15 | 4.24 | 1.70 | 0.11 |
| D | 9.16 | 9.10 | 1.74 | 1.62 | 1.87 | 0.10 |
| **E** | **1.73** | **1.13** | **1.21** | **0.85** | 1.97 | 0.42 |

*(figure slot: `figE_error_series.png`)*
<img width="1650" height="1100" alt="figE_error_series" src="https://github.com/user-attachments/assets/83bb1b22-9174-4bac-932b-6c64ded1be55" />

Each principle removes the part of the error it targets: topography correction (B→C) −30 % near-surface ΔP; Deborah blend (C→D) −66 % near-surface (the cold lid keeps NN); untouched carry-through (D→E) cuts the **whole-domain** error ~5× by eliminating the deep error band entirely. In the low-viscosity band — genuinely remeshed, De ≪ 1 — all SPR variants including E are statistically identical in ΔP, so the stabilizing smoothing is preserved exactly where it is needed; E's weak-band Δτ_II is elevated (0.42 vs 0.11 MPa) but bounded — it oscillates and decays, band size stays normal, no A-style runaway.

### Where the error lives: one event, and all events

*(figure slot: `figE_remap_maps.png` — element-resolved ΔP at the ~500 kyr event of each variant, after − before at the same physical time)*
<img width="1430" height="1705" alt="figE_remap_maps" src="https://github.com/user-attachments/assets/0914ed7a-a8c0-4bc4-ad99-ee7be2143937" />

*(figure slot: `figE_remap_avg_maps.png` — RMS ΔP over ALL remesh events on a common grid)*
<img width="1430" height="1705" alt="figE_remap_avg_maps" src="https://github.com/user-attachments/assets/663150fa-399e-4cff-b455-4639396f9786" />

B and C pay a saturated two-band error at the lithosphere base across the full domain width at *every* event, plus near-surface fabric; D cleans the lid but keeps the deep bands; E is near-zero everywhere except the actively-remeshed rift interior. A's error is a ±40 MPa element-scale checkerboard confined to the deep weak band — while its *surface* is usually re-triangulated identically, which is why a surface metric alone underestimates the NN-only failure.

### Bias, not noise

*(figure slot: `figE_remap_mean_maps.png` — SIGNED mean ΔP over all events)*
<img width="1430" height="1705" alt="figE_remap_mean_maps" src="https://github.com/user-attachments/assets/40f44b3c-ad1b-4e6a-8ea9-9b27d55c1ba3" />

Keeping the sign separates the two failure modes. A's signed mean is ≈ 0 despite its saturated RMS: pure zero-mean noise, amplified by the EVP feedback. B/C/D's band dipole survives averaging at nearly full amplitude — every remesh pumps pressure the same direction across the brittle–ductile transition (SPR smoothing the same curvature every time). A same-direction bias accumulates where noise would cancel; this is the mechanism behind SPR's cold-lid stress relaxation, and E removes it.

### Where the peak velocity lives

*(figure slot: `figE_vmax_locations.png` — peak-|v| node of every frame over the RMS error background)*
<img width="1430" height="1705" alt="figE_vmax_locations" src="https://github.com/user-attachments/assets/57bd8b71-4490-4e95-a66d-96184910704b" />

E's cost accounting: ~50 % more remesh events (33 vs 22) and recurring post-remesh velocity transients (~15× v_bc, decaying, never cascading, quietening after 600 kyr). Locating the per-frame peak velocity shows these transients live at the **bottom wall/floor corner** — not at the rift or distributed through the interior; baseline frames peak in the rift upwelling column exactly like B/C/D. The anatomy figure explains why: the floor strip is re-discretized at *every* remesh (panel b), so its elements always take remapped values against untouched neighbours above, under the Winkler support. The transient is a localized boundary artifact with an evident refinement path (exclude boundary-adjacent elements from the carry-through), not an inherent instability of the method.

### Rift architecture

*(figure slot: `figE_topography_localization.png` — topography evolution + fault patterns)*
<img width="1650" height="1716" alt="figE_topography_localization" src="https://github.com/user-attachments/assets/2b5811a3-a8bd-4891-bfda-d067d3d93aa7" />

Same graben, conjugate fault sets and ~25 km localization depth in B/C/D/E; shoulder heights at 800 kyr agree to ±2 % with no fidelity ordering (single realization per variant, so shoulder height is realization scatter, not a remap signal).

*(figure slot: `figE_stressII_comparison.png` — deviatoric stress II in the same rift window at 800 kyr)*
<img width="1650" height="1716" alt="figE_stressII_comparison" src="https://github.com/user-attachments/assets/635a1d79-e781-4647-af6e-30f279d2851a" />

The stress state each remap leaves behind, as a field: B and C carry the smoothest τ_II — the lid's stress a soft blur, the fault stress-shadows smeared away — the cumulative fingerprint of SPR smoothing at every event. D is crisper; E retains the most structure: distinct low-stress fault shadows in the lid on both flanks, element-scale texture, and the sharpest high-stress core and axial stress shadow, with the same large-scale architecture as the others — fidelity, not divergence.

## Testing

- 2-D and 3-D build cleanly; `tests/functional/2d-ep-irregular.cfg` and `3d-evp-regular.cfg` pass with remeshing exercised.
- Both new behaviors engage exactly at remeshing and nowhere else: output frames before the first remesh are field-identical to the previous (pure-SPR) behavior, and only post-remesh frames differ.
- Restart is bit-deterministic across post-restart remeshes with the blend on (exercising the checkpointed `last_remesh_time`) and off.
- All four surviving benchmark variants ran to the 800 kyr time limit with no terminal cascade — the deaths reported in the earlier revision of this benchmark (541/758 kyr) were removed by the branch's robustness fixes, independent of remap choice.

<details>
<summary>Earlier four-variant benchmark (superseded by the five-variant rerun above; kept for the record)</summary>

<img width="1725" height="1320" alt="figR1_setup_stability" src="https://github.com/user-attachments/assets/5afd9c82-ecf8-49c5-a503-fdf331ed9f34" />
<img width="1725" height="1650" alt="figR2_remap_maps" src="https://github.com/user-attachments/assets/28ff1726-ab09-464a-a56c-28547777ba36" />
<img width="1725" height="1080" alt="figR3_error_series" src="https://github.com/user-attachments/assets/20cf06b5-2be1-41ef-95c0-bd871e42d445" />
<img width="1725" height="1350" alt="figR4_topography_localization" src="https://github.com/user-attachments/assets/6f0ad316-707a-4d3b-a5af-7a0f3c59b2e7" />

Variant labels in these figures follow the old scheme (A fixed-datum,
B topo-corrected, C NN-only, D blend), which maps to the new B, C, A, D.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
