### PR TITLE
build: locate HDF5 automatically on Linux and macOS

### DIFF
--- a/.github/workflows/basic-build.yml
+++ b/.github/workflows/basic-build.yml
@@ -32,13 +32,6 @@ jobs:
         echo Install boost-program-options and hdf5 ====================
         sudo apt-get update
         sudo apt-get install -y libboost-program-options-dev libhdf5-serial-dev make pkg-config
-    - name: set path for hdf5
-      run: |
-        HDF5_INCLUDE_DIR=$(pkg-config --cflags hdf5-serial | sed 's/-I//g')
-        HDF5_LIB_DIR=$(pkg-config --libs hdf5-serial | tr ' ' '\n' | grep '^-L' | sed 's/^-L//')
-        echo "HDF5_INCLUDE_DIR=${HDF5_INCLUDE_DIR}" >> $GITHUB_ENV
-        echo "HDF5_LIB_DIR=${HDF5_LIB_DIR}" >> $GITHUB_ENV
-  
     - name: make debug 2d
       run: make clean ndims=2; make ndims=2 opt=0 openmp=0 hdf5=0
     - name: make debug 3d
@@ -48,8 +41,8 @@ jobs:
     - name: make 3d
       run: make clean ndims=3; make ndims=3 opt=2 openmp=1 hdf5=0
     - name: make 3d hdf5
-      run: make clean ndims=3; make ndims=3 opt=2 openmp=1 hdf5=1 \
-            HDF5_LIB_DIR=$HDF5_LIB_DIR HDF5_INCLUDE_DIR=$HDF5_INCLUDE_DIR
+      # No HDF5_*_DIR: the Makefile finds the paths itself.
+      run: make clean ndims=3; make ndims=3 opt=2 openmp=1 hdf5=1
     # - name: make check
     #   run: make check
     # - name: make distcheck

--- a/.github/workflows/basic-build.yml
+++ b/.github/workflows/basic-build.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: get boost and hdf5
       run: |
         echo Install boost-program-options and hdf5 ====================

--- a/.github/workflows/exodus-build.yml
+++ b/.github/workflows/exodus-build.yml
@@ -24,7 +24,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: get exodus
       run: |
         sudo apt update

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -43,17 +43,10 @@ jobs:
         echo Install boost-program-options and hdf5 ====================
         sudo apt-get update
         sudo apt-get install -y libboost-program-options-dev libhdf5-serial-dev make pkg-config
-    - name: set path for hdf5
-      run: |
-        HDF5_INCLUDE_DIR=$(pkg-config --cflags hdf5-serial | sed 's/-I//g')
-        HDF5_LIB_DIR=$(pkg-config --libs hdf5-serial | tr ' ' '\n' | grep '^-L' | sed 's/^-L//')
-        echo "HDF5_INCLUDE_DIR=${HDF5_INCLUDE_DIR}" >> $GITHUB_ENV
-        echo "HDF5_LIB_DIR=${HDF5_LIB_DIR}" >> $GITHUB_ENV
-  
     - name: make 3d hdf5
       working-directory: .
-      run: make -j ndims=3 opt=2 openmp=1 hdf5=1 \
-            HDF5_LIB_DIR=$HDF5_LIB_DIR HDF5_INCLUDE_DIR=$HDF5_INCLUDE_DIR
+      # No HDF5_*_DIR here or below: the Makefile finds the paths itself.
+      run: make -j ndims=3 opt=2 openmp=1 hdf5=1
 
     - name: test 3d evp regular remesh temp-dome
       run: ../../dynearthsol3d 3d-evp-regular.cfg && rm -rf functional-test.*
@@ -64,8 +57,7 @@ jobs:
 
     - name: make 2d hdf5
       working-directory: .
-      run: make -j ndims=2 opt=2 openmp=1 hdf5=1 \
-            HDF5_LIB_DIR=$HDF5_LIB_DIR HDF5_INCLUDE_DIR=$HDF5_INCLUDE_DIR
+      run: make -j ndims=2 opt=2 openmp=1 hdf5=1
 
     - name: test 2d ep irregular remesh
       run: ../../dynearthsol2d 2d-ep-irregular.cfg && rm -rf functional-test.*
