### PR TITLE
Regular update 2026-07: remeshing robustness, restart metadata, GPU and build fixes

### DIFF
--- a/.github/workflows/basic-build.yml
+++ b/.github/workflows/basic-build.yml
@@ -40,15 +40,15 @@ jobs:
         echo "HDF5_LIB_DIR=${HDF5_LIB_DIR}" >> $GITHUB_ENV
   
     - name: make debug 2d
-      run: make clean; make ndims=2 opt=0 openmp=0 hdf5=0
+      run: make clean ndims=2; make ndims=2 opt=0 openmp=0 hdf5=0
     - name: make debug 3d
-      run: make clean; make ndims=3 opt=0 openmp=0 hdf5=0
+      run: make clean ndims=3; make ndims=3 opt=0 openmp=0 hdf5=0
     - name: make 2d
-      run: make clean; make ndims=2 opt=2 openmp=1 hdf5=0
+      run: make clean ndims=2; make ndims=2 opt=2 openmp=1 hdf5=0
     - name: make 3d
-      run: make clean; make ndims=3 opt=2 openmp=1 hdf5=0
+      run: make clean ndims=3; make ndims=3 opt=2 openmp=1 hdf5=0
     - name: make 3d hdf5
-      run: make clean; make ndims=3 opt=2 openmp=1 hdf5=1 \
+      run: make clean ndims=3; make ndims=3 opt=2 openmp=1 hdf5=1 \
             HDF5_LIB_DIR=$HDF5_LIB_DIR HDF5_INCLUDE_DIR=$HDF5_INCLUDE_DIR
     # - name: make check
     #   run: make check

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -49,15 +49,15 @@ jobs:
         make -j4 && make install && cd ../../
 
     - name: make debug 2d
-      run: make clean; make ndims=2 opt=0 openmp=0 BOOST_ROOT_DIR=$(brew --prefix boost)
+      run: make clean ndims=2; make ndims=2 opt=0 openmp=0 BOOST_ROOT_DIR=$(brew --prefix boost)
     - name: make debug 3d
-      run: make clean; make ndims=3 opt=0 openmp=0 BOOST_ROOT_DIR=$(brew --prefix boost)
+      run: make clean ndims=3; make ndims=3 opt=0 openmp=0 BOOST_ROOT_DIR=$(brew --prefix boost)
     - name: make 2d
-      run: make clean; make ndims=2 opt=2 openmp=1 BOOST_ROOT_DIR=$(brew --prefix boost)
+      run: make clean ndims=2; make ndims=2 opt=2 openmp=1 BOOST_ROOT_DIR=$(brew --prefix boost)
     - name: make 3d
-      run: make clean; make ndims=3 opt=2 openmp=1 BOOST_ROOT_DIR=$(brew --prefix boost)
+      run: make clean ndims=3; make ndims=3 opt=2 openmp=1 BOOST_ROOT_DIR=$(brew --prefix boost)
     - name: make 3d hdf5
-      run: make clean; make ndims=3 opt=2 openmp=1 hdf5=1
+      run: make clean ndims=3; make ndims=3 opt=2 openmp=1 hdf5=1
             BOOST_ROOT_DIR=$(brew --prefix boost)
             HDF5_INCLUDE_DIR=$(brew --prefix hdf5)/include
             HDF5_LIB_DIR=$(brew --prefix hdf5)/lib

--- a/.github/workflows/mmg-build.yml
+++ b/.github/workflows/mmg-build.yml
@@ -30,7 +30,7 @@ jobs:
         sudo apt update
         sudo apt install libboost-program-options-dev
     - name: make 2d with mmg
-      run: make clean; make ndims=2 usemmg=1
+      run: make clean ndims=2; make ndims=2 usemmg=1
     - name: make 3d with mmg
-      run: make clean; make ndims=3 usemmg=1
+      run: make clean ndims=3; make ndims=3 usemmg=1
       

--- a/.github/workflows/nvc-build.yml
+++ b/.github/workflows/nvc-build.yml
@@ -146,13 +146,13 @@ jobs:
         echo "BASE_MAKE=make hdf5=1 NVHPC_DIR=$NVHPC_DIR HDF5_LIB_DIR=$HDF5_LIB HDF5_INCLUDE_DIR=$HDF5_INC" >> $GITHUB_ENV
 
     - name: make ndims=${{ matrix.ndims }} openacc=1 SM=80 hdf5=1
-      run: make cleanall && $BASE_MAKE ndims=${{ matrix.ndims }} openacc=1 hdf5=1 SM=80
+      run: make clean openacc=1 ndims=${{ matrix.ndims }} && $BASE_MAKE ndims=${{ matrix.ndims }} openacc=1 hdf5=1 SM=80 -j
 
     - name: make ndims=${{ matrix.ndims }} openacc=1 SM=80 hdf5=1 usemmg=1
-      run: make cleanall && $BASE_MAKE ndims=${{ matrix.ndims }} openacc=1 hdf5=1 usemmg=1 SM=80
+      run: make clean openacc=1 ndims=${{ matrix.ndims }} && $BASE_MAKE ndims=${{ matrix.ndims }} openacc=1 hdf5=1 usemmg=1 SM=80 -j
 
     - name: make ndims=${{ matrix.ndims }} openacc=1 nprof=1 SM=80 hdf5=1
-      run: make cleanall && $BASE_MAKE ndims=${{ matrix.ndims }} openacc=1 hdf5=1 nprof=1 SM=80
+      run: make cleanall openacc=1 ndims=${{ matrix.ndims }} && $BASE_MAKE ndims=${{ matrix.ndims }} openacc=1 hdf5=1 nprof=1 SM=80 -j
 
     - name: make ndims=${{ matrix.ndims }} nprof=1 opt=0 hdf5=1
-      run: make cleanall && $BASE_MAKE ndims=${{ matrix.ndims }} hdf5=1 nprof=1 opt=0
+      run: make cleanall ndims=${{ matrix.ndims }} && $BASE_MAKE ndims=${{ matrix.ndims }} hdf5=1 nprof=1 opt=0 -j

--- a/Dynearthsol.py
+++ b/Dynearthsol.py
@@ -4,6 +4,83 @@ from __future__ import print_function, unicode_literals
 import sys, os
 import numpy as np
 
+# must match binaryio.cxx
+HEADERLEN = 4096
+
+
+def _scan_frame_hdf5(fname):
+    import h5py
+    with h5py.File(fname, 'r') as f:
+        def get(name):
+            return f[name][0]
+        return dict(
+            steps = get('steps'),
+            time = float(get('time_sec')),
+            dt = float(get('dt_sec')),
+            walltime = float(get('walltime_sec')),
+            nnode = get('nnode'),
+            nelem = get('nelem'),
+            nseg = get('nseg'),
+        )
+
+
+def _scan_frame_binary(fname):
+    import struct
+    with open(fname, 'rb') as f:
+        header = f.read(HEADERLEN).splitlines()
+        if not header[0].startswith(b'# DynEarthSol'):
+            raise KeyError(fname + ' is not a DynEarthSol binary frame')
+        pos = {}
+        for line in header[1:]:
+            if not line or line[0] in (0, b'\x00'[0]):
+                break
+            name, p = line.split(b'\t')
+            pos[name.decode('ascii')] = int(p)
+
+        def get(name, fmt, default=None):
+            if name not in pos:
+                return default
+            f.seek(pos[name])
+            return struct.unpack(fmt, f.read(struct.calcsize(fmt)))[0]
+
+        if 'steps' not in pos or 'time_sec' not in pos:
+            raise KeyError('steps/time_sec scalars missing in ' + fname +
+                           ' (frame predates the .info metadata in binary '
+                           'output; a .info file is required)')
+        return dict(
+            steps=get('steps', '<i'),
+            time=get('time_sec', '<d'),
+            dt=get('dt_sec', '<d'),
+            walltime=get('walltime_sec', '<d', 0.0),
+            nnode=get('nnode', '<i'),
+            nelem=get('nelem', '<i'),
+            nseg=get('nseg', '<i'),
+        )
+
+
+def scan_frames(modelname):
+    '''Read the per-frame .info metadata (frame, steps, time, dt, walltime,
+    nnode, nelem, nseg) directly from <modelname>.save.NNNNNN[.vtkhdf] frame
+    files, sorted by frame number. dt/nseg are None for frames written
+    before they were added to the frame metadata.'''
+    import glob, re
+    pat = re.compile(re.escape(os.path.basename(modelname))
+                     + r'\.save\.(\d+)(\.vtkhdf)?$')
+    found = []
+    for fname in glob.glob(modelname + '.save.*'):
+        m = pat.search(os.path.basename(fname))
+        if m:
+            found.append((int(m.group(1)), fname, bool(m.group(2))))
+    found.sort()
+
+    rows = []
+    for frame, fname, is_hdf5 in found:
+        d = _scan_frame_hdf5(fname) if is_hdf5 else _scan_frame_binary(fname)
+        d['frame'] = frame
+        rows.append(d)
+    return rows
+
+
 class Dynearthsol:
     '''Read output file of 2D/3D DynEarthSol'''
 

--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ ifneq (, $(findstring clang++, $(CXX)))
 		ifeq ($(filter /%,$(OPENMP_ROOT_DIR)),$(OPENMP_ROOT_DIR))
 			OPENMP_RPATH := $(OPENMP_ROOT_DIR)/lib
 		else
-			OPENMP_RPATH := @executable_path/$(OPENMP_ROOT_DIR)/lib
+			OPENMP_RPATH := $(CURDIR)/$(OPENMP_ROOT_DIR)/lib
 		endif
 		CXXFLAGS += -Xpreprocessor -fopenmp -I$(OPENMP_ROOT_DIR)/include
 		LDFLAGS += -L$(OPENMP_ROOT_DIR)/lib -lomp

--- a/bc.cxx
+++ b/bc.cxx
@@ -337,6 +337,7 @@ void apply_vbcs(const Param &param, const Variables &var, array_t &vel)
     };
 #else
     double zmin = 0;
+    #pragma acc enter data copyin(zmin) async
 #ifndef ACC
     #pragma omp parallel for default(none) shared(var) reduction(min:zmin)
 #endif
@@ -366,7 +367,7 @@ void apply_vbcs(const Param &param, const Variables &var, array_t &vel)
 #ifdef THREED
     #pragma acc parallel loop gang vector async copyin(lateral_faces[0:4])
 #else
