### PR TITLE
ci: notify des3d when a PR merges

### DIFF
--- a/.github/workflows/notify-des3d.yml
+++ b/.github/workflows/notify-des3d.yml
@@ -4,6 +4,9 @@ name: Notify des3d when a PR merges
 # a PR merges to master/main, so its dynearthsol-pr-notify.yml workflow can
 # triage whether the change needs a doc update. Mirrors notify-inputgen.yml.
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [closed]

--- a/.github/workflows/notify-des3d.yml
+++ b/.github/workflows/notify-des3d.yml
@@ -1,0 +1,53 @@
+name: Notify des3d when a PR merges
+
+# Sends a repository_dispatch to GeoFLAC/des3d (the user-docs site) whenever
+# a PR merges to master/main, so its dynearthsol-pr-notify.yml workflow can
+# triage whether the change needs a doc update. Mirrors notify-inputgen.yml.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [master, main]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to (re-)notify des3d about'
+        required: true
+
+jobs:
+  notify:
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App Token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          repositories: des3d
+
+      - name: Dispatch event to des3d
+        env:
+          APP_TOKEN: ${{ steps.generate_token.outputs.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+        run: |
+          if [ -z "$APP_TOKEN" ]; then
+            echo "ERROR: APP_TOKEN is empty — token generation failed"
+            exit 1
+          fi
+          payload=$(jq -n --arg number "$PR_NUMBER" \
+            '{"event_type":"dynearthsol-pr-merged","client_payload":{"number":$number}}')
+          http_code=$(curl -s -o /dev/null -w "%{http_code}" \
+            -X POST \
+            -H "Authorization: Bearer $APP_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/GeoFLAC/des3d/dispatches" \
+            -d "$payload")
+          echo "Dispatch HTTP status: $http_code"
+          if [ "$http_code" -ge 200 ] && [ "$http_code" -lt 300 ]; then
+            echo "Dispatch created (HTTP $http_code) for PR #$PR_NUMBER"
+          else
+            echo "Dispatch failed (HTTP $http_code)"
+            exit 1
+          fi

--- a/.github/workflows/notify-des3d.yml
+++ b/.github/workflows/notify-des3d.yml
@@ -3,12 +3,19 @@ name: Notify des3d when a PR merges
 # Sends a repository_dispatch to GeoFLAC/des3d (the user-docs site) whenever
 # a PR merges to master/main, so its dynearthsol-pr-notify.yml workflow can
 # triage whether the change needs a doc update. Mirrors notify-inputgen.yml.
+#
+# Uses pull_request_target (not pull_request) so this still fires with
+# secrets available when the merged PR came from a fork — pull_request
+# strips secrets/token permissions for fork-origin PRs, which would silently
+# break notifications for external contributions. Safe here because this
+# workflow never checks out or executes any code from the PR itself; it only
+# reads the PR number and reports to another repo.
 
 permissions:
   contents: read
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches: [master, main]
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Adds a workflow that fires on PR merge to `master`/`main` and sends a `repository_dispatch` event to `GeoFLAC/des3d` (the user-docs site)
- des3d's receiving workflow (`dynearthsol-pr-notify.yml`) fetches the PR's changed files, skips it if the PR only touched `.github/` (CI-only), and otherwise opens a triage issue pointing at the PR and its doc-sync procedure

## Setup
Reuses the existing `notify-des-inputgen` GitHub App (APP_ID/APP_PRIVATE_KEY secrets already in this repo) rather than adding a new one — its installation has now been granted access to `des3d` as well.

## Test plan
- [ ] Merge this PR
- [ ] Manually trigger via `workflow_dispatch` with a past PR number, or merge a trivial PR
- [ ] Confirm a triage issue (or a skip notice, for CI-only PRs) appears in `GeoFLAC/des3d`

🤖 Generated with [Claude Code](https://claude.com/claude-code)