### PR TITLE
Generate GitHub App token for dispatch event

### DIFF
--- a/.github/workflows/notify-inputgen.yml
+++ b/.github/workflows/notify-inputgen.yml
@@ -10,10 +10,21 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
+      # Step 1: Generate a dynamic access token using your GitHub App
+      - name: Generate GitHub App Token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: 'GeoFLAC'
+          repositories: 'des-inputgen'
+
+      # Step 2: Use the generated token to dispatch the event
       - name: Dispatch event to des-inputgen
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.INPUTGEN_REPO_TOKEN }}
+          github-token: ${{ steps.generate_token.outputs.token }}
           script: |
             await github.rest.repos.createDispatchEvent({
               owner: 'GeoFLAC',


### PR DESCRIPTION
Trying to fix the failing workflow, ` Notify des-inputgen when input.cxx changes`. 
The main change is to use a Github App, not personal access token.