@@ -79,8 +71,7 @@ jobs:
 
     - name: make 3d hdf5 opt=-1
       working-directory: .
-      run: make cleanall && make -j ndims=3 opt=-1 openmp=1 hdf5=1 \
-            HDF5_LIB_DIR=$HDF5_LIB_DIR HDF5_INCLUDE_DIR=$HDF5_INCLUDE_DIR
+      run: make cleanall && make -j ndims=3 opt=-1 openmp=1 hdf5=1
 
     - name: test memory leak 3d evp regular remesh temp-dome
       run: ../../dynearthsol3d 3d-evp-regular.cfg && rm -rf functional-test.*

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -28,7 +28,7 @@ jobs:
       run:
         working-directory: ./tests/functional
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/workflows/get-g++version.yml
+++ b/.github/workflows/get-g++version.yml
@@ -26,6 +26,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: get g++ version
       run: g++ --version

--- a/.github/workflows/gospl-build.yml
+++ b/.github/workflows/gospl-build.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install system dependencies
       run: |

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -57,7 +57,8 @@ jobs:
     - name: make 3d
       run: make clean ndims=3; make ndims=3 opt=2 openmp=1 BOOST_ROOT_DIR=$(brew --prefix boost)
     - name: make 3d hdf5
+      # No HDF5_*_DIR: the Makefile finds the paths itself, and on macOS it
+      # picks the Homebrew prefix matching the build architecture rather than
+      # whichever brew happens to be first on PATH.
       run: make clean ndims=3; make ndims=3 opt=2 openmp=1 hdf5=1
             BOOST_ROOT_DIR=$(brew --prefix boost)
-            HDF5_INCLUDE_DIR=$(brew --prefix hdf5)/include
-            HDF5_LIB_DIR=$(brew --prefix hdf5)/lib

--- a/.github/workflows/mmg-build.yml
+++ b/.github/workflows/mmg-build.yml
@@ -24,7 +24,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: get boost
       run: |
         sudo apt update

--- a/.github/workflows/nvc-build.yml
+++ b/.github/workflows/nvc-build.yml
@@ -136,14 +136,10 @@ jobs:
     - name: Fix git safe directory
       run: git config --global --add safe.directory '*'
 
-    - name: set path for nvc and hdf5 (${{ matrix.ndims }}D)
+    - name: set path for nvc (${{ matrix.ndims }}D)
+      # No HDF5_*_DIR: the Makefile finds the paths itself.
       run: |
-        HDF5_INC=$(pkg-config --cflags-only-I hdf5-serial | sed 's/-I//g' | tr -d ' ')
-        HDF5_LIB=$(pkg-config --libs-only-L hdf5-serial | sed 's/-L//g' | tr -d ' ')
-        
-        echo "HDF5_INCLUDE_DIR=$HDF5_INC" >> $GITHUB_ENV
-        echo "HDF5_LIB_DIR=$HDF5_LIB" >> $GITHUB_ENV
-        echo "BASE_MAKE=make hdf5=1 NVHPC_DIR=$NVHPC_DIR HDF5_LIB_DIR=$HDF5_LIB HDF5_INCLUDE_DIR=$HDF5_INC" >> $GITHUB_ENV
+        echo "BASE_MAKE=make hdf5=1 NVHPC_DIR=$NVHPC_DIR" >> $GITHUB_ENV
 
     - name: make ndims=${{ matrix.ndims }} openacc=1 SM=80 hdf5=1
       run: make clean openacc=1 ndims=${{ matrix.ndims }} && $BASE_MAKE ndims=${{ matrix.ndims }} openacc=1 hdf5=1 SM=80 -j

--- a/Makefile
+++ b/Makefile
@@ -120,9 +120,13 @@ ifeq ($(HDF5_DETECT), yes)
 		endif
 	endif
 
