### PR TITLE
ci: shrink the nvhpc build image so job containers start faster

### DIFF
--- a/.github/workflows/nvc-build.yml
+++ b/.github/workflows/nvc-build.yml
@@ -68,7 +68,7 @@ jobs:
         with:
           filters: |
             docker_changed:
-              - 'docker/Dockerfile.cuda'
+              - 'docker/**'
 
   build-and-push-image:
     needs: detect-changes
@@ -101,11 +101,17 @@ jobs:
         with:
           context: .
           file: ./docker/Dockerfile.cuda
-          push: true
           tags: ghcr.io/${{ env.REPO_LC }}/nvhpc-build-env:latest
 
+          # zstd layers decompress far faster than gzip, which is most of what
+          # "Starting job container" spends its time on. It needs OCI media
+          # types, and the provenance attestation is disabled so the pushed tag
+          # stays a plain image manifest for the runner to pull.
+          outputs: type=image,push=true,oci-mediatypes=true,compression=zstd,compression-level=3,force-compression=true
+          provenance: false
+
           cache-from: type=registry,ref=ghcr.io/${{ env.REPO_LC }}/nvhpc-build-env:buildcache
-          cache-to: type=registry,ref=ghcr.io/${{ env.REPO_LC }}/nvhpc-build-env:buildcache,mode=max
+          cache-to: type=registry,ref=ghcr.io/${{ env.REPO_LC }}/nvhpc-build-env:buildcache,mode=max,compression=zstd
 
   nvc-build:
     needs: [check-duplicate, detect-changes, build-and-push-image]

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -1,12 +1,84 @@
-FROM nvcr.io/nvidia/nvhpc:25.7-devel-cuda12.9-ubuntu24.04
+# Build environment for the nvc++ / OpenACC CI jobs (.github/workflows/nvc-build.yml).
+#
+# The upstream nvhpc devel image unpacks to roughly 20 GB, and GitHub-hosted
+# runners have no image cache between jobs, so every matrix job pays the full
+# pull under "Starting job container". These builds use only the compilers plus
+# the CUDA headers and libraries, so the rest of the SDK is deleted in a builder
+# stage and the survivors are copied onto a clean base. Deleting in a single
+# stage would not shrink the pull at all -- the parent layers would still carry
+# the files.
 
+FROM nvcr.io/nvidia/nvhpc:25.7-devel-cuda12.9-ubuntu24.04 AS sdk
+
+# Keep in sync with the image tag above.
+ENV NVHPC_DIR=/opt/nvidia/hpc_sdk/Linux_x86_64/25.7
+
+# comm_libs   MPI, NCCL, NVSHMEM      -- DynEarthSol is OpenMP/OpenACC only.
+# math_libs   cuBLAS, cuFFT, cuSOLVER -- nothing in the build links them.
+# profilers   Nsight Systems/Compute  -- CI compiles, it never profiles.
+# REDIST      deploy-time copies of the compiler runtimes.
+# The nvtx headers the nprof build needs live under cuda/, which is kept whole.
+RUN set -eux; \
+    du -sh "$NVHPC_DIR"; \
+    cd "$NVHPC_DIR"; \
+    rm -rf comm_libs math_libs profilers examples REDIST; \
+    du -sh "$NVHPC_DIR"
+
+
+# The Ubuntu release here MUST match the -ubuntu24.04 suffix of the image above:
+# nvc++ has no C++ standard library of its own and drives the system GNU
+# toolchain for headers, startup files and ld, using paths baked into
+# compilers/bin/localrc when the upstream image was built.
+FROM ubuntu:24.04
+
+ENV NVARCH=Linux_x86_64
+ENV NVHPC_DIR=/opt/nvidia/hpc_sdk/${NVARCH}/25.7
+# cuda/bin carries nvcc, which is a separate entry from compilers/bin in the
+# upstream image. knn-bvh calls nvcc unqualified and derives CUDA_HOME from
+# `which nvcc`, so dropping it here would both fail the compile and silently
+# point that build at the wrong include tree.
+ENV PATH=${NVHPC_DIR}/compilers/bin:${NVHPC_DIR}/cuda/bin:${PATH}
+ENV LD_LIBRARY_PATH=${NVHPC_DIR}/compilers/lib:${NVHPC_DIR}/cuda/lib64
+
+COPY --from=sdk /opt/nvidia/hpc_sdk /opt/nvidia/hpc_sdk
+
+# The devel image carried a full distro toolchain that a bare Ubuntu base does
+# not, and the build leans on more of it than just the compiler:
+#   gcc, g++       nvc++ has no standard library of its own (see the FROM note),
+#                  and the mmg build names them explicitly.
+#   git            the Makefile initialises the nanoflann, knn-bvh and mmg
+#                  submodules itself and aborts outright when git is missing;
+#                  the workflow also marks the checkout a safe.directory first.
+#   ca-certificates  so those submodule fetches can reach github.com.
+#   cmake          configures the mmg submodule for the usemmg=1 job.
 RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive \
     apt-get install -y --no-install-recommends \