-    #pragma acc parallel loop gang vector async
+    #pragma acc parallel loop gang vector async present(zmin)
 #endif
     for (int i=0; i<var.nnode; ++i) {
 
@@ -624,6 +625,10 @@ void apply_vbcs(const Param &param, const Variables &var, array_t &vel)
             }
         }
     }
+#ifndef THREED
+    #pragma acc exit data copyout(zmin) async
+#endif
+    #pragma acc wait
 #ifdef NPROF
     nvtxRangePop();
 #endif

--- a/bc.cxx
+++ b/bc.cxx
@@ -726,8 +726,16 @@ void apply_stress_bcs(const Param& param, const Variables& var, array_t& force)
                     }
                 }
                 else {
-                    // sidewalls
+                    // sidewalls: lithostatic support pressure (Archimedes) from the exterior column.
+                    // Floor at zero: for a wall facet ABOVE the datum (zcenter > 0, wall-edge
+                    // topography) ref_pressure_option 0/4 extrapolate linearly NEGATIVE, which would
+                    // flip the traction into an unphysical OUTWARD suction that actively pulls the
+                    // topographic strip out of the domain. The true exterior there is air/vacuum
+                    // (zero traction), so clamp. Options 1/2/3 already return 0 above the datum, so
+                    // this only changes options 0/4; below the datum (the usual case) p > 0 and the
+                    // clamp is inert -> normal runs are bit-identical.
                     p = ref_pressure(param, zcenter);
+                    if (p < 0.0) p = 0.0;
                 }
 
                 (*var.etmp_int)[e] = n;

--- a/benchmarks-cores/Makefile
+++ b/benchmarks-cores/Makefile
@@ -18,6 +18,7 @@
 #   DEBUG   1 = run under valgrind/CUDA memcheck            (default: 0)
 #   NSYS    1 = profile with nsys                           (default: 0)
 #   VTK     1 = also convert output to VTK after run        (default: 0)
+#   INDIR   1 = run in a subdirectory (model-<CASE>-<MODELNAME>) to avoid overwriting output from other runs (default: 0)
 #
 # Targets
 # -------
@@ -50,6 +51,7 @@ DEBUG := 0
 NSYS := 0
 VTK := 0
 NDIMS := 3
+INDIR := 0
 EXE := ../dynearthsol$(NDIMS)d
 FUNC := compute_mass
 NUM := 0
@@ -104,7 +106,18 @@ CURR = ~/data/jobs/${CASE}
 all: cmp
 
 test:
+ifeq ($(INDIR), 1)
+	@echo "Test in directory: model-${CASE}-${MODELNAME} ..."
+	mkdir -p model-${CASE}-${MODELNAME}
+	cp $(CURDIR)/${EXE} model-${CASE}-${MODELNAME}/
+	cp $(CURDIR)/${CASE} model-${CASE}-${MODELNAME}/
+	cp $(CURDIR)/../snapshot.diff model-${CASE}-${MODELNAME}/
+	cd model-${CASE}-${MODELNAME} && \
+	rm -f ${MODELNAME}.* && \
+	OMP_NUM_THREADS=${OMP} ${TFLAG} ${DEBUGFLAG} ./$(notdir ${EXE}) $(notdir ${CASE})
+else
 	${RUN_TEST}
+endif
 
 job:
 	# run jobs on server

--- a/benchmarks-cores/Makefile
+++ b/benchmarks-cores/Makefile
@@ -111,7 +111,7 @@ ifeq ($(INDIR), 1)
 	mkdir -p model-${CASE}-${MODELNAME}
 	cp $(CURDIR)/${EXE} model-${CASE}-${MODELNAME}/
 	cp $(CURDIR)/${CASE} model-${CASE}-${MODELNAME}/
-	cp $(CURDIR)/../snapshot.diff model-${CASE}-${MODELNAME}/
+	@if [ -f "$(CURDIR)/../snapshot.diff" ]; then cp "$(CURDIR)/../snapshot.diff" model-${CASE}-${MODELNAME}/; fi
 	cd model-${CASE}-${MODELNAME} && \
 	rm -f ${MODELNAME}.* && \
 	OMP_NUM_THREADS=${OMP} ${TFLAG} ${DEBUGFLAG} ./$(notdir ${EXE}) $(notdir ${CASE})

--- a/binaryio.cxx
+++ b/binaryio.cxx
@@ -938,6 +938,12 @@ void HDF5Input::read_header()
     H5Tclose(atype);
     H5Aclose(attr);
 
+    if (ndims != NDIMS) {
+        std::cerr << "Error: mismatching ndims in HDF5 file\n"
+                  << "  Expect: " << NDIMS << "  Got: " << ndims << '\n';
+        std::exit(1);
+    }
+
     if (H5Aexists(file_id, "revision") <= 0) {
         std::cerr << "Error: missing attribute revision in HDF5 file\n";
         std::exit(1);
@@ -950,6 +956,12 @@ void HDF5Input::read_header()
     H5Aread(attr, atype, &revision);
     H5Tclose(atype);
     H5Aclose(attr);
+
+    if (revision != BINARY_FILE_REVISION) {
+        std::cerr << "Error: mismatching revision in HDF5 file\n"
+                  << "  Expect: " << BINARY_FILE_REVISION << "  Got: " << revision << '\n';
+        std::exit(1);
+    }
 }
 
 HDF5Input::~HDF5Input()

--- a/binaryio.cxx
+++ b/binaryio.cxx
@@ -26,15 +26,17 @@ namespace std { using ::snprintf; }
  * 2  The rests are binary data.
  ****************************************************************************/
 
+// Revision number of the binary file format. Bump it whenever the layout
+// of the header or of the data written after it changes.
+#define BINARY_FILE_REVISION 4
+/* Revision notes:
+ * 4: Add write/read scalar for binary io
+ */
+
 namespace {
     const std::size_t headerlen = 4096;
-    const char revision_str[] = "# DynEarthSol ndims="
-#ifdef THREED
-        "3"
-#else
-        "2"
-#endif
-        " revision=3\n";
+    const std::string revision_str = "# DynEarthSol ndims=" + std::to_string(NDIMS)
+                                   + " revision=" + std::to_string(BINARY_FILE_REVISION) + "\n";
 }
 
 
@@ -72,7 +74,7 @@ BinaryOutput::BinaryOutput(const char *filename, const bool rename_if_exists)
     }
 
     header = new char[headerlen]();
-    hd_pos = std::strcat(header, revision_str);
+    hd_pos = std::strcat(header, revision_str.c_str());
     eof_pos = headerlen;
 
     std::fseek(f, eof_pos, SEEK_SET);
@@ -241,7 +243,7 @@ void BinaryInput::read_header()
 
     // Compare revision string (excluding the trailing new line)
     line = std::strtok(header, "\n");