-	## Without a .pc file, probe the layouts real installs use. Debian splits
-	## the serial build across two trees, so the header and the library are
-	## searched separately instead of under one prefix.
+	## Without a .pc file, probe the layouts real installs use -- Fedora and
+	## RHEL need this branch unconditionally, as their hdf5-devel ships no
+	## pkg-config file at all. Debian splits its serial build across two trees
+	## (/usr/include/hdf5/serial and .../hdf5/serial under the multiarch libdir),
+	## so the header and the library are searched separately, not under one
+	## prefix. /usr/local comes before the system directories so a hand-built
+	## HDF5 installed there wins over the distro package.
 	ifeq ($(strip $(HDF5_INCLUDE_DIR)),)
 		HDF5_INCLUDE_DIR := $(shell for d in \
 				$(HDF5_BREW)/opt/hdf5/include \
@@ -134,8 +138,9 @@ ifeq ($(HDF5_DETECT), yes)
 		HDF5_LIB_DIR := $(shell for d in \
 				$(HDF5_BREW)/opt/hdf5/lib \
 				/usr/lib/$(shell uname -m)-linux-gnu/hdf5/serial \
-				/usr/local/lib \
-				/usr/lib/$(shell uname -m)-linux-gnu /usr/lib; do \
+				/usr/local/lib /usr/local/lib64 \
+				/usr/lib/$(shell uname -m)-linux-gnu \
+				/usr/lib64 /usr/lib; do \
 			ls $$d/libhdf5.* >/dev/null 2>&1 && { echo $$d; break; }; done)
 	endif
 

--- a/Makefile
+++ b/Makefile
@@ -66,9 +66,97 @@ else
 endif
 CXX_BACKEND = ${CXX}
 
-## path to HDF5's base directory, if not in standard system location
-HDF5_INCLUDE_DIR = #/path/to/include/hdf5/serial
-HDF5_LIB_DIR = #/path/to/lib/x86_64-linux-gnu/hdf5/serial
+## path to HDF5's base directory. Leave both blank to auto-detect; set them
+## (here or on the command line) to force one specific install -- an HPC
+## module, a conda env, a hand-built HDF5 -- which skips detection entirely.
+## The layouts the search below knows about, if you would rather set them:
+##   Debian/Ubuntu  /usr/include/hdf5/serial  /usr/lib/<arch>-linux-gnu/hdf5/serial
+##   Fedora/RHEL    /usr/include              /usr/lib64
+##   Homebrew       $(brew --prefix hdf5)/include  $(brew --prefix hdf5)/lib
+HDF5_INCLUDE_DIR = #/usr/include/hdf5/serial
+HDF5_LIB_DIR = #/usr/lib/x86_64-linux-gnu/hdf5/serial
+
+ifeq ($(hdf5), 1)
+## Every stage below fills only what is still blank, so a path set by hand is
+## never overwritten, and setting just one of the two still leaves the other
+## detected instead of empty (a blank -L would eat the -lhdf5 that follows it).
+HDF5_DETECT :=
+ifeq ($(strip $(HDF5_INCLUDE_DIR)),)
+	HDF5_DETECT := yes
+endif
+ifeq ($(strip $(HDF5_LIB_DIR)),)
+	HDF5_DETECT := yes
+endif
+ifeq ($(HDF5_DETECT), yes)
+	ifeq ($(OSNAME), Darwin)
+		## Homebrew has two prefixes -- /opt/homebrew (arm64) and /usr/local
+		## (x86_64) -- and a machine that has ever run the other one keeps its
+		## pkg-config and h5cc on PATH. Trusting PATH there silently links an
+		## HDF5 of the wrong architecture, so choose the prefix by host arch
+		## and use that prefix's own pkg-config.
+		ifeq ($(shell uname -m), arm64)
+			HDF5_BREW = /opt/homebrew
+		else
+			HDF5_BREW = /usr/local
+		endif
+		PKGCONFIG := $(HDF5_BREW)/bin/pkg-config
+	else
+		HDF5_BREW =
+		PKGCONFIG := pkg-config
+	endif
+
+	## Ask pkg-config for directories rather than parsing --cflags/--libs:
+	## h5cc -show and --libs mix in inline .a paths and -lsz/-lz/-ldl, which
+	## are painful to filter and differ per build. Debian and Ubuntu name the
+	## serial module hdf5-serial; everyone else ships plain hdf5.
+	HDF5_PC := $(shell for m in hdf5 hdf5-serial; do \
+		$(PKGCONFIG) --exists $$m 2>/dev/null && { echo $$m; break; }; done)
+	ifneq ($(HDF5_PC),)
+		ifeq ($(strip $(HDF5_INCLUDE_DIR)),)
+			HDF5_INCLUDE_DIR := $(shell $(PKGCONFIG) --variable=includedir $(HDF5_PC))
+		endif
+		ifeq ($(strip $(HDF5_LIB_DIR)),)
+			HDF5_LIB_DIR := $(shell $(PKGCONFIG) --variable=libdir $(HDF5_PC))
+		endif
+	endif
+
+	## Without a .pc file, probe the layouts real installs use. Debian splits
+	## the serial build across two trees, so the header and the library are
+	## searched separately instead of under one prefix.
+	ifeq ($(strip $(HDF5_INCLUDE_DIR)),)
+		HDF5_INCLUDE_DIR := $(shell for d in \
+				$(HDF5_BREW)/opt/hdf5/include \
+				/usr/include/hdf5/serial \
+				/usr/local/include /usr/include; do \
+			test -f $$d/hdf5.h && { echo $$d; break; }; done)
+	endif
+	ifeq ($(strip $(HDF5_LIB_DIR)),)
+		HDF5_LIB_DIR := $(shell for d in \
+				$(HDF5_BREW)/opt/hdf5/lib \
+				/usr/lib/$(shell uname -m)-linux-gnu/hdf5/serial \
+				/usr/local/lib \
+				/usr/lib/$(shell uname -m)-linux-gnu /usr/lib; do \
+			ls $$d/libhdf5.* >/dev/null 2>&1 && { echo $$d; break; }; done)
+	endif
+
+	## Checked separately: finding one without the other is still unbuildable,
+	## and failing here beats a confusing link error hundreds of lines later.
+	## Indented with SPACES, not a tab: a tab-indented $(error) this early
+	## reads as a recipe line and make reports "commands commence before first
+	## target" instead of the message below.
+	ifeq ($(strip $(HDF5_INCLUDE_DIR)),)
+        $(error hdf5=1 but no HDF5 headers found. Install HDF5 (macOS: brew install hdf5; \
+Debian/Ubuntu: apt install libhdf5-dev; Fedora/RHEL: dnf install hdf5-devel), \
+or set the paths by hand: \
+make hdf5=1 HDF5_INCLUDE_DIR=/prefix/include HDF5_LIB_DIR=/prefix/lib)
+	endif
+	ifeq ($(strip $(HDF5_LIB_DIR)),)
+        $(error hdf5=1: found HDF5 headers in $(HDF5_INCLUDE_DIR) but no libhdf5. \
+Set HDF5_LIB_DIR to the directory holding libhdf5, \
+e.g. make hdf5=1 HDF5_LIB_DIR=/prefix/lib)
+	endif
+endif
+endif
 
 ## path to cuda's base directory
 NVHPC_DIR = # /cluster/nvidia/hpc_sdk/Linux_x86_64/21.2

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ git submodule update --init --recursive
       ```
     * The header files and built shared library will be in `mmg/build/include` and `mmg/build/lib`. 
 * [HDF5](https://www.hdfgroup.org/solutions/hdf5/) for outputting model results in HDF5-based vtkhdf format, which is compressed (reducing size by up to 50%) and can be visualized directly in Paraview.
-  * The HDF5 Library is generally pre-installed on modern computer operating systems. User can use `which h5cc` to find the path to the HDF5 Library.
+  * The HDF5 Library is generally pre-installed on modern computer operating systems; otherwise `brew install hdf5` (macOS), `apt install libhdf5-dev` (Debian/Ubuntu) or `dnf install hdf5-devel` (Fedora/RHEL). `make hdf5=1` locates it on its own, via `pkg-config` and then the usual install layouts.
+    * Prefer that search over `which h5cc`: on a Mac that has ever used both Homebrew prefixes, `h5cc` and `pkg-config` on `PATH` are often the `/usr/local` (x86_64) ones while the build is arm64, and their paths link an HDF5 of the wrong architecture. The Makefile picks the prefix matching the host architecture instead.
   * The HDF5-based vtkhdf format follows the data structure of VTK, which can be visualized directly in Paraview. Please refer to the official [VTKHDF File Format](https://docs.vtk.org/en/latest/vtk_file_formats/vtkhdf_file_format) documentation for more information.
 
 <div id="llvm"></div>
@@ -161,9 +162,13 @@ git submodule update --init --recursive
     * Set `use_gospl = 1`.
     * Set `GOSPL_EXT_DIR` and `CONDA_ENV_PATH` if they differ from the defaults (`~/opt/gospl_extensions` and `~/miniconda3/envs/gospl`).
   * If outputing in HDF5-based vtkhdf format:
-    * set `hdf5 = 1`.
-    * set `HDF5_INCLUDE_DIR` to the HDF5 header file directory.
-    * set `HDF5_LIB_DIR` to the HDF5 library directory.
+    * set `hdf5 = 1`. The paths are found automatically on Linux and macOS, so
+      normally there is nothing else to set.
+    * `HDF5_INCLUDE_DIR` and `HDF5_LIB_DIR` override that search. Set them
+      (in the Makefile or on the command line) to build against one specific
+      HDF5 -- an HPC module, a conda env, a hand-built copy:
+      `make hdf5=1 HDF5_INCLUDE_DIR=/prefix/include HDF5_LIB_DIR=/prefix/lib`.
+      Either one alone is enough; the other is still detected.
     * Install python HDF5 lib by `pip install h5py` for further analyzed vtk visualization.
   * If enabling openMP on macOS:
     *  set `OPENMP_ROOT_DIR` path if it differs from the default value.


### PR DESCRIPTION
`make hdf5=1` required editing `HDF5_INCLUDE_DIR` and `HDF5_LIB_DIR` by hand before the first build, on every new checkout and machine. It now finds them itself.

- **pkg-config first**, asked for `--variable=includedir/libdir` rather than parsing `--cflags`/`--libs`, which interleave inline `.a` paths with `-lsz/-lz/-ldl`. Debian/Ubuntu name the module `hdf5-serial`; everyone else ships `hdf5`.
- **Then the usual install layouts**: Homebrew, Debian's split multiarch serial build, `/usr/local`, `/usr/lib64`. Fedora and RHEL need this branch unconditionally — their `hdf5-devel` ships no `.pc` file at all.
- **On macOS the Homebrew prefix is chosen by host architecture, not by `PATH`.** A Mac that has used both prefixes keeps `/usr/local`'s (x86_64) `pkg-config` and `h5cc` ahead of `/opt/homebrew`'s, so following `PATH` hands an arm64 build the x86_64 library and fails at link.

Setting either variable still overrides detection, and each stage fills only what is blank, so a hand-set path is never overwritten. When HDF5 is genuinely missing the build stops with install advice instead of a confusing link error.

Also removes the now-redundant HDF5 path plumbing from four workflows (which had drifted into four different implementations), and moves the last six `actions/checkout@v3` to `@v4` — v3 runs on the deprecated Node 16, and checkout was the final such action in the repo.

No C++ changes.

## Testing

- **macOS arm64** — resolves to the arm64 Homebrew install with x86 `pkg-config`/`h5cc` still first on `PATH`; builds and runs.
- **Debian 12 container** — detects via pkg-config, and again via the path search with pkg-config uninstalled; full build links `libhdf5_serial.so.103`, runs, writes vtkhdf output.
- **Fedora 41 container** — resolves to `/usr/include` + `/usr/lib64`.
- **No HDF5 installed** — `hdf5=1` stops with install advice; `hdf5=0` builds normally.
- **`basic-build` run locally under `act`** (arm64 runner) — job green, all five builds, HDF5 discovered with nothing set by hand.
- Override permutations checked: both set, either alone, neither. 2D and 3D, `hdf5=0` and `hdf5=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