+    ca-certificates \
+    cmake \
+    g++ \
+    gcc \
+    git \
     libboost-program-options-dev \
     libhdf5-serial-dev \
     make \
     pkg-config && \
     rm -rf /var/lib/apt/lists/*
 
-ENV NVARCH=Linux_x86_64
-ENV NVHPC_DIR=/opt/nvidia/hpc_sdk/${NVARCH}/25.7
+# Fail here, while the image is still being built, rather than after it has been
+# pushed to the :latest tag that every GPU branch pulls. The flags mirror what
+# the workflow's four make variants actually use, so that a prune which removed
+# something they need cannot reach the tag.
+COPY docker/acc_check.cxx docker/nvcc_check.cu /tmp/
+RUN set -eux; \
+    for tool in cmake g++ gcc git make nvc++ nvcc pkg-config; do \
+        command -v "$tool" >/dev/null || { echo "missing: $tool" >&2; exit 1; }; \
+    done; \
+    nvcc -std=c++14 -arch=sm_80 -dc /tmp/nvcc_check.cu -o /tmp/nvcc_check.o; \
+    nvc++ -acc=gpu -cuda -DACC -gpu=mem:managed -fopenmp -DNPROF \
+          -I"$NVHPC_DIR/cuda/include" -c /tmp/acc_check.cxx -o /tmp/acc_check.o; \
+    nvc++ -acc=gpu -gpu=mem:managed -cuda -fopenmp /tmp/acc_check.o \
+          $(pkg-config --libs hdf5-serial) -lboost_program_options \
+          -o /tmp/acc_check; \
+    rm -f /tmp/acc_check.cxx /tmp/nvcc_check.cu /tmp/acc_check.o \
+          /tmp/nvcc_check.o /tmp/acc_check

--- a/docker/acc_check.cxx
+++ b/docker/acc_check.cxx
@@ -1,0 +1,34 @@
+// Smoke test for the pruned NVHPC image in Dockerfile.cuda.
+//
+// The image build compiles and links this with the same nvc++ flags the CI jobs
+// use, so that a prune which removed something the real build needs fails while
+// the image is being built instead of after it has been pushed to :latest.
+
+#include <cstdio>
+#include <vector>
+
+#ifdef NPROF
+#include <nvtx3/nvToolsExt.h>
+#endif
+
+int main()
+{
+    std::vector<double> v(8, 1.0);
+    double *p = v.data();
+    double sum = 0.0;
+
+#ifdef NPROF
+    nvtxRangePushA("acc_check");
+#endif
+
+    #pragma acc parallel loop reduction(+:sum) copyin(p[0:8])
+    for (int i = 0; i < 8; ++i)
+        sum += p[i];
+
+#ifdef NPROF
+    nvtxRangePop();
+#endif
+
+    std::printf("%f\n", sum);
+    return 0;
+}

--- a/docker/nvcc_check.cu
+++ b/docker/nvcc_check.cu
@@ -1,0 +1,20 @@
+// Smoke test for the pruned NVHPC image in Dockerfile.cuda -- nvcc half.
+//
+// The knn-bvh submodule the openacc=1 jobs build compiles its kernels with the
+// SDK's bundled nvcc rather than nvc++, and resolves CUDA_HOME by looking up
+// `which nvcc`. Both break quietly if cuda/bin is not on PATH, so the image
+// build compiles this the same way knn-bvh does.
+
+#include <cstdio>
+
+__global__ void axpy(int n, double a, const double *x, double *y)
+{
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n)
+        y[i] += a * x[i];
+}
+
+extern "C" void launch_axpy(int n, double a, const double *x, double *y)
+{
+    axpy<<<(n + 255) / 256, 256>>>(n, a, x, y);
+}


### PR DESCRIPTION
## Why

The `nvc-build` jobs run in a container built on `nvcr.io/nvidia/nvhpc:25.7-devel-cuda12.9-ubuntu24.04`. That base unpacks to ~18 GB of SDK tree, and GitHub-hosted runners keep no image cache between jobs — so both matrix legs paid a full pull under **"Starting job container"** on every run, around **220–325 s each**.

## Measured result

CI run [`31036320727`](https://github.com/GeoFLAC/DynEarthSol/actions/runs/31036320727) — both matrix legs green.

| | before | after | |
|---|---|---|---|
| NVHPC SDK tree in image (`du -sh`, from the build log) | 18 GB | **3.7 GB** | 4.9× smaller |
| `Initialize containers`, 2D leg | 218 s | **40 s** | |
| `Initialize containers`, 3D leg | 217–325 s | **40 s** | |
| pre-change mean across both legs | 236 s | **40 s** | **5.9× faster** |

That is ~196 s back per job, and with two matrix legs, roughly **6.5 minutes of wall clock per `nvc build` run**.

Baselines are the `Initialize containers` step of the `Build *_All_Targets` jobs in the three most recent pre-change runs — [`31033531523`](https://github.com/GeoFLAC/DynEarthSol/actions/runs/31033531523), [`30970085918`](https://github.com/GeoFLAC/DynEarthSol/actions/runs/30970085918), [`30946365131`](https://github.com/GeoFLAC/DynEarthSol/actions/runs/30946365131) — read from the Actions API.

<img width="1625" height="650" alt="92_ci_container_start_time" src="https://github.com/user-attachments/assets/fcca46fc-5b10-4ca9-855c-86a02197d998" />

_(figure to be attached)_

## What this does

**Prune the SDK to what the build actually uses.** A builder stage deletes `comm_libs`, `math_libs`, `profilers`, `examples` and `REDIST`, and the survivors are copied onto a clean `ubuntu:24.04`. Deleting in a single stage would not shrink the pull at all — the parent layers would still carry the files.

Those trees are unreferenced: nothing links cuBLAS/cuFFT/cuSOLVER, nothing calls MPI/NCCL/NVSHMEM, and CI compiles without ever profiling. The Makefile touches the SDK in exactly three places, all under `cuda/`, which is kept whole — including the `<nvtx3/nvToolsExt.h>` that `parameters.hpp` needs for the `nprof=1` builds.

**Push with zstd layers**, which decompress much faster than gzip. This needs OCI media types; the provenance attestation is disabled so the tag stays a plain single-platform manifest for the runner to pull.

## The part that needs review attention

A bare Ubuntu base drops a distro toolchain the build quietly depended on. Each of these is a real failure, not a precaution — and each is now exercised by the green run above:

- **`cuda/bin` must stay on PATH as its own entry.** `nvcc` lives there, not in `compilers/bin`. `knn-bvh/Makefile` calls `nvcc` unqualified *and* derives `CUDA_HOME ?= $(dir $(shell which $(NVCC)))..` — a missing `nvcc` fails the compile *and* silently points that build at the wrong include tree. This would have broken all three `openacc=1` steps in both matrix legs.
- **`git`** — the Makefile initialises the `nanoflann`, `knn-bvh` and `mmg` submodules itself and hard-errors when git is absent (`actions/checkout` is not configured with `submodules: true`). Plus `ca-certificates` for those fetches.
- **`cmake`, `gcc`, `g++`** — the `usemmg=1` step configures mmg with `-DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++`, and nvc++ has no standard library of its own.
- **The final stage's Ubuntu release must track the base image's `-ubuntu24.04` suffix**, since nvc++ drives the system GNU toolchain through paths baked into `compilers/bin/localrc`.

## Guard rail

`docker/acc_check.cxx` and `docker/nvcc_check.cu` are compiled during the image build with the flags the four make variants actually use (including `-fopenmp` and the real hdf5/boost link, and `nvcc -arch=sm_80 -dc` for the knn-bvh path). BuildKit pushes only after every stage succeeds, so a prune that removed something needed fails *before* the shared `:latest` tag moves. The rebuild trigger widens to `docker/**` so these sources are covered.

## Deliberately not in scope

Two pre-existing issues this does not introduce and does not fix:

- `:latest` is a single mutable tag pushed *before* the matrix validates it, so a bad image breaks every GPU branch until another `docker/**` commit lands.
- A fork PR gets a read-only `GITHUB_TOKEN`, so the push 403s and `!failure()` then skips `nvc-build` entirely — silent no-CI.

Both want the same fix: push `:sha-<sha>`, consume that digest via a job output, promote to `:latest` only after the matrix passes. That is a workflow restructure with its own failure modes and belongs in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
