### PR TITLE
Fix notify-inputgen workflow (wrong action name + token repo scope)

### DIFF
--- a/.github/workflows/notify-inputgen.yml
+++ b/.github/workflows/notify-inputgen.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: generate_token
-        uses: softprops/create-github-app-token@v1
+        uses: actions/create-github-app-token@v1
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/notify-inputgen.yml
+++ b/.github/workflows/notify-inputgen.yml
@@ -15,8 +15,9 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          repositories: des-inputgen
 
       - name: Test generated token
         env:


### PR DESCRIPTION
 - Fixed softprops/create-github-app-token@v1 (nonexistent) → actions/create-github-app-token@v1
 - Scoped the generated token to des-inputgen via repositories: input, since the action defaults to scoping only to the triggering repo, causing 403 on the dispatch POST
 - Switched deprecated app_id/private_key inputs to app-id/private-key
 - Verified end-to-end: manual workflow_dispatch run succeeded and created https://github.com/GeoFLAC/des-inputgen/issues/1