-    if (strncmp(line, revision_str, strlen(revision_str)-1) != 0) {
+    if (strncmp(line, revision_str.c_str(), revision_str.size()-1) != 0) {
         std::cerr << "Error: mismatching revision string in header\n"
                   << "  Expect: " << revision_str
                   << "  Got: "<< line << '\n';
@@ -438,7 +440,7 @@ void HDF5Output::add_soft_link(const std::string& assemblyNodePath,
 void HDF5Output::write_header()
 {
     write_attribute(NDIMS, "ndims", file_id);
-    write_attribute(3, "revision", file_id);
+    write_attribute(BINARY_FILE_REVISION, "revision", file_id);
 
     hid_t gid = create_group_with_order("/VTKHDF");
 

--- a/binaryio.cxx
+++ b/binaryio.cxx
@@ -119,6 +119,21 @@ void BinaryOutput::write_header(const char *name)
     hd_pos = std::strncat(hd_pos, buffer, len);
 }
 
+template <typename T>
+void BinaryOutput::write_scalar(const T& A, const std::string& name)
+{
+    write_header(name.c_str());
+    std::size_t n = std::fwrite(&A, sizeof(T), 1, f);
+    eof_pos += n * sizeof(T);
+}
+
+
+// explicit instantiation
+template
+void BinaryOutput::write_scalar<int>(const int& A, const std::string& name);
+template
+void BinaryOutput::write_scalar<double>(const double& A, const std::string& name);
+
 // XXX: when A is *var.bcflag, i.e. T is uint, g++ cannot instantiate the template
 template <typename T>
 void BinaryOutput::write_array(const std::vector<T>& A, const char *name, std::size_t size)
@@ -266,6 +281,25 @@ void BinaryInput::seek_to_array(const char *name)
     //std::cout << name << ' ' << loc << '\n';
     std::fseek(f, loc, SEEK_SET);
 }
+
+
+template <typename T>
+void BinaryInput::read_scaler(T& A, const std::string& name)
+{
+    seek_to_array(name.c_str());
+    std::size_t n = std::fread(&A, sizeof(T), 1, f);
+    if (n != 1) {
+        std::cerr << "Error: cannot read scalar: " << name << '\n';
+        std::exit(1);
+    }
+}
+
+
+// explicit instantiation
+template
+void BinaryInput::read_scaler<int>(int& A, const std::string& name);
+template
+void BinaryInput::read_scaler<double>(double& A, const std::string& name);
 
 
 template <typename T>

--- a/binaryio.cxx
+++ b/binaryio.cxx
@@ -284,7 +284,7 @@ void BinaryInput::seek_to_array(const char *name)
 
 
 template <typename T>
-void BinaryInput::read_scaler(T& A, const std::string& name)
+void BinaryInput::read_scalar(T& A, const std::string& name)
 {
     seek_to_array(name.c_str());
     std::size_t n = std::fread(&A, sizeof(T), 1, f);
@@ -297,9 +297,9 @@ void BinaryInput::read_scaler(T& A, const std::string& name)
 
 // explicit instantiation
 template
-void BinaryInput::read_scaler<int>(int& A, const std::string& name);
+void BinaryInput::read_scalar<int>(int& A, const std::string& name);
 template
-void BinaryInput::read_scaler<double>(double& A, const std::string& name);
+void BinaryInput::read_scalar<double>(double& A, const std::string& name);
 
 
 template <typename T>
@@ -965,7 +965,7 @@ bool HDF5Input::has_array(const char *name) const
 }
 
 template <typename T>
-void HDF5Input::read_scaler(T& A, const std::string& name)
+void HDF5Input::read_scalar(T& A, const std::string& name)
 {
     hid_t dset_id = H5Dopen2(file_id, name.c_str(), H5P_DEFAULT);
     if (dset_id < 0) {
@@ -1013,9 +1013,9 @@ void HDF5Input::read_scaler(T& A, const std::string& name)
 }
 
 template
-void HDF5Input::read_scaler<int>(int& A, const std::string& name);
+void HDF5Input::read_scalar<int>(int& A, const std::string& name);
 template
-void HDF5Input::read_scaler<double>(double& A, const std::string& name);
+void HDF5Input::read_scalar<double>(double& A, const std::string& name);
 
 template <typename T>
 void HDF5Input::read_array(std::vector<T>& A, const char *name, std::size_t size)

--- a/binaryio.hpp
+++ b/binaryio.hpp
@@ -62,7 +62,7 @@ public:
     bool has_array(const char *name) const;
 
     template <typename T>
-    void read_scaler(T& A, const std::string& name);
+    void read_scalar(T& A, const std::string& name);
 
     template <typename T>
     void read_array(std::vector<T>& A, const char *name, std::size_t size = 0);
@@ -135,7 +135,7 @@ public:
     bool has_array(const char *name) const;
 
     template <typename T>
-    void read_scaler(T& A, const std::string& name);
+    void read_scalar(T& A, const std::string& name);
 
     template <typename T>
     void read_array(std::vector<T>& A, const char *name, std::size_t size = 0);

--- a/binaryio.hpp
+++ b/binaryio.hpp
@@ -32,6 +32,9 @@ public:
     ~BinaryOutput();
 
     template <typename T>
+    void write_scalar(const T& A, const std::string& name);
+
+    template <typename T>
     void write_array(const std::vector<T>& A, const char *name, std::size_t size);
 
     void write_array(const std::vector<uint>& A, const char *name, std::size_t size);
@@ -57,6 +60,9 @@ public:
     ~BinaryInput();
 
     bool has_array(const char *name) const;
+
+    template <typename T>
+    void read_scaler(T& A, const std::string& name);
 
     template <typename T>
     void read_array(std::vector<T>& A, const char *name, std::size_t size = 0);

--- a/brc-interpolation.cxx
+++ b/brc-interpolation.cxx
@@ -238,10 +238,10 @@ void prepare_interpolation(const Param& param, const Variables &var,
                 * The one-level expansion above fails when q lies in a large old element
                 * whose nearest node nn is not one of its vertices (common after aggressive
                 * 3D remeshing that places new nodes far from any existing node).
-                * BFS guarantees every reachable element is visited and the correct
-                * enclosing element is found.  When the frontier empties without finding
-                * q, it is outside the old domain and falls through to the nearest-node
-                * fallback below.
+                * BFS visits neighbors level-by-level (capped by MAX_LAYERS below) and will
+                * typically find the enclosing element even after aggressive remeshing. If
+                * the capped search does not find q, it may be outside the old domain and
+                * will fall through to the nearest-node fallback below.
                 */
                 std::unordered_set<int> visited(nn_elem.begin(), nn_elem.end());
                 int_vec frontier(nn_elem.begin(), nn_elem.end());

--- a/brc-interpolation.cxx
+++ b/brc-interpolation.cxx
@@ -1,5 +1,6 @@
 #include "algorithm"
 #include "iostream"
+#include "unordered_set"
 
 #include "constants.hpp"
 #include "parameters.hpp"
@@ -223,70 +224,82 @@ void prepare_interpolation(const Param& param, const Variables &var,
 
             /* not_found */
 
-        {
-            /* Situation: q is in the upper element, but its nearest point is o!
-             * we won't find the enclosing element with the method above
-             *     x
-             *    / \   <-- this is a large triangle
-             *   / q                            \
-             *  x---- x
-             *   \-o-/   <-- this is a small triangle
-             */
+            {
+                /* Situation: q is in the upper element, but its nearest point is o!
+                * we won't find the enclosing element with the method above
+                *     x
+                *    / \   <-- this is a large triangle
+                *   / q                            \
+                *  x---- x
+                *   \-o-/   <-- this is a small triangle
+                *
+                * True Breadth-First Search (BFS) outward from nn's element support, 
+                * expanding level by level.
+                * The one-level expansion above fails when q lies in a large old element
+                * whose nearest node nn is not one of its vertices (common after aggressive
+                * 3D remeshing that places new nodes far from any existing node).
+                * BFS guarantees every reachable element is visited and the correct
+                * enclosing element is found.  When the frontier empties without finding
+                * q, it is outside the old domain and falls through to the nearest-node
+                * fallback below.
+                */
+                std::unordered_set<int> visited(nn_elem.begin(), nn_elem.end());
+                int_vec frontier(nn_elem.begin(), nn_elem.end());
+                // Track the element where q is least outside (highest min bary coord).
+                // Used post-BFS to distinguish boundary-face vs. clearly-outside vs. bug.
+                int    best_e_bfs    = nn_elem.empty() ? 0 : nn_elem[0];
+                double best_min_bary = -1e30;
 
-            // this array contains the elements that have been searched so far
-                const int MAX_SEARCH = 256;
-                int searched[MAX_SEARCH];
-                int n_searched = 0;
-
-                // Initialize searched with nn_elem
-                for (std::size_t k=0; k<nn_elem.size(); ++k) {
-                    if (n_searched < MAX_SEARCH) {
-                        searched[n_searched++] = nn_elem[k];
-                    }
-                }
-
-                // search through elements that are neighbors of nn_elem
-                for (std::size_t j=0; j<nn_elem.size(); j++) {
-                    int ee = nn_elem[j];
-                    ConstConnAccessor conn = old_connectivity[ee];
-                    for (int m=0; m<NODES_PER_ELEM; m++) {
-                        // np is a node close to q
-                        int np = conn[m];
-                        const int_vec &np_elem = old_support[np];
-                        for (std::size_t jj=0; jj<np_elem.size(); jj++) {
-                            e = np_elem[jj];
-
-                            // Check if e is already in searched
-                            bool found_in_searched = false;
-                            for (int k=0; k<n_searched; ++k) {
-                                if (searched[k] == e) {
-                                    found_in_searched = true;
-                                    break;
+                while (!frontier.empty()) {
+                    int_vec next_frontier;
+                    for (int ee : frontier) {
+                        ConstConnAccessor conn = old_connectivity[ee];
+                        for (int m=0; m<NODES_PER_ELEM; m++) {
+                            // np is a node close to q
+                            int np = conn[m];
+                            const int_vec &np_elem = old_support[np];
+                            for (std::size_t jj=0; jj<np_elem.size(); jj++) {
+                                int candidate = np_elem[jj];
+                                if (!visited.insert(candidate).second) continue;
+                                bary.transform(q, candidate, r);
+                                // min bary coord = how far inside (negative means outside)
+                                double min_bary = r[0];
+                                for (int d = 1; d < NDIMS; d++)
+                                    if (r[d] < min_bary) min_bary = r[d];
+                                double last = 1.0;
+                                for (int d = 0; d < NDIMS; d++) last -= r[d];
+                                if (last < min_bary) min_bary = last;
+                                if (min_bary > best_min_bary) {
+                                    best_min_bary = min_bary;
+                                    best_e_bfs = candidate;
                                 }
-                            }
-
-                            if (found_in_searched) {
-                            // this element has been searched before
-                                continue;
-                            }
-
-                            if (n_searched < MAX_SEARCH) {
-                                searched[n_searched++] = e;
-                            } else {
-                                printf("Error: barycentric_node_interpolation prepare_interpolation: ");
-                                printf("MAX_SEARCH (%d) exceeded for node %d.\n", MAX_SEARCH, i);
-                                std::exit(11);
-                            }
-
-                            bary.transform(q, e, r);
-                        // std::cout << e << " ";
-                        // print(std::cout, r, NDIMS);
-                        // std::cout << " ... \n";
-                            if (bary.is_inside(r)) {
-                                goto found;
+                                if (bary.is_inside(r)) {
+                                    e = candidate;
+                                    goto found;
+                                }
+                                next_frontier.push_back(candidate);
                             }
                         }
                     }
+                    frontier = std::move(next_frontier);
+                }
+                // BFS exhausted without finding q.
+                // best_min_bary > -1e-10: q is numerically on a face (FP tolerance
+                //   missed it) — use best_e_bfs directly, no fallback needed.
+                if (best_min_bary > -1e-10) {
+                    e = best_e_bfs;
+                    bary.transform(q, e, r);
+                    goto found;
+                }
+                // For all other cases, distinguish by bcflag of the new node:
+                //   bcflag == 0: interior node — might be inside old domain, BFS failure might be a bug.
+                //   bcflag != 0: boundary node — may sit just outside the old mesh after
+                //                remeshing; nearest-node fallback is correct.
+                if ((*var.bcflag)[i] == 0) {
+                    printf("Warning: prepare_interpolation: interior node %d (bcflag=0) "
+                           "not found after full BFS (%zu/%d elements searched), "
+                           "best_min_bary=%.3e. Mesh connectivity may be broken.\n",
+                           i, visited.size(), (int)old_connectivity.size(), best_min_bary);
                 }
             }
             {

--- a/brc-interpolation.cxx
+++ b/brc-interpolation.cxx
@@ -250,7 +250,8 @@ void prepare_interpolation(const Param& param, const Variables &var,
                 int    best_e_bfs    = nn_elem.empty() ? 0 : nn_elem[0];
                 double best_min_bary = -1e30;
 
-                while (!frontier.empty()) {
+                const int MAX_LAYERS = 3;
+                for (int layer = 0; layer < MAX_LAYERS && !frontier.empty(); layer++) {
                     int_vec next_frontier;
                     for (int ee : frontier) {
                         ConstConnAccessor conn = old_connectivity[ee];
@@ -297,9 +298,9 @@ void prepare_interpolation(const Param& param, const Variables &var,
                 //                remeshing; nearest-node fallback is correct.
                 if ((*var.bcflag)[i] == 0) {
                     printf("Warning: prepare_interpolation: interior node %d (bcflag=0) "
-                           "not found after full BFS (%zu/%d elements searched), "
+                           "not found after capped BFS (MAX_LAYERS=%d; %zu/%d elements searched), "
                            "best_min_bary=%.3e. Mesh connectivity may be broken.\n",
-                           i, visited.size(), (int)old_connectivity.size(), best_min_bary);
+                           i, MAX_LAYERS, visited.size(), (int)old_connectivity.size(), best_min_bary);
                 }
             }
             {

--- a/dynearthsol.cxx
+++ b/dynearthsol.cxx
@@ -947,7 +947,10 @@ int main(int argc, const char* argv[])
         nvtxRangePop();
 #endif
 
-    } while (var.steps < param.sim.max_steps && var.time <= param.sim.max_time_in_yr * YEAR2SEC);
+    } while (var.steps < param.sim.max_steps &&
+             (var.time <= param.sim.max_time_in_yr * YEAR2SEC ||
+              (param.sim.is_outputting_averaged_fields &&
+               var.steps % param.mesh.quality_check_step_interval != 0)));
 
     monitor_finalize(var);
 

--- a/dynearthsol.cxx
+++ b/dynearthsol.cxx
@@ -332,6 +332,10 @@ void restart(const Param& param, Variables& var)
         bin_chkpt.read_scaler(var.reference_frame_time, "reference_frame_time");
     }
 
+    if (var.steps % param.mesh.quality_check_step_interval == 0 &&
+        var.steps >= var.info_display_next_step)
+        var.info_display_next_step = var.steps + param.sim.info_display_step_interval;
+
     // Initializing field variables
     {
         bin_save.read_array(*var.vel, "velocity");

--- a/dynearthsol.cxx
+++ b/dynearthsol.cxx
@@ -228,31 +228,6 @@ void restart(const Param& param, Variables& var)
 {
     std::cout << "Initializing mesh and field data from checkpoints...\n";
 
-    /* Reading info file */
-    {
-        char filename[256];
-        std::snprintf(filename, 255, "%s.info", param.sim.restarting_from_modelname.c_str());
-        std::FILE *f = std::fopen(filename, "r");
-        int frame, steps, nnode, nelem, nseg;
-        while (1) {
-            int n = std::fscanf(f, "%d %d %*f %*f %*f %d %d %d\n",
-                                &frame, &steps, &nnode, &nelem, &nseg);
-            if (n != 5) {
-                std::cerr << "Error: reading info file: " << filename << '\n';
-                std::exit(2);
-            }
-            if (frame == param.sim.restarting_from_frame)
-                break;
-        }
-
-        var.steps = steps;
-        var.nnode = nnode;
-        var.nelem = nelem;
-        var.nseg = nseg;
-
-        std::fclose(f);
-    }
-
     char filename_save[256];
 #ifdef HDF5
     std::snprintf(filename_save, 255, "%s.save.%06d.vtkhdf",
@@ -264,6 +239,49 @@ void restart(const Param& param, Variables& var)
     BinaryInput bin_save(filename_save);
 #endif
     std::cout << "  Reading " << filename_save << "...\n";
+
+    char filename[256];
+    std::snprintf(filename, 255, "%s.info", param.sim.restarting_from_modelname.c_str());
+    bool got_meta = false;
+    std::FILE *f = std::fopen(filename, "r");
+    if (f != NULL) {
+        int frame, steps, nnode, nelem, nseg;
+        while (1) {
+            int n = std::fscanf(f, "%d %d %*f %*f %*f %d %d %d\n",
+                                &frame, &steps, &nnode, &nelem, &nseg);
+            if (n != 5) break;   // EOF or malformed line: stop scanning, fall back
+            if (frame == param.sim.restarting_from_frame) {
+                var.steps = steps;
+                var.nnode = nnode;
+                var.nelem = nelem;
+                var.nseg = nseg;
+                got_meta = true;
+                break;
+            }
+        }
+        std::fclose(f);
+        if (!got_meta) {
+            std::cerr << "Error: frame " << param.sim.restarting_from_frame
+                    << " not found in " << filename << ".\n";
+            exit(2);
+        }
+    } else {
+        std::cerr << "Warning: cannot open info file " << filename
+                << "; using metadata embedded in " << filename_save << ".\n";
+    }
+
+    if (!got_meta) {
+        if (bin_save.has_array("steps") && bin_save.has_array("nseg")) {
+            bin_save.read_scaler(var.steps, "steps");
+            bin_save.read_scaler(var.nnode, "nnode");
+            bin_save.read_scaler(var.nelem, "nelem");
+            bin_save.read_scaler(var.nseg, "nseg");
+        } else {
+            std::cerr << "Error: cannot read frame metadata from " << filename
+                      << " and " << filename_save << " has none embedded.\n";
+            std::exit(2);
+        }
+    }
 
     char filename_chkpt[256];
 #ifdef HDF5

--- a/dynearthsol.cxx
+++ b/dynearthsol.cxx
@@ -627,7 +627,7 @@ int main(int argc, const char* argv[])
         restart(param, var);
     }
 
-    var.dt_PT = var.dt;
+    // var.dt_PT = var.dt;
 
 #ifdef HAS_GOSPL_CPP_INTERFACE
     // Initialize GoSPL driver if surface process option is 11

--- a/dynearthsol.cxx
+++ b/dynearthsol.cxx
@@ -373,6 +373,8 @@ void restart(const Param& param, Variables& var)
         // for tidal heating
         bin_save.read_array(*var.viscosity, "viscosity");
         bin_save.read_array(*var.force, "force");
+        // delta_plstrain carries per-element state across steps:
+        bin_save.read_array(*var.delta_plstrain, "plastic strain-rate");
     }
 
     compute_volume(*var.coord, *var.connectivity, *var.volume);

--- a/dynearthsol.cxx
+++ b/dynearthsol.cxx
@@ -323,7 +323,6 @@ void restart(const Param& param, Variables& var)
 
     // Misc. items
     {
-#ifdef HDF5
         bin_chkpt.read_scaler(var.time, "time");
         bin_chkpt.read_scaler(var.info_display_next_step, "info_display_next_step");
         bin_chkpt.read_scaler(var.compensation_pressure, "compensation_pressure");
@@ -331,17 +330,6 @@ void restart(const Param& param, Variables& var)
         bin_chkpt.read_scaler(var.dt, "dt");
         bin_chkpt.read_scaler(var.max_global_vel_mag, "max_global_vel_mag");
         bin_chkpt.read_scaler(var.reference_frame_time, "reference_frame_time");
-#else
-        double_vec tmp(7);
-        bin_chkpt.read_array(tmp, "time info_display_next_step compensation_pressure bottom_temperature dt max_global_vel_mag reference_frame_time");
-        var.time = tmp[0];
-        var.info_display_next_step = tmp[1];
-        var.compensation_pressure = tmp[2];
-        var.bottom_temperature = tmp[3];
-        var.dt = tmp[4];
-        var.max_global_vel_mag = tmp[5];
-        var.reference_frame_time = tmp[6];
-#endif
     }
 
     // Initializing field variables

--- a/dynearthsol.cxx
+++ b/dynearthsol.cxx
@@ -272,10 +272,10 @@ void restart(const Param& param, Variables& var)
 
     if (!got_meta) {
         if (bin_save.has_array("steps") && bin_save.has_array("nseg")) {
-            bin_save.read_scaler(var.steps, "steps");
-            bin_save.read_scaler(var.nnode, "nnode");
-            bin_save.read_scaler(var.nelem, "nelem");
-            bin_save.read_scaler(var.nseg, "nseg");
+            bin_save.read_scalar(var.steps, "steps");
+            bin_save.read_scalar(var.nnode, "nnode");
+            bin_save.read_scalar(var.nelem, "nelem");
+            bin_save.read_scalar(var.nseg, "nseg");
         } else {
             std::cerr << "Error: cannot read frame metadata from " << filename
                       << " and " << filename_save << " has none embedded.\n";
@@ -341,13 +341,13 @@ void restart(const Param& param, Variables& var)
 
     // Misc. items
     {
-        bin_chkpt.read_scaler(var.time, "time");
-        bin_chkpt.read_scaler(var.info_display_next_step, "info_display_next_step");
-        bin_chkpt.read_scaler(var.compensation_pressure, "compensation_pressure");
-        bin_chkpt.read_scaler(var.bottom_temperature, "bottom_temperature");
-        bin_chkpt.read_scaler(var.dt, "dt");
-        bin_chkpt.read_scaler(var.max_global_vel_mag, "max_global_vel_mag");
-        bin_chkpt.read_scaler(var.reference_frame_time, "reference_frame_time");
+        bin_chkpt.read_scalar(var.time, "time");
+        bin_chkpt.read_scalar(var.info_display_next_step, "info_display_next_step");
+        bin_chkpt.read_scalar(var.compensation_pressure, "compensation_pressure");
+        bin_chkpt.read_scalar(var.bottom_temperature, "bottom_temperature");
+        bin_chkpt.read_scalar(var.dt, "dt");
+        bin_chkpt.read_scalar(var.max_global_vel_mag, "max_global_vel_mag");
+        bin_chkpt.read_scalar(var.reference_frame_time, "reference_frame_time");
     }
 
     if (var.steps % param.mesh.quality_check_step_interval == 0 &&

--- a/examples/defaults.cfg
+++ b/examples/defaults.cfg
@@ -59,6 +59,10 @@ resolution = 30e3
 
 ### For 2d mesh quality
 #min_angle = 32.
+### Cap on Triangle Steiner points as a multiple of the input node count (2d only).
+### Bounds the non-terminating segment splitting Triangle can enter on a highly
+### distorted mesh (two boundary segments at a tiny angle). <= 0 disables the cap.
+#max_steiner_factor = 30.
 ### For 3d mesh quality
 #min_tet_angle = 22.
 #max_ratio = 2.0

--- a/fields.cxx
+++ b/fields.cxx
@@ -746,22 +746,22 @@ void update_velocity(const Variables& var, array_t& vel)
 #endif
 }
 
-void update_velocity_PT(const Variables& var, array_t& vel)
-{
-#ifdef NPROF_DETAIL
-    nvtxRangePush(__FUNCTION__);
-#endif
+// void update_velocity_PT(const Variables& var, array_t& vel)
+// {
+// #ifdef NPROF_DETAIL
+//     nvtxRangePush(__FUNCTION__);
+// #endif
 
-    #pragma omp parallel for default(none) shared(var, vel)
-    // #pragma acc parallel loop
-    for (int i=0; i<var.nnode; ++i)
-        for (int j=0;j<NDIMS;j++)
-            vel[i][j] += var.dt_PT * (*var.force)[i][j] / (*var.mass)[i];
+//     #pragma omp parallel for default(none) shared(var, vel)
+//     // #pragma acc parallel loop
+//     for (int i=0; i<var.nnode; ++i)
+//         for (int j=0;j<NDIMS;j++)
+//             vel[i][j] += var.dt_PT * (*var.force)[i][j] / (*var.mass)[i];
 
-#ifdef NPROF_DETAIL
-    nvtxRangePop();
-#endif
-}
+// #ifdef NPROF_DETAIL
+//     nvtxRangePop();
+// #endif
+// }
 
 void update_coordinate(const Variables& var, array_t& coord)
 {

--- a/fields.hpp
+++ b/fields.hpp
@@ -13,7 +13,7 @@ void update_force(const Param& param, const Variables& var, array_t& force, arra
     elem_cache& tmp_result);
 double calculate_residual_force(const Variables& var, array_t& vel);
 void update_velocity(const Variables& var, array_t& vel);
-void update_velocity_PT(const Variables& var, array_t& vel);
+// void update_velocity_PT(const Variables& var, array_t& vel);
 void update_coordinate(const Variables& var, array_t& coord);
 void rotate_stress(const Variables &var, tensor_t &stress, tensor_t &strain);
 

--- a/geometry.cxx
+++ b/geometry.cxx
@@ -922,100 +922,100 @@ double compute_dt(const Param& param, Variables& var)
     return dt;
 }
 
-double compute_dt_PT(const Param& param, const Variables& var)
-{
-#ifdef NPROF_DETAIL
-    nvtxRangePush(__FUNCTION__);
-#endif
-    // constant dt
-    if (param.control.fixed_dt != 0) return param.control.fixed_dt;
+// double compute_dt_PT(const Param& param, const Variables& var)
+// {
+// #ifdef NPROF_DETAIL
+//     nvtxRangePush(__FUNCTION__);
+// #endif
+//     // constant dt
+//     if (param.control.fixed_dt != 0) return param.control.fixed_dt;
 
-    // dynamic dt
-    double dt_maxwell = std::numeric_limits<double>::max();
-    double dt_diffusion = std::numeric_limits<double>::max();
-    double dt_hydro_diffusion = std::numeric_limits<double>::max();
-    double minl = std::numeric_limits<double>::max();
+//     // dynamic dt
+//     double dt_maxwell = std::numeric_limits<double>::max();
+//     double dt_diffusion = std::numeric_limits<double>::max();
+//     double dt_hydro_diffusion = std::numeric_limits<double>::max();
+//     double minl = std::numeric_limits<double>::max();
 
-    #pragma omp parallel for reduction(min:minl,dt_maxwell,dt_diffusion,dt_hydro_diffusion)    \
-        default(none) shared(param,var)
-    // #pragma acc parallel loop reduction(min:minl, dt_maxwell, dt_diffusion,dt_hydro_diffusion)
-    for (int e=0; e<var.nelem; ++e) {
-        int n0 = (*var.connectivity)[e][0];
-        int n1 = (*var.connectivity)[e][1];
-        int n2 = (*var.connectivity)[e][2];
+//     #pragma omp parallel for reduction(min:minl,dt_maxwell,dt_diffusion,dt_hydro_diffusion)    \
+//         default(none) shared(param,var)
+//     // #pragma acc parallel loop reduction(min:minl, dt_maxwell, dt_diffusion,dt_hydro_diffusion)
+//     for (int e=0; e<var.nelem; ++e) {
+//         int n0 = (*var.connectivity)[e][0];
+//         int n1 = (*var.connectivity)[e][1];
+//         int n2 = (*var.connectivity)[e][2];
 
-        ConstArrayAccessor a = (*var.coord)[n0];
-        ConstArrayAccessor b = (*var.coord)[n1];
-        ConstArrayAccessor c = (*var.coord)[n2];
+//         ConstArrayAccessor a = (*var.coord)[n0];
+//         ConstArrayAccessor b = (*var.coord)[n1];
+//         ConstArrayAccessor c = (*var.coord)[n2];
 
-        // min height of this element
-        double minh;
-#ifdef THREED
-        {
-            int n3 = (*var.connectivity)[e][3];
-            ConstArrayAccessor d = (*var.coord)[n3];
+//         // min height of this element
+//         double minh;
+// #ifdef THREED
+//         {
+//             int n3 = (*var.connectivity)[e][3];
+//             ConstArrayAccessor d = (*var.coord)[n3];
 
-            // max facet area of this tet
-            double maxa = std::max(std::max(triangle_area(a, b, c),
-                                            triangle_area(a, b, d)),
-                                   std::max(triangle_area(c, d, a),
-                                            triangle_area(c, d, b)));
-            minh = 3 * (*var.volume)[e] / maxa;
-        }
-#else
-        {
-            // max edge length of this triangle
-            double maxl = std::sqrt(std::max(std::max(dist2(a, b),
-                                                      dist2(b, c)),
-                                             dist2(a, c)));
-            minh = 2 * (*var.volume)[e] / maxl;
-        }
-#endif
-        dt_maxwell = std::min(dt_maxwell,
-                              0.5 * var.mat->visc_min / (1e-40 + var.mat->shearm(e)));
-        // if (param.control.has_thermal_diffusion)
-        //     dt_diffusion = std::min(dt_diffusion,
-        //                             0.5 * minh * minh / var.mat->therm_diff_max);
+//             // max facet area of this tet
+//             double maxa = std::max(std::max(triangle_area(a, b, c),
+//                                             triangle_area(a, b, d)),
+//                                    std::max(triangle_area(c, d, a),
+//                                             triangle_area(c, d, b)));
+//             minh = 3 * (*var.volume)[e] / maxa;
+//         }
+// #else
+//         {
+//             // max edge length of this triangle
+//             double maxl = std::sqrt(std::max(std::max(dist2(a, b),
+//                                                       dist2(b, c)),
+//                                              dist2(a, c)));
+//             minh = 2 * (*var.volume)[e] / maxl;
+//         }
+// #endif
+//         dt_maxwell = std::min(dt_maxwell,
+//                               0.5 * var.mat->visc_min / (1e-40 + var.mat->shearm(e)));
+//         // if (param.control.has_thermal_diffusion)
+//         //     dt_diffusion = std::min(dt_diffusion,
+//         //                             0.5 * minh * minh / var.mat->therm_diff_max);
         
-        // // Compute dt_hydro_diffusion (hydraulic)
-        // if (var.mat->hydro_diff_max > 0) {
-        //     dt_hydro_diffusion = std::min(dt_hydro_diffusion,
-        //                                   0.5 * minh * minh / var.mat->hydro_diff_max);
-        // }
-        minl = std::min(minl, minh);
-    }
+//         // // Compute dt_hydro_diffusion (hydraulic)
+//         // if (var.mat->hydro_diff_max > 0) {
+//         //     dt_hydro_diffusion = std::min(dt_hydro_diffusion,
+//         //                                   0.5 * minh * minh / var.mat->hydro_diff_max);
+//         // }
+//         minl = std::min(minl, minh);
+//     }
 
 
-    // max_vbc_val is maximum boundary velocity
-    double max_vbc_val;
-    if (param.control.characteristic_speed == 0) {
-        max_vbc_val = var.max_vbc_val; 
+//     // max_vbc_val is maximum boundary velocity
+//     double max_vbc_val;
+//     if (param.control.characteristic_speed == 0) {
+//         max_vbc_val = var.max_vbc_val; 
 
-        if (param.control.surface_process_option > 0)
-            max_vbc_val = std::max(max_vbc_val, var.surfinfo.max_surf_vel*5e-1);
-    }
-    else
-        max_vbc_val = param.control.characteristic_speed;
+//         if (param.control.surface_process_option > 0)
+//             max_vbc_val = std::max(max_vbc_val, var.surfinfo.max_surf_vel*5e-1);
+//     }
+//     else
+//         max_vbc_val = param.control.characteristic_speed;
 
-    double dt_advection = 0.5 * minl / max_vbc_val;
-    double dt_elastic = (param.control.is_quasi_static) ?
-        0.5 * minl / (max_vbc_val * param.control.inertial_scaling) :
-        0.5 * minl / std::sqrt(param.mat.bulk_modulus[param.mat.mattype_ref] / param.mat.rho0[param.mat.mattype_ref]);
+//     double dt_advection = 0.5 * minl / max_vbc_val;
+//     double dt_elastic = (param.control.is_quasi_static) ?
+//         0.5 * minl / (max_vbc_val * param.control.inertial_scaling) :
+//         0.5 * minl / std::sqrt(param.mat.bulk_modulus[param.mat.mattype_ref] / param.mat.rho0[param.mat.mattype_ref]);
 
-    double dt = std::min({dt_elastic, dt_maxwell, dt_advection}) * param.control.dt_fraction;
-    if (param.debug.dt) {
-        std::cout << "step #" << var.steps << "  dt: " << dt_maxwell << " " << dt_advection << " " << dt_elastic << " sec\n";
-    }
-    if (dt <= 0) {
-        std::cerr << "Error: dt <= 0!  " << dt_maxwell << " "  << dt_advection << " " << dt_elastic << "\n";
-        var.output->write_exact_error(var);
-        std::exit(11);
-    }
-#ifdef NPROF_DETAIL
-    nvtxRangePop();
-#endif
-    return dt;
-}
+//     double dt = std::min({dt_elastic, dt_maxwell, dt_advection}) * param.control.dt_fraction;
+//     if (param.debug.dt) {
+//         std::cout << "step #" << var.steps << "  dt: " << dt_maxwell << " " << dt_advection << " " << dt_elastic << " sec\n";
+//     }
+//     if (dt <= 0) {
+//         std::cerr << "Error: dt <= 0!  " << dt_maxwell << " "  << dt_advection << " " << dt_elastic << "\n";
+//         var.output->write_exact_error(var);
+//         std::exit(11);
+//     }
+// #ifdef NPROF_DETAIL
+//     nvtxRangePop();
+// #endif
+//     return dt;
+// }
 
 void compute_mass(const Param &param, const Variables &var,
                   double max_vbc_val, double_vec &volume_n,

--- a/geometry.cxx
+++ b/geometry.cxx
@@ -865,7 +865,7 @@ double compute_dt(const Param& param, Variables& var)
         minl = std::min(minl, minh);
 
         // Find global min delta t to meet CFL condition
-        global_dt_min = std::min(global_dt_min, minl/std::sqrt(var.mat->shearm(e)/var.mat->rho(e)) /5.0);
+        global_dt_min = std::min(global_dt_min, minh/std::sqrt(var.mat->shearm(e)/var.mat->rho(e)) /5.0);
     }
 
     #pragma acc wait

--- a/geometry.hpp
+++ b/geometry.hpp
@@ -27,16 +27,8 @@ void spr_node_to_elem(const Param& param, const Variables& var,
                       tensor_t* stress, double_vec* stressyy);
 
 double compute_dt(const Param& param, Variables& var);
-// double compute_dt(const Param& param, const Variables& var);
 
-double compute_dt_PT(const Param& param, const Variables& var);
-
-// void compute_mass(const Param &param, const Variables &var,
-//                   double max_vbc_val, double_vec &volume_n,
-//                   double_vec &mass, double_vec &tmass, double_vec &hmass,
-//                   elem_cache &tmp_result);
-
-double compute_dt_PT(const Param& param, const Variables& var);
+// double compute_dt_PT(const Param& param, const Variables& var);
 
 void compute_mass(const Param &param, const Variables &var,
                   double max_vbc_val, double_vec &volume_n,

--- a/input.cxx
+++ b/input.cxx
@@ -176,6 +176,14 @@ static void declare_parameters(po::options_description &cfg,
         // for 2D only
         ("mesh.min_angle", po::value<double>(&p.mesh.min_angle)->default_value(32.),
          "Min. angle of all triangles (in degrees), for 2D only")
+        ("mesh.max_steiner_factor", po::value<double>(&p.mesh.max_steiner_factor)->default_value(30.),
+         "Cap on the number of Steiner points Triangle may insert while (re)meshing, "
+         "expressed as a multiple of the number of input nodes (2D only). This bounds the "
+         "pathological, non-terminating segment splitting that Triangle can enter when two "
+         "boundary segments meet at a very small angle (e.g. a highly distorted mesh at "
+         "extreme strain), which would otherwise spin forever and exhaust memory. The cap is "
+         "far above any healthy remesh, so normal meshing is unaffected. Set <= 0 to disable "
+         "the cap (Triangle default: unlimited).")
         // for 3D only
         ("mesh.min_tet_angle", po::value<double>(&p.mesh.min_tet_angle)->default_value(22.),
          "Min. dihedral angle of all tetrahedra (in degrees), for 3D only")

--- a/markerset.cxx
+++ b/markerset.cxx
@@ -899,9 +899,9 @@ template <class T>
 void MarkerSet::read_chkpt_file(Variables &var, T &bin_save, T &bin_chkpt)
 {
 #ifdef HDF5
-    bin_save.read_scaler(_nmarkers, _name + ".nmarkers");
-    bin_chkpt.read_scaler(_last_id, _name + ".last_id");
-    bin_chkpt.read_scaler(_reserved_space, _name + ".reserved_space");
+    bin_save.read_scalar(_nmarkers, _name + ".nmarkers");
+    bin_chkpt.read_scalar(_last_id, _name + ".last_id");
+    bin_chkpt.read_scalar(_reserved_space, _name + ".reserved_space");
 #else
     int_vec itmp(3);
     bin_chkpt.read_array(itmp, (_name + " size").c_str());

--- a/markerset.cxx
+++ b/markerset.cxx
@@ -1811,7 +1811,7 @@ void remap_markers(const Param& param, Variables &var, const array_t &old_coord,
     int nunplenished = 0;
 
 #ifndef ACC
-    #pragma omp parallel default(none) shared(param, var) reduction(+:nunplenished)
+    #pragma omp parallel for default(none) shared(param, var) reduction(+:nunplenished)
 #endif
     #pragma acc parallel loop gang vector reduction(+:nunplenished)
     for (int e = 0; e < var.nelem; e++) {

--- a/markerset.cxx
+++ b/markerset.cxx
@@ -326,9 +326,25 @@ void MarkerSet::set_surface_marker(const Param& param,const Variables& var, cons
 
         // height of marker
         double dv_apply = (*var.volume)[e] / nmarkers;
-        edvacc[i] -= dv_apply;
-
         double edh = dv_apply / base;
+
+        // Guard against a DEGENERATE (near-zero-area) surface facet -- e.g. a collapsed "cliff" at a
+        // convergent trench. There dv_apply/base blows up, so the marker (placed edh below the
+        // surface) lands absurdly far down (observed z ~ -2.5e13 m for a 1.5e5 m-deep domain), where
+        // it cannot be located in any element -- the old code then aborted the whole run (exit 168).
+        // A well-formed deposit sits a small fraction of an element below the surface (edh << element
+        // size); only a degenerate facet drives edh past the element's own scale. Skip deposition on
+        // such a facet and KEEP edvacc, so it deposits once the next remesh regularises the surface.
+        double char_size = std::sqrt((*var.volume)[e]);
+#ifdef THREED
+        char_size = std::cbrt((*var.volume)[e]);
+#endif
+        if (!(base > 0.0) || edh > 2.0 * char_size) {
+            (*var.etmp_int)[i] = -1;   // no marker from this facet this step
+            continue;
+        }
+
+        edvacc[i] -= dv_apply;
         mcoord[NDIMS-1] -= edh * marker_dh_applied_ratio;
 
         ConstArrayIndirectAccessor coord1 = var.coord->view_const((*var.connectivity)[e]);
@@ -345,20 +361,15 @@ void MarkerSet::set_surface_marker(const Param& param,const Variables& var, cons
             remap_marker(var, mcoord, e, elem_dest, eta0, inc);
 
             if (!inc) {
-                // msg += "... Success!\n";
-                // printf("%s", msg.c_str());
-            // } else {
-                char buffer[200];
-                sprintf(buffer, "  A generated marker (mat=%d) in element %7d is trying to remap in elements ",
-                        mattype, e);
-                std::string msg(buffer);
-                printf("%s", msg.c_str());
-                printf("... Surface marker generated fail!\n Coordinate: ");
+                // The degenerate-facet guard above prevents the known trench pathology. A deposited
+                // marker that STILL cannot be located in element e's neighbourhood is unexpected, so
+                // fail fast with the offending geometry rather than silently dropping the sediment.
+                printf("  A generated marker (mat=%d) in element %d could not be remapped"
+                       " -- Surface marker generated fail! Coordinate:", mattype, e);
                 for (int j=0; j<NDIMS; j++) printf(" %f", mcoord[j]);
-                printf("\neta: ");
-                for (int j=0; j<NDIMS; j++) printf(" %d %f", j, eta0[j]); 
+                printf("  eta:");
+                for (int j=0; j<NDIMS; j++) printf(" %f", eta0[j]);
                 printf("\n");
-
                 std::exit(168);
             }
         }

--- a/mesh.cxx
+++ b/mesh.cxx
@@ -245,7 +245,6 @@ void create_elem_from_cell(const Variables& var, int *&connectivity) {
     connectivity = new int[var.nelem*NODES_PER_ELEM];
 #ifndef THREED
 
-    #pragma acc parallel loop gang vector collapse(2)
     for (int i = 0; i < var.nx - 1; ++i) {
         for (int j = 0; j < var.nz - 1; ++j) {
             int idx = i * (var.nz - 1) + j;
@@ -300,7 +299,6 @@ void create_rect_node(const Param& param, const Variables& var, double *&points)
 #endif
 
 #ifndef THREED
-    #pragma acc parallel loop gang vector collapse(2)
     for (int i = 0; i < var.nx; ++i) {
         for (int j = 0; j < var.nz; ++j) {
             points[(j + i * var.nz)*2] = i * dx;

--- a/mesh.cxx
+++ b/mesh.cxx
@@ -117,6 +117,33 @@ void set_2d_quality_str(std::string &quality, double min_angle)
 }
 
 
+void set_steiner_str(std::string &steiner, double max_steiner_factor, int npoints,
+                     double max_area)
+{
+    // Triangle's -S switch caps the number of Steiner points (vertices not in the
+    // input) it may insert. Without it (steinerleft == -1), Triangle's encroached-
+    // subsegment splitting can fail to terminate when two input segments meet at a
+    // very small angle -- each split encroaches the other, forever (see the loop at
+    // triangle.c splitencsegs()). A cap set well above any healthy remesh bounds this
+    // runaway without changing the mesh in the normal case, because steinerleft never
+    // reaches 0.
+    //
+    // The cap is factor*npoints, so it is only meaningful when the output size stays
+    // close to the input size -- i.e. during remeshing (max_area < 0, no area target).
+    // When an area constraint is active (initial meshing), the legitimate point count
+    // is driven by max_area rather than npoints, so the cap must NOT be applied or it
+    // would truncate a perfectly good mesh.
+    steiner.clear();
+    if (max_steiner_factor > 0 && npoints > 0 && max_area < 0) {
+        long cap = (long)(max_steiner_factor * npoints);
+        if (cap < 1) cap = 1;
+        if (cap > 100000000L) cap = 100000000L; // keep within int, far above any real need
+        steiner += 'S';
+        steiner += std::to_string(cap);
+    }
+}
+
+
 void create_quadrilateral_cells(Variables &var, int *&cells) {
 #ifndef THREED
     cells = new int[(var.nx-1)*(var.nz-1)*4];
@@ -660,7 +687,7 @@ void new_mesh_regular_equilateral(const Param& param, Variables& var)
 
 void triangulate_polygon
 (double min_angle, double max_area,
- int meshing_verbosity,
+ int meshing_verbosity, double max_steiner_factor,
  int npoints, int nsegments,
  const double *points, const int *segments, const int *segflags,
  const int nregions, const double *regionattributes,
@@ -671,15 +698,16 @@ void triangulate_polygon
     char options[255];
     triangulateio in, out;
 
-    std::string verbosity, vol, quality;
+    std::string verbosity, vol, quality, steiner;
     set_verbosity_str(verbosity, meshing_verbosity);
     set_volume_str(vol, max_area);
     set_2d_quality_str(quality, min_angle);
+    set_steiner_str(steiner, max_steiner_factor, npoints, max_area);
 
     if( nregions > 0 )
-        std::sprintf(options, "%s%spjz%sA", verbosity.c_str(), quality.c_str(), vol.c_str());
+        std::sprintf(options, "%s%spjz%s%sA", verbosity.c_str(), quality.c_str(), vol.c_str(), steiner.c_str());
     else
-        std::sprintf(options, "%s%spjz%s", verbosity.c_str(), quality.c_str(), vol.c_str());
+        std::sprintf(options, "%s%spjz%s%s", verbosity.c_str(), quality.c_str(), vol.c_str(), steiner.c_str());
 
     if( meshing_verbosity >= 0 )
         std::cout << "The meshing option is: " << options << '\n';
@@ -2597,7 +2625,7 @@ void points_to_new_mesh(const Mesh &mesh, int npoints, const double *points,
 #else
 
     triangulate_polygon(mesh.min_angle, max_elem_size,
-                        mesh.meshing_verbosity,
+                        mesh.meshing_verbosity, mesh.max_steiner_factor,
                         npoints, n_init_segments, points,
                         init_segments, init_segflags,
                         n_regions, regattr,
@@ -2630,7 +2658,7 @@ void points_to_new_surface(const Mesh &mesh, int npoints, const double *points,
     /* For triangulation of boundary surfaces in 3D */
 
     triangulate_polygon(mesh.min_angle, max_elem_size,
-                        mesh.meshing_verbosity,
+                        mesh.meshing_verbosity, mesh.max_steiner_factor,
                         npoints, n_init_segments, points,
                         init_segments, init_segflags,
                         n_regions, regattr,

--- a/output.cxx
+++ b/output.cxx
@@ -122,7 +122,19 @@ void Output::_write(const Variables& var, bool disable_averaging)
 
     bin.write_array(*var.coord, "coordinate", var.coord->size());
     bin.write_array(*var.connectivity, "connectivity", var.connectivity->size());
+
+    // Scalars completing the .info row (frame, steps, time, dt, walltime,
+    // nnode, nelem, nseg) so utils/recreate_info.py can rebuild a lost
+    // .info from the frame files alone.
+    bin.write_scalar(var.steps, "steps");
+    bin.write_scalar(double(run_time_ns) * 1e-9, "walltime_sec");
+    bin.write_scalar(var.nnode, "nnode");
+    bin.write_scalar(var.nelem, "nelem");
 #endif
+
+    bin.write_scalar(var.time, "time_sec");
+    bin.write_scalar(dt, "dt_sec");
+    bin.write_scalar(var.nseg, "nseg");
 
     bin.write_nodal_vec_array(*var.vel, "velocity", var.vel->size());
     if (!disable_averaging && is_averaged) {

--- a/output.cxx
+++ b/output.cxx
@@ -352,6 +352,10 @@ void Output::write_checkpoint(const Param& param, const Variables& var)
                    may_overwrite_ && (frame == start_frame_));
 
     bin.write_block_metadata(var, "grid");
+#else
+    std::snprintf(filename, 255, "%s.chkpt.%06d", modelname.c_str(), frame);
+    BinaryOutput bin(filename, may_overwrite_ && (frame == start_frame_));
+#endif
 
     bin.write_scalar(var.time, "time");
     bin.write_scalar(var.info_display_next_step, "info_display_next_step");
@@ -360,20 +364,6 @@ void Output::write_checkpoint(const Param& param, const Variables& var)
     bin.write_scalar(var.dt, "dt");
     bin.write_scalar(var.max_global_vel_mag, "max_global_vel_mag");
     bin.write_scalar(var.reference_frame_time, "reference_frame_time");
-#else
-    std::snprintf(filename, 255, "%s.chkpt.%06d", modelname.c_str(), frame);
-    BinaryOutput bin(filename, may_overwrite_ && (frame == start_frame_));
-
-    double_vec tmp(7);
-    tmp[0] = var.time;
-    tmp[1] = var.info_display_next_step;
-    tmp[2] = var.compensation_pressure;
-    tmp[3] = var.bottom_temperature;
-    tmp[4] = var.dt;
-    tmp[5] = var.max_global_vel_mag;
-    tmp[6] = var.reference_frame_time;
-    bin.write_array(tmp, "time info_display_next_step compensation_pressure bottom_temperature dt max_global_vel_mag reference_frame_time", tmp.size());
-#endif
 
     bin.write_array(*var.segment, "segment", var.segment->size());
     bin.write_array(*var.segflag, "segflag", var.segflag->size());

--- a/parameters.hpp
+++ b/parameters.hpp
@@ -646,7 +646,7 @@ class MarkerSet;
 struct Variables {
     double time;
     double dt;
-    double dt_PT;
+    // double dt_PT;
     double l2_residual;
     double reference_frame_time;
     int steps;

--- a/parameters.hpp
+++ b/parameters.hpp
@@ -183,6 +183,7 @@ struct Mesh {
     double largest_size;
     double sediment_size;
     double min_angle;  // for 2D only
+    double max_steiner_factor; // cap Triangle Steiner points at factor*npoints; <=0 unlimited (2D only)
     double min_tet_angle, max_ratio; // for 3D only
     double min_quality;
     double max_boundary_distortion;

--- a/remeshing.cxx
+++ b/remeshing.cxx
@@ -978,7 +978,12 @@ void delete_points_and_merge_facets(const int_vec &points_to_delete,
 }
 
 
-void delete_points_on_boundary(int_vec &points_to_delete,
+// Delete every point in points_to_delete, merging the neighbouring boundary
+// segments (2D) / facets (3D) for the points that lie on a boundary so the
+// boundary stays closed. Non-boundary points are simply removed. This is the
+// deletion path for remeshing_option >= 10 (boundaries may be modified); it fully
+// handles the removal, so the caller must NOT also call delete_points().
+void delete_points_and_merge_boundary(int_vec &points_to_delete,
                                const int_vec (&bnodes)[nbdrytypes],
                                const int_vec (&bdry_polygons)[nbdrytypes],
                                const array_t &bnormals,
@@ -1236,12 +1241,19 @@ void new_mesh(const Param &param, Variables &var, int bad_quality,
     case 11:
     case 12:
     case 13:
-        // deleting points, some of them might be on the boundary
-        delete_points_on_boundary(points_to_delete, old_bnodes, bdry_polygons, *var.bnormals,
+        // deleting points, some of them might be on the boundary.
+        // delete_points_and_merge_boundary() already removes every point in
+        // points_to_delete (merging segments for the boundary ones) and reduces
+        // old_nnode accordingly. Calling delete_points() again on the same list
+        // would be a *second* deletion pass over an already-compacted array with
+        // now-stale indices: its swap-delete + std::replace(segment, end, *i)
+        // rewrites the boundary segments of the highest-index nodes (typically the
+        // most recently added surface/corner nodes), which detaches the top surface
+        // from the side wall and collapses the corner into a spurious cliff. Do NOT
+        // call delete_points() here.
+        delete_points_and_merge_boundary(points_to_delete, old_bnodes, bdry_polygons, *var.bnormals,
                                   old_nnode, old_nseg,
                                   qcoord, qsegment, qsegflag, old_bcflag, min_dist);
-        delete_points(points_to_delete, old_nnode, old_nseg,
-                      qcoord, qsegment);
         break;
     }
 

--- a/remeshing.cxx
+++ b/remeshing.cxx
@@ -3075,8 +3075,13 @@ void remesh(const Param &param, Variables &var, int bad_quality)
     for (int e=0; e<var.nelem; ++e)
         (*var.volume_old)[e] = (*var.volume)[e] / (1.0 + (*var.volume_old)[e]);
 
-    if(param.control.use_global_velocity_scaling)
-        var.dt = compute_dt(param, var);
+    // Refresh dt on the NEW mesh unconditionally. dt is otherwise only recomputed every
+    // slow_updates_interval (10) steps in the main loop, so a remesh that refines the mesh
+    // (smaller minl -> smaller stable dt) would run up to 10 steps on the stale, too-large
+    // dt -- enough for an explicit CFL runaway to invert elements (then the step-10
+    // compute_dt hits negative volumes and dies with "dt <= 0"). compute_mass below
+    // consumes var.dt, so the refresh must come first.
+    var.dt = compute_dt(param, var);
     compute_mass(param, var, var.max_vbc_val, *var.volume_n, *var.mass, *var.tmass, *var.hmass, *var.ymass, *var.tmp_result);
 
 

--- a/rheology.cxx
+++ b/rheology.cxx
@@ -775,6 +775,15 @@ void update_stress(const Param& param, Variables& var, tensor_t& stress,
             de[i] = edot[i] * var.dt;
         }
 
+        // delta_plstrain is the plastic-strain increment of THIS step (output as
+        // "plastic strain-rate" after /dt, and read by the earthquake-state check). Only the
+        // plastic branches write it, so clear it here: an evp/evp_rsf element that takes the
+        // viscous branch, or an elastic/viscous/maxwell element, would otherwise keep the value
+        // from the last time it yielded forever. That stale value is then smeared across the
+        // mesh by the nearest-neighbour remap at each remesh, growing a spurious nonzero halo
+        // that diffuses out of the yielding zones. Resetting to 0 makes it a true per-step rate.
+        delta_plstrain[e] = 0.;
+
         switch (param.mat.rheol_type) {
         case MatProps::rh_elastic:
             {

--- a/utils/recreate_info.py
+++ b/utils/recreate_info.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+'''Recreate <modelname>.info from DynEarthSol .save.NNNNNN[.vtkhdf] frame files.
+
+Dynearthsol.py and restart read the frame files directly by default, so this
+script is only needed to materialize the file again (e.g. for tools that
+parse .info themselves). It rebuilds it from the per-frame metadata written by output.cxx:
+FieldData in HDF5 (.vtkhdf) frames, or header scalars in plain binary frames.
+
+Frames written before this metadata was added get 0 in the missing columns
+(HDF5 frames always had steps/time; old binary frames have neither and are
+rejected). Dynearthsol.py does not read the dt/walltime/nseg columns.
+
+Usage: python utils/recreate_info.py <modelname> [-f]
+       <modelname> may include a directory prefix, no extension.
+'''
+from __future__ import print_function
+import argparse, os, sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from Dynearthsol import scan_frames
+
+# must match Output::write_info() in output.cxx
+ROW_FMT = '%6d\t%10d\t%12.6e\t%12.4e\t%12.6e\t%8d\t%8d\t%8d\n'
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument('modelname', help='model output path prefix, no extension')
+    p.add_argument('-f', '--force', action='store_true',
+                   help='overwrite an existing .info (backed up to .info.bak)')
+    args = p.parse_args()
+
+    info_path = args.modelname + '.info'
+    if os.path.exists(info_path) and not args.force:
+        print('Error: %s already exists; use -f to overwrite (backs it up to .bak)'
+              % info_path, file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        frames = scan_frames(args.modelname)
+    except (OSError, KeyError) as e:
+        print('Error: %s' % e, file=sys.stderr)
+        sys.exit(2)
+
+    if not frames:
+        print('Error: no %s.save.* frame files found' % args.modelname,
+              file=sys.stderr)
+        sys.exit(1)
+
+    rows = []
+    n_missing = 0
+    for d in frames:
+        if d['dt'] is None or d['nseg'] is None:
+            n_missing += 1
+        rows.append(ROW_FMT % (d['frame'], d['steps'], d['time'],
+                               d['dt'] or 0.0, d['walltime'],
+                               d['nnode'], d['nelem'], d['nseg'] or 0))
+
+    if n_missing:
+        print('Warning: %d/%d frames predate dt_sec/nseg frame metadata; '
+              'those columns are written as 0 (unused by Dynearthsol.py)'
+              % (n_missing, len(rows)), file=sys.stderr)
+
+    if os.path.exists(info_path):
+        os.replace(info_path, info_path + '.bak')
+        print('Backed up existing file to %s.bak' % info_path)
+
+    with open(info_path, 'w') as f:
+        f.writelines(rows)
+    print('Wrote %s (%d frames)' % (info_path, len(rows)))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

Regular maintenance update (2026-07): 26 commits of bug fixes and robustness work accumulated in six groups — remeshing robustness, boundary conditions, time stepping and parallel loops, restart/output metadata, GPU fixes, and build/tooling.

## Remeshing robustness

- **Boundary point deletion merged segments incorrectly** — `delete_points_on_boundary()` (renamed `delete_points_and_merge_boundary()`) already fully removes the points and merges the adjacent boundary segments; the caller ran `delete_points()` again on the same list, a second deletion pass over an already-compacted array with stale indices. That rewrote the boundary segments of the highest-index nodes, detaching the top surface from the side wall and collapsing the corner into a spurious cliff.
- **`mesh.max_steiner_factor` (new parameter, default 30, 2D only)** — caps Triangle's Steiner-point insertion at `factor × npoints` during remeshing. Bounds the non-terminating encroached-subsegment splitting Triangle enters when two boundary segments meet at a tiny angle (highly distorted mesh at extreme strain), which otherwise spins forever and exhausts memory. Applied only when no area constraint is active, so initial meshing is unaffected; `<= 0` disables.
- **True BFS in barycentric interpolation** — the enclosing-element search after remeshing only expanded one neighbor level and hard-exited at a fixed 256-element cap. Now a level-by-level BFS (capped at 3 layers, `unordered_set` dedup) with a best-candidate tolerance for nodes numerically on a face, and a nearest-node fallback for boundary nodes that legitimately fall just outside the old mesh. Interior nodes that still fail print a diagnostic instead of dying.
- **dt refreshed unconditionally after remeshing** — dt is otherwise recomputed only every `slow_updates_interval` steps, so a remesh that refines the mesh could run up to 10 steps on a stale, too-large dt — enough for an explicit CFL runaway to invert elements. `compute_mass` consumes `var.dt`, so the refresh comes first.
- **Sediment deposition guarded against degenerate surface facets** — a near-zero-area facet (collapsed "cliff" at a convergent trench) made `dv_apply/base` blow up, placing the marker ~10¹³ m below the domain and aborting the run (exit 168). Deposition on such a facet is skipped for the step (volume accumulator kept, so it deposits after the next remesh regularizes the surface).

## Boundary conditions

- **Open-sidewall lithostatic traction floored at zero** — for wall facets above the datum, `ref_pressure` options 0/4 extrapolate linearly negative, flipping the support traction into an outward suction that pulls the topographic strip out of the domain. The true exterior there is air/vacuum. Below the datum the clamp is inert, so normal runs are bit-identical.

## Time stepping & parallel loops

- **`compute_dt` read its own min-reduction accumulator inside the loop** — the S-wave CFL bound `global_dt_min` was computed from `minl`, the `reduction(min:)` accumulator holding the smallest element height seen *so far*, instead of `minh`, the current element's own min height. Each thread therefore read its private partial minimum, so the bound depended on thread count and loop schedule, and — because `minl <= minh` always holds — came out systematically too small. `global_dt_min` is the floor applied to `dt_elastic` (`dt_elastic = max(dt_elastic, global_dt_min)`), so the floor was weaker than intended and dt was not reproducible across `OMP_NUM_THREADS`. Now uses `minh`.
- **Missing `for` in the `remap_markers` unplenished-element scan** — `#pragma omp parallel default(none) ... reduction(+:nunplenished)` opened a parallel region without distributing the element loop, so every thread walked all `nelem` elements. The stores are idempotent (each thread writes the same value into `var.etmp_int[e]`), so no field was corrupted, but the sweep ran `nthreads` times and `nunplenished` came out `nthreads`× too large — it only feeds `unplenished_elems.reserve()`, so the visible cost was the duplicated work and the over-reservation. The paired `#pragma acc parallel loop` was already correct.

## Restart & output metadata

- **Frame files now embed the full `.info` row** (steps, time, dt, walltime, nnode, nelem, nseg) — as FieldData in HDF5 frames and named header scalars in plain binary frames. `restart()` falls back to the embedded metadata when the `.info` file is missing, and the new `utils/recreate_info.py` rebuilds a deleted `.info` from the frame files alone. `Dynearthsol.py` gains `scan_frames()` to read the per-frame metadata directly.
- **`plastic strain-rate` read back at restart** — `delta_plstrain` carries per-element state across steps but was never restored, so restarted runs diverged from continuous ones.
- **`delta_plstrain` reset each step** — only the plastic branches write it, so an element that stopped yielding kept its last increment forever; the NN remap then smeared that fossil across the mesh at each remesh into a growing spurious halo. Clearing it at the top of `update_stress` makes "plastic strain-rate" a true per-step rate. Diagnostic-only: no feedback into the physics.
- **Final averaged-fields frame reached past `max_time`** — with `is_outputting_averaged_fields` the run now continues to the next averaging-aligned step so the last frame is written instead of silently dropped.
- **`info_display_next_step` made consistent at restart**, and the non-HDF5 checkpoint scalars converted from one packed 7-double array to named scalars via new `BinaryOutput::write_scalar` / `BinaryInput::read_scalar` (matching the existing HDF5 reader API).
- **File format revision centralized and bumped to 4** — a single `BINARY_FILE_REVISION` macro (with revision notes) replaces the hard-coded `revision=3` in the plain-binary header string *and* the literal `3` written into the HDF5 `revision` attribute, so the two formats can no longer drift apart. The header string is built from `NDIMS` and the macro with `std::to_string` instead of preprocessor string pasting, with the `std::strcat`/`strncmp`/length calls adapted to `std::string`. The bump records the named-scalar checkpoint layout introduced in this branch.
- **HDF5 header now validated on read** — `HDF5Input::read_header()` exits with a diagnostic naming the expected and actual values when the file's `ndims` or `revision` does not match the running binary, matching what the plain-binary reader already did for its revision string. Previously a 2D file fed to a 3D binary, or a file in an older format, was accepted silently and misread.

## GPU (OpenACC)

- Fixed device data management for `zmin` in `apply_vbcs` (2D): the reduction result was never made present on the device for the subsequent kernel.
- Fixed 2D regular-mesh generation under GPU builds: `create_elem_from_cell` / `create_rect_node` write host-allocated arrays and must not be ACC kernels.

## Build & tooling

- macOS/clang: `OPENMP_RPATH` uses an absolute path instead of `@executable_path`, so the binary runs from any working directory (e.g. `benchmarks-cores` subdirectory runs).
- `benchmarks-cores/Makefile`: new `INDIR=1` option runs each case in its own `model-<CASE>-<MODELNAME>` subdirectory to avoid clobbering output from other runs.
- Unused pseudo-transient (PT) solver remnants (`compute_dt_PT`, `update_velocity_PT`, `var.dt_PT`) commented out.
- **CI workflows now clean the configuration they rebuild** — `clean` removes only `$(OBJS)`/`$(EXE)`, whose names depend on `ndims` and the OpenACC suffix, so the previous bare `make clean` only removed default-config (3D, non-GPU) objects. A `make ndims=2` step after an earlier 2D build with different flags (e.g. `opt=0 openmp=0`) silently reused the stale objects, since flags are not encoded in object names. All build steps in `basic-build`, `macos-build`, `mmg-build`, and `nvc-build` now pass the matching `ndims=`/`openacc=1` to their clean invocation.

## Compatibility notes

- **Output/checkpoint format revision bumped 3 → 4, and mismatches are now hard errors.** `.chkpt` scalars are individual named entries instead of one packed array, and both readers reject a mismatching revision — so files written before this branch cannot be restarted by the new binary. This now applies to HDF5 as well as plain binary: the HDF5 `revision` attribute is bumped and checked (together with `ndims`), where previously it was written as `3` and never verified. Failures are explicit diagnostics rather than silent misreads. Restart also expects the `plastic strain-rate` array in the save frame (present in all existing output). The Python readers (`Dynearthsol.py`, `2vtk.py`) parse the revision without enforcing a value, so post-processing of both old and new files is unaffected.
- New parameter `mesh.max_steiner_factor` defaults to 30 (documented in `examples/defaults.cfg`); set `<= 0` for the old unlimited behavior.

## Testing

- 2D build verified on macOS arm64 (clang++, Homebrew boost/HDF5/libomp).
- The remeshing and restart fixes were each validated on long-running 2D convergent-margin simulations (multi-Myr, thousands of remeshes) where the original failures reproduced; restart determinism was checked bit-exact against continuous runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
