### PR TITLE
Regular update 2026-08: build correctness, OpenMP/OpenACC defect fixes, run provenance, exit codes, 1.55x/2.17x perf

### DIFF
--- a/.github/workflows/basic-build.yml
+++ b/.github/workflows/basic-build.yml
@@ -1,5 +1,8 @@
 name: Basic build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]

--- a/.github/workflows/exodus-build.yml
+++ b/.github/workflows/exodus-build.yml
@@ -1,5 +1,8 @@
 name: Exodus build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -1,5 +1,8 @@
 name: Functional tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master", "bugfix*" ]

--- a/.github/workflows/get-g++version.yml
+++ b/.github/workflows/get-g++version.yml
@@ -1,5 +1,8 @@
 name: C/C++ CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]

--- a/.github/workflows/gospl-build.yml
+++ b/.github/workflows/gospl-build.yml
@@ -1,5 +1,8 @@
 name: GoSPL build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -1,5 +1,8 @@
 name: macOS build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master", "*macOS*" ]

--- a/.github/workflows/mmg-build.yml
+++ b/.github/workflows/mmg-build.yml
@@ -1,5 +1,8 @@
 name: MMG build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]

--- a/.github/workflows/notify-inputgen.yml
+++ b/.github/workflows/notify-inputgen.yml
@@ -1,5 +1,8 @@
 name: Notify des-inputgen when input.cxx changes
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [master, main]

--- a/.github/workflows/nvc-build.yml
+++ b/.github/workflows/nvc-build.yml
@@ -147,14 +147,14 @@ jobs:
       run: |
         echo "BASE_MAKE=make hdf5=1 NVHPC_DIR=$NVHPC_DIR" >> $GITHUB_ENV
 
-    - name: make ndims=${{ matrix.ndims }} openacc=1 SM=80 hdf5=1
-      run: make clean openacc=1 ndims=${{ matrix.ndims }} && $BASE_MAKE ndims=${{ matrix.ndims }} openacc=1 hdf5=1 SM=80 -j
+    - name: make ndims=${{ matrix.ndims }} openacc=1 GPU_CC=80 hdf5=1
+      run: make clean openacc=1 ndims=${{ matrix.ndims }} && $BASE_MAKE ndims=${{ matrix.ndims }} openacc=1 hdf5=1 GPU_CC=80 -j
 
-    - name: make ndims=${{ matrix.ndims }} openacc=1 SM=80 hdf5=1 usemmg=1
-      run: make clean openacc=1 ndims=${{ matrix.ndims }} && $BASE_MAKE ndims=${{ matrix.ndims }} openacc=1 hdf5=1 usemmg=1 SM=80 -j
+    - name: make ndims=${{ matrix.ndims }} openacc=1 GPU_CC=80 hdf5=1 usemmg=1
+      run: make clean openacc=1 ndims=${{ matrix.ndims }} && $BASE_MAKE ndims=${{ matrix.ndims }} openacc=1 hdf5=1 usemmg=1 GPU_CC=80 -j
 
-    - name: make ndims=${{ matrix.ndims }} openacc=1 nprof=1 SM=80 hdf5=1
-      run: make cleanall openacc=1 ndims=${{ matrix.ndims }} && $BASE_MAKE ndims=${{ matrix.ndims }} openacc=1 hdf5=1 nprof=1 SM=80 -j
+    - name: make ndims=${{ matrix.ndims }} openacc=1 nprof=1 GPU_CC=80 hdf5=1
+      run: make cleanall openacc=1 ndims=${{ matrix.ndims }} && $BASE_MAKE ndims=${{ matrix.ndims }} openacc=1 hdf5=1 nprof=1 GPU_CC=80 -j
 
     - name: make ndims=${{ matrix.ndims }} nprof=1 opt=0 hdf5=1
       run: make cleanall ndims=${{ matrix.ndims }} && $BASE_MAKE ndims=${{ matrix.ndims }} hdf5=1 nprof=1 opt=0 -j

--- a/.github/workflows/nvc-build.yml
+++ b/.github/workflows/nvc-build.yml
@@ -1,5 +1,10 @@
 name: nvc build
 
+permissions:
+  contents: read
+  pull-requests: read
+  packages: read
+
 on:
   push:
     branches:

--- a/.github/workflows/omp-gcc-matrix.yml
+++ b/.github/workflows/omp-gcc-matrix.yml
@@ -1,5 +1,8 @@
 name: OMP g++ matrix
 
+permissions:
+  contents: read
+
 # Two gates for OpenMP pragma correctness:
 #   1. compile-matrix: g++ 8-15 hard-error on default(none) data-sharing
 #      violations, whose rules changed across versions (gcc 8 vs 9+).

--- a/.github/workflows/omp-gcc-matrix.yml
+++ b/.github/workflows/omp-gcc-matrix.yml
@@ -1,0 +1,102 @@
+name: OMP g++ matrix
+
+# Two gates for OpenMP pragma correctness:
+#   1. compile-matrix: g++ 8-15 hard-error on default(none) data-sharing
+#      violations, whose rules changed across versions (gcc 8 vs 9+).
+#   2. thread-count-check: 1-thread vs 4-thread runs compared with
+#      compare.py, which tolerates reduction round-off (<1e-8) but fails
+#      on race-sized divergence or NaN.
+
+on:
+  pull_request:
+    branches: [ "master" ]
+    paths:
+      - '**.cxx'
+      - '**.hpp'
+      - '**.cpp'
+      - 'Makefile'
+      - '.github/workflows/omp-gcc-matrix.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compile-matrix:
+    strategy:
+      fail-fast: false
+      matrix:
+        gcc: [8, 9, 10, 11, 12, 13, 14, 15]
+    runs-on: ubuntu-latest
+    container: gcc:${{ matrix.gcc }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # As in nvc-build; `|| true` tolerates act runs from a git worktree.
+      - name: Fix git safe directory
+        run: git config --global --add safe.directory '*' || true
+
+      - name: install boost (archive fallback for EOL Debian bases)
+        run: |
+          apt-get update || { \
+            sed -i -e 's|deb.debian.org/debian|archive.debian.org/debian|g' \
+                   -e 's|security.debian.org|archive.debian.org|g' \
+                   -e '/-updates/d' /etc/apt/sources.list; \
+            apt-get -o Acquire::Check-Valid-Until=false update; }
+          apt-get install -y --no-install-recommends libboost-program-options-dev
+
+      - name: g++ version
+        run: g++ --version
+
+      - name: make 2d openmp
+        run: make clean ndims=2; make -j4 ndims=2 opt=2 openmp=1 hdf5=0
+
+      - name: make 3d openmp
+        run: make clean ndims=3; make -j4 ndims=3 opt=2 openmp=1 hdf5=0
+
+  thread-count-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install Python dependencies
+        run: python -m pip install --upgrade pip numpy h5py
+
+      - name: get boost and hdf5
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libboost-program-options-dev libhdf5-serial-dev make pkg-config
+
+      - name: make 2d openmp hdf5
+        run: make -j4 ndims=2 opt=2 openmp=1 hdf5=1
+
+      - name: reference run, 1 thread
+        working-directory: ./tests/functional
+        run: |
+          OMP_NUM_THREADS=1 ../../dynearthsol2d 2d-ep-irregular.cfg
+          mkdir ref-omp1 && mv functional-test.* ref-omp1/
+
+      - name: run A, 4 threads, compare
+        working-directory: ./tests/functional
+        run: |
+          OMP_NUM_THREADS=4 ../../dynearthsol2d 2d-ep-irregular.cfg
+          cd ../../benchmarks-cores
+          python compare.py ../tests/functional/ref-omp1/functional-test \
+                            ../tests/functional/functional-test 4
+
+      # Second multithreaded run: races are schedule-dependent and one
+      # clean pass is weak evidence.
+      - name: run B, 4 threads, compare
+        working-directory: ./tests/functional
+        run: |
+          rm -f functional-test.*
+          OMP_NUM_THREADS=4 ../../dynearthsol2d 2d-ep-irregular.cfg
+          cd ../../benchmarks-cores
+          python compare.py ../tests/functional/ref-omp1/functional-test \
+                            ../tests/functional/functional-test 4

--- a/3x3-C/Makefile
+++ b/3x3-C/Makefile
@@ -21,11 +21,18 @@ ifneq (, $(findstring nvc++, $(CC)))
 		CFLAGS += -Minfo=mp,accel -I$(CUDA_DIR)/include
 	endif
 	ifeq ($(openacc), 1)
-		ifeq ($(nofma), 1)
-			CFLAGS += -acc=gpu -gpu=mem:managed,nofma -cuda
-		else
-			CFLAGS += -acc=gpu -gpu=mem:managed -cuda
+		## GPU_CC = compute capability, from the parent make. Blank lets nvc++ infer it
+		## from the build host, which is what makes a tree shared between hosts link
+		## objects built for the wrong arch. Assembled into ONE -gpu=: repeating the
+		## option leaves it to nvc++ whether occurrences merge or the last one wins.
+		GPU_OPTS = mem:managed
+		ifneq ($(strip $(GPU_CC)),)
+			GPU_OPTS := cc$(strip $(GPU_CC)),$(GPU_OPTS)
 		endif
+		ifeq ($(nofma), 1)
+			GPU_OPTS := $(GPU_OPTS),nofma
+		endif
+		CFLAGS += -acc=gpu -gpu=$(GPU_OPTS) -cuda
 	endif
 
 endif
@@ -48,14 +55,31 @@ HEADER = dsytrd3.h dsyevc3.h dsyevq3.h dsyevh3.h
 
 # Rules
 # -----
+# The stamp DELETES the objects when flags change: make 3.81 compares whole
+# seconds, so mtime is unreliable here, and the delete must run in an earlier
+# process than the build -- hence the re-entry in `all`.
+STAMP = .build-flags-3x3$(suffix)
+
+.PHONY: all clean FORCE
+all: $(STAMP)
+	@$(MAKE) --no-print-directory $(BIN)
+
+$(STAMP): FORCE
+	@echo '$(CC)|$(CFLAGS)|$(INCFLAGS)' > $@.tmp
+	@if cmp -s $@.tmp $@; then rm -f $@.tmp; else \
+		test -f $@ && echo "   3x3-C flags changed since the last build -- rebuilding"; \
+		mv $@.tmp $@; rm -f $(OBJ) $(BIN); \
+	fi
+
+FORCE:
+
 $(BIN): Makefile $(OBJ)
 	$(AR) $(ARFLAGS) $(BIN) $(OBJ)
 
 %$(suffix).o : %.c Makefile $(HEADER)
 	$(CC) $(CFLAGS) -c $(INCFLAGS) $< -o $@
 
-.PHONY: clean
 clean:
-	@rm -f $(BIN) $(OBJ)
+	@rm -f $(BIN) $(OBJ) $(STAMP)
 
 

--- a/3x3-C/Makefile
+++ b/3x3-C/Makefile
@@ -62,7 +62,7 @@ STAMP = .build-flags-3x3$(suffix)
 
 .PHONY: all clean FORCE
 all: $(STAMP)
-	@$(MAKE) --no-print-directory $(BIN)
+	@$(MAKE) -q --no-print-directory $(BIN) || $(MAKE) --no-print-directory $(BIN)
 
 $(STAMP): FORCE
 	@echo '$(CC)|$(CFLAGS)|$(INCFLAGS)' > $@.tmp

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -27,12 +27,19 @@ Low priority:
 * Avoid C++ stream for bulk output, as stream is slower than C-style IO.
 * Avoid creating/destroying objects in inner for-loops.
 * Avoid static variables and global variables.
-* Meaning of error codes:
-   1: User input error
-   2: IO error
-  10: Triangulation/tetrahedralization error
-  11: Runtime error
-  12: Assertion error (due to programming)
+* Meaning of error codes. First digit is the category, second the specific
+  cause; 1x is the user's to fix, 2x the environment, 3x-6x ours. Exit via
+  `die(EXIT_...)` in `utils.hpp`, which prints the code and its category, so
+  never `exit()` a bare number.
+   0: Normal exit
+  10: Config error          11: bad value/unknown option  12: malformed .poly/.exo
+  20: Cannot open file      21: read/write failed (HDF5)  22: restart mismatch
+  30: Unsupported in this NDIMS                           31: library not built in
+  40: Triangle/TetGen       41: MMG                       42: mesh quality/topology
+  50: NaN/non-finite        51: marker/geometry lookup    52: resource exhausted
+  60: Assertion violated    61: unreachable branch
+  These are renumbered: earlier builds used 1 input, 2 IO, 10 triangulation,
+  11 runtime, 12 assertion, so 10-12 mean something different in older logs.
 
 ## Benchmarks and regression testing
 

--- a/Makefile
+++ b/Makefile
@@ -666,18 +666,34 @@ INCS =	\
 	array2d.hpp \
 	ats_output_scheduler.hpp \
 	barycentric-fn.hpp \
+	bc.hpp \
 	binaryio.hpp \
+	brc-interpolation.hpp \
 	constants.hpp \
 	earthquake_state.hpp \
-	monitor.hpp \
-	parameters.hpp \
-	matprops.hpp \
-	sortindex.hpp \
-	utils.hpp \
-	mesh.hpp \
+	fields.hpp \
+	geometry.hpp \
+	ic.hpp \
+	ic-read-temp.hpp \
+	input.hpp \
+	knn.hpp \
 	markerset.hpp \
+	matprops.hpp \
+	mesh.hpp \
+	monitor.hpp \
+	nn-interpolation.hpp \
 	output.hpp \
-	knn.hpp
+	parameters.hpp \
+	phasechanges.hpp \
+	remeshing.hpp \
+	rheology.hpp \
+	runtime_info.hpp \
+	sortindex.hpp \
+	utils.hpp
+
+ifeq ($(use_gospl), 1)
+	INCS += gospl_driver/gospl-driver.hpp
+endif
 
 OBJS = $(SRCS:.cxx=.$(ndims)d$(suffix).o)
 

--- a/Makefile
+++ b/Makefile
@@ -835,7 +835,7 @@ CXXFLAGS += -DSOA
 .PHONY: all clean take-snapshot prepare build check-deps config FORCE
 
 all: prepare
-	$(MAKE) build
+	@$(MAKE) build
 
 ## Rebuild when the FLAGS change, not just when a source file does.
 ##

--- a/Makefile
+++ b/Makefile
@@ -403,7 +403,7 @@ ifneq (, $(findstring clang++, $(CXX)))
 	else ifeq ($(opt), 3)
 		CXXFLAGS += -march=native -O3 -ffast-math -funroll-loops
 	else # debugging
-		CXXFLAGS += -O0 -Wall -Wno-unused-variable -Wno-unused-function -Wno-unknown-pragmas
+		CXXFLAGS += -O0 -Wall -Wno-unused-variable -Wno-unused-function
 		ifeq ($(opt), -1)
 			CXXFLAGS += -fsanitize=address
 			LDFLAGS += -fsanitize=address

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,22 @@ ifeq ($(ndims), 2)
 	useexo = 0    # for now, can import only 3d exo mesh
 endif
 
+## Reject a variable this Makefile does not know: make accepts any NAME=VALUE
+## silently, so `ndim=2` builds 3D and reports success. Command-line names only.
+KNOWN_VARS = ndims opt openacc openmp nprof gprof usemmg useexo use_gospl hdf5 \
+             nofma GPU_CC CXX \
+             BOOST_ROOT_DIR HDF5_INCLUDE_DIR HDF5_LIB_DIR NVHPC_DIR \
+             OPENMP_ROOT_DIR OPENMP_INCLUDE_DIR OPENMP_LIB_DIR \
+             BREW_PREFIX MACPORTS_PREFIX CONDA_PREFIX \
+             PYTHON_VERSION PYTHON_INCLUDE_DIR PYTHON_LIB_DIR \
+             EXO_INCLUDE EXO_LIB_DIR MMG_INCLUDE MMG_LIB_DIR \
+             GOSPL_EXT_DIR CONDA_ENV_PATH
+CMDLINE_VARS = $(foreach v,$(.VARIABLES),$(if $(filter command line,$(origin $(v))),$(v)))
+UNKNOWN_VARS = $(filter-out $(KNOWN_VARS),$(CMDLINE_VARS))
+ifneq ($(UNKNOWN_VARS),)
+$(error unknown make variable(s): $(UNKNOWN_VARS). Known: $(KNOWN_VARS))
+endif
+
 OSNAME := $(shell uname -s)
 
 ########################################################################

--- a/Makefile
+++ b/Makefile
@@ -984,7 +984,7 @@ prepare: check-deps $(FLAG_STAMPS)
 	@if command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then \
 		if git submodule status $(ANN_DIR) | grep -q '^[-+]'; then \
 			echo "   Status mismatch. Updating submodule $(ANN_DIR)..."; \
-			git submodule update --init --recursive $(ANN_DIR); \
+			git submodule update --init --recursive --progress --depth 1 $(ANN_DIR); \
 		fi; \
 	elif [ -f "$(ANN_DIR)/include/nanoflann.hpp" ]; then \
 		:; \
@@ -997,7 +997,7 @@ ifeq ($(openacc), 1)
 	@if command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then \
 		if git submodule status $(KNN_BVH_DIR) | grep -q '^[-+]'; then \
 			echo "   Status mismatch. Updating submodule $(KNN_BVH_DIR)..."; \
-			git submodule update --init --recursive $(KNN_BVH_DIR); \
+			git submodule update --init --recursive --progress --depth 1 $(KNN_BVH_DIR); \
 		fi; \
 	elif [ -f "$(KNN_BVH_DIR)/Makefile" ]; then \
 		:; \
@@ -1011,7 +1011,7 @@ ifeq ($(usemmg), 1)
 	@if command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then \
 		if git submodule status mmg | grep -q '^[-+]'; then \
 			echo "   Status mismatch. Updating submodule mmg..."; \
-			git submodule update --init --recursive mmg; \
+			git submodule update --init --recursive --progress --depth 1 mmg; \
 		fi; \
 	elif [ -f "mmg/CMakeLists.txt" ]; then \
 		:; \

--- a/Makefile
+++ b/Makefile
@@ -406,9 +406,27 @@ ifeq ($(use_gospl), 1)
 endif
 
 
+## Warnings belong in every build, not only the debug one. gcc's uninitialized and
+## array-bounds analyses run inside the optimizer, so -O0 -- the only level that used to
+## ask for warnings -- is where they see the least: -O2 -Wall finds real defects that
+## -O0 -Wall cannot. The two suppressions cover what this codebase does deliberately,
+## namely file-static helpers in headers that not every translation unit calls.
+## Two flags are added per compiler below instead of here: -Wno-unknown-pragmas, because
+## the clang debug build wants to hear about acc pragmas while every other build would
+## drown in them, and -Wno-unused-private-field, which only clang has.
+WARNFLAGS = -Wall -Wno-unused-variable -Wno-unused-function
+
 ifneq (, $(findstring clang++, $(CXX)))
 	CXX_SUPPORTED = yes
-	CXXFLAGS = -g -std=c++0x -DGPP1X
+	## -Wno-unused-private-field is the member-field half of the WARNFLAGS suppressions
+	## and has no g++ spelling. It fires on members a sibling configuration uses -- the
+	## THREED-only axis, the ACC-only knn state, the hdf5-only compression level -- which
+	## is the same deliberate pattern, not a finding.
+	CXXFLAGS = -g -std=c++0x -DGPP1X $(WARNFLAGS) -Wno-unused-private-field
+	## Everything but opt=0 and opt=-1; those two are the builds that report acc pragmas.
+	ifeq (,$(filter 0 -1,$(opt)))
+		CXXFLAGS += -Wno-unknown-pragmas
+	endif
 	LDFLAGS = -lm
 	TETGENFLAG = 
 	
@@ -424,7 +442,7 @@ ifneq (, $(findstring clang++, $(CXX)))
 	else ifeq ($(opt), 3)
 		CXXFLAGS += -march=native -O3 -ffast-math -funroll-loops
 	else # debugging
-		CXXFLAGS += -O0 -Wall -Wno-unused-variable -Wno-unused-function
+		CXXFLAGS += -O0
 		ifeq ($(opt), -1)
 			CXXFLAGS += -fsanitize=address
 			LDFLAGS += -fsanitize=address
@@ -507,7 +525,7 @@ ifneq (, $(findstring clang++, $(CXX)))
 
 else ifneq (, $(findstring g++, $(CXX_BACKEND))) # if using any version of g++
 	CXX_SUPPORTED = yes
-	CXXFLAGS = -g -std=c++0x
+	CXXFLAGS = -g -std=c++0x $(WARNFLAGS) -Wno-unknown-pragmas
 	LDFLAGS = -lm
 	TETGENFLAG = -Wno-unused-but-set-variable -Wno-int-to-pointer-cast
 
@@ -518,7 +536,7 @@ else ifneq (, $(findstring g++, $(CXX_BACKEND))) # if using any version of g++
 	else ifeq ($(opt), 3) # experimental, use at your own risk :)
 		CXXFLAGS += -march=native -O3 -ffast-math -funroll-loops
 	else # debugging flags
-		CXXFLAGS += -O0 -Wall -Wno-unused-variable -Wno-unused-function -Wno-unknown-pragmas -fbounds-check -ftrapv
+		CXXFLAGS += -O0 -fbounds-check -ftrapv
 		ifeq ($(opt), -1)
 			CXXFLAGS += -fsanitize=address
 			LDFLAGS += -fsanitize=address
@@ -563,7 +581,14 @@ else ifneq (, $(findstring icpc, $(CXX_BACKEND))) # if using intel compiler, tes
 
 else ifneq (, $(findstring nvc++, $(CXX)))
 	CXX_SUPPORTED = yes
-	CXXFLAGS = -g -Minfo=mp,accel
+	## No WARNFLAGS here: nvc++ rejects -Wno-unknown-pragmas outright ("Unknown switch"),
+	## and bare -Wall only adds a macro redefinition inside boost's own pgi.hpp.
+	## It does report unreferenced file statics by default, which is the class g++'s
+	## WARNFLAGS suppresses on purpose -- headers here carry helpers not every translation
+	## unit calls, and each dimension compiles the other's. --diag_suppress is nvc++'s
+	## spelling of that -Wno-unused-{variable,function}. Its set_but_not_used stays on, so
+	## that a value written and never read is still reported, as it is under g++.
+	CXXFLAGS = -g -Minfo=mp,accel --diag_suppress declared_but_not_referenced
 	LDFLAGS =
 	TETGENFLAGS = 
 

--- a/Makefile
+++ b/Makefile
@@ -693,6 +693,7 @@ SRCS =	\
 	remeshing.cxx \
 	rheology.cxx \
 	runtime_info.cxx \
+	utils.cxx \
 	markerset.cxx \
 	knn.cxx
 

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@
 ##       1 = low optimization, 2 = default optimized build, 3 = aggressive
 ##       optimizations (-march=native, -O3, etc.).
 ##  - openacc = 1 : enable OpenACC compilation (NVHPC).
+##  - GPU_CC = 80 : GPU compute capability to target, for openacc=1. Default: the
+##       capability of the GPU in this host, else 80. `make config` prints it.
 ##  - openmp = 1 : enable OpenMP parallelization.
 ##  - nprof = 1 : enable NVHPC nprof profiling build (uses nvc++ when set),
 ##       1 = main dynearthsol loop profiling, 2 = detailed profiling.
@@ -98,8 +100,8 @@ BOOST_ROOT_DIR ?= # /path/to/boost
 HDF5_INCLUDE_DIR ?= # /usr/include/hdf5/serial
 HDF5_LIB_DIR ?= # /usr/lib/x86_64-linux-gnu/hdf5/serial
 
-## NVHPC, for openacc=1 and nprof=1. Also where the CUDA toolkit is found, for
-## the nprof profiling build and the 3x3-C sub-make.
+## NVHPC. Blank takes nvc++ from PATH; naming an SDK uses its compilers/bin/nvc++
+## for openacc=1 and nprof, and its CUDA toolkit for nprof's NVTX headers.
 NVHPC_DIR ?= # /cluster/nvidia/hpc_sdk/Linux_x86_64/21.2
 
 ## Package-manager prefixes the macOS searches start from. Chosen by host
@@ -133,12 +135,15 @@ firstfile = $(firstword $(shell for f in $(wildcard $(addsuffix /$(1),$(2))); do
 under = $(if $(strip $(1)),$(addprefix $(strip $(1)),$(2)))
 
 ## Select C++ compiler and set paths to necessary libraries
+## A named NVHPC_DIR picks the compiler out of that SDK, so a host with several
+## installed builds against the one whose CUDA toolkit nprof is also given.
+NVHPC_CXX = $(if $(strip $(NVHPC_DIR)),$(strip $(NVHPC_DIR))/compilers/bin/nvc++,nvc++)
 ifeq ($(openacc), 1)
-	CXX = nvc++
+	CXX = $(NVHPC_CXX)
 	suffix = .gpu
 else
 	ifneq ($(nprof), 0)
-		CXX = nvc++
+		CXX = $(NVHPC_CXX)
 	else
 		# Select compiler based on platform
 		ifeq ($(OSNAME), Darwin)
@@ -573,15 +578,32 @@ else ifneq (, $(findstring nvc++, $(CXX)))
 	endif
 
 	ifeq ($(openacc), 1)
+		## Name the GPU target; origin read before the := below rewrites it to "file".
+		GPU_CC_NOTE := $(if $(filter command line environment,$(origin GPU_CC)),overridden,detected)
+		GPU_CC := $(strip $(GPU_CC))
+		ifeq ($(GPU_CC),)
+			GPU_CC := $(shell nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null \
+			            | head -1 | tr -d '.')
+		endif
+		## $(warning) and $(error) indented with SPACES, not a tab -- see the note
+		## at the hdf5 $(error) above.
+		ifeq ($(GPU_CC),)
+			## 80 = A100, what the CI matrix targets. Nothing is known about
+			## the local host here, so this is a guess that at least links.
+			GPU_CC := 80
+			GPU_CC_NOTE := no GPU found, default
+        $(warning No GPU detected via nvidia-smi -- targeting cc$(GPU_CC). Pass GPU_CC=<cc> to override.)
+		endif
+
 		CXXFLAGS += -acc=gpu -cuda -DACC
-		LDFLAGS += -acc=gpu -gpu=mem:managed -cuda
+		LDFLAGS += -acc=gpu -gpu=cc$(GPU_CC),mem:managed -cuda
 		# CXXFLAGS += -acc=gpu -Mcuda -DACC
 		# LDFLAGS += -acc=gpu -gpu=managed -Mcuda
 		ifeq ($(nofma), 1)
-			CXXFLAGS += -gpu=mem:managed,nofma
+			CXXFLAGS += -gpu=cc$(GPU_CC),mem:managed,nofma
 			# CXXFLAGS += -gpu=managed,nofma
 		else
-			CXXFLAGS += -gpu=mem:managed
+			CXXFLAGS += -gpu=cc$(GPU_CC),mem:managed
 			# CXXFLAGS += -gpu=managed
 		endif
 	endif
@@ -759,6 +781,12 @@ endif
 
 C3X3_DIR = 3x3-C
 C3X3_LIBNAME = 3x3$(suffix)
+## GPU_CC goes to the sub-make as itself: it folds the capability into the one -gpu= it
+## assembles, and its flag stamp covers CFLAGS, so a changed capability deletes the
+## objects it invalidates.
+ifeq ($(openacc), 1)
+	C3X3_SUBMAKE = CC=$(NVHPC_CXX) GPU_CC=$(GPU_CC)
+endif
 
 ANN_DIR = nanoflann
 CXXFLAGS += -I$(ANN_DIR)/include
@@ -769,7 +797,7 @@ CXXFLAGS += -I$(GOSPL_DIR)
 KNN_BVH_DIR = knn-bvh
 ifeq ($(openacc), 1)
 	CXXFLAGS += -I$(KNN_BVH_DIR)/include
-	KNN_BVH_LIB = $(KNN_BVH_DIR)/lib/libknn_bvh.$(ndims)d.a
+	KNN_BVH_LIB = $(KNN_BVH_DIR)/lib/libknn_bvh.$(ndims)d.sm$(GPU_CC).a
 	LDFLAGS += $(KNN_BVH_LIB)
 endif
 
@@ -956,6 +984,10 @@ endif
 	@echo "useexo             $(strip $(useexo))"
 	@echo "use_gospl          $(strip $(use_gospl))"
 	@echo "openacc            $(strip $(openacc))"
+ifeq ($(openacc), 1)
+	@echo "  gpu target       cc$(GPU_CC)   ($(GPU_CC_NOTE))"
+	@echo "  knn-bvh archive  $(KNN_BVH_LIB)"
+endif
 	@echo
 	@echo "CXXFLAGS           $(CXXFLAGS) $(BOOST_CXXFLAGS)"
 	@echo "LDFLAGS            $(LDFLAGS) $(BOOST_LDFLAGS)"
@@ -1117,8 +1149,8 @@ endif
 $(OBJS): %.$(ndims)d$(suffix).o : %.cxx $(INCS) $(BUILD_STAMP)
 	$(CXX) $(CXXFLAGS) $(BOOST_CXXFLAGS) -c $< -o $@
 
-$(KNN_BVH_LIB):
-	$(MAKE) -C $(KNN_BVH_DIR) NDIM=$(ndims)
+$(KNN_BVH_LIB): FORCE
+	@$(MAKE) --no-print-directory -C $(KNN_BVH_DIR) NDIM=$(ndims) SM=$(GPU_CC)
 
 $(TRI_OBJS): %.$(ndims)d$(suffix).o : %.c $(TRI_INCS) $(BUILD_STAMP)
 	@# Triangle cannot be compiled with -O2
@@ -1139,10 +1171,9 @@ tetgen/tetgen.$(ndims)d$(suffix).o: tetgen/tetgen.cxx $(TET_INCS) $(BUILD_STAMP)
 tetgen/tetgen: tetgen/predicates.cxx tetgen/tetgen.cxx
 	$(CXX) $(CXXFLAGS) -O0 -DNDEBUG $(TETGENFLAG) tetgen/predicates.cxx tetgen/tetgen.cxx -o $@
 
-$(C3X3_DIR)/lib$(C3X3_LIBNAME).a:
-	@# CUDA_DIR only when there is an NVHPC_DIR to build it from; otherwise this
-	@# handed the sub-make a literal "/cuda" on every single build.
-	@+$(MAKE) -C $(C3X3_DIR) openacc=$(openacc) nofma=$(nofma) \
+$(C3X3_DIR)/lib$(C3X3_LIBNAME).a: FORCE
+	@# CUDA_DIR only with an NVHPC_DIR, else the sub-make got a literal "/cuda".
+	@+$(MAKE) -C $(C3X3_DIR) openacc=$(openacc) nofma=$(nofma) $(C3X3_SUBMAKE) \
 		$(if $(strip $(NVHPC_DIR)),CUDA_DIR=$(NVHPC_DIR)/cuda)
 
 clean-submodules:

--- a/Makefile
+++ b/Makefile
@@ -555,7 +555,7 @@ else ifneq (, $(findstring g++, $(CXX_BACKEND))) # if using any version of g++
 
 	GCCVERSION = $(shell $(CXX) --version | grep g++ | sed 's/^.* //g' | cut -d. -f1)
 
-	ifeq ($(shell expr $(GCCVERSION) \> 10), 1)
+	ifeq ($(shell expr $(GCCVERSION) \> 8), 1)
 		CXXFLAGS += -DGPP1X
 	endif
 

--- a/README.md
+++ b/README.md
@@ -327,6 +327,9 @@ make nprof=1
 
 # OpenACC build (NVHPC compiler)
 make openacc=1
+
+# OpenACC targeting a specific GPU (else from nvidia-smi, default 80; see make config)
+make openacc=1 GPU_CC=90
 ```
 
 # Running DES3D

--- a/array2d.hpp
+++ b/array2d.hpp
@@ -185,12 +185,13 @@ public:
             n_ = count;
         }
 #ifndef ACC
-        #pragma omp parallel for collapse(2) if(count > 10000)
+        #pragma omp parallel for default(none) shared(buffer, count) \
+            collapse(2) if(count > 10000)
 #endif
         #pragma acc parallel loop gang vector collapse(2)
         for (std::size_t i = 0; i < count; ++i) {
             for (int d = 0; d < N; ++d) {
-                (*this)[i][d] = buffer[i * N + d]; 
+                (*this)[i][d] = buffer[i * N + d];
             }
         }
     }
@@ -214,7 +215,8 @@ public:
         buffer.resize(total_elements);
 
 #ifndef ACC
-        #pragma omp parallel for collapse(2) if(n_ > 10000)
+        #pragma omp parallel for default(none) shared(buffer, count) \
+            collapse(2) if(count > 10000)
 #endif
         #pragma acc parallel loop gang vector collapse(2)
         for (std::size_t i = 0; i < count; ++i) {
@@ -273,7 +275,8 @@ public:
             if (aos_data != nullptr) {
 #ifdef SOA
 #ifndef ACC
-                #pragma omp parallel for collapse(2) if(n_ > 10000)
+                #pragma omp parallel for default(none) shared(aos_data) \
+                    collapse(2) if(n_ > 10000)
 #endif
                 #pragma acc parallel loop gang vector collapse(2)
                 for (int i = 0; i < n_; ++i) {
@@ -388,7 +391,8 @@ public:
 #endif
 
 #ifndef ACC
-        #pragma omp parallel for if(n_ > 10000)
+        #pragma omp parallel for default(none) shared(ptr, offset, stride, val) \
+            if(n_ > 10000)
 #endif
         #pragma acc parallel loop gang vector
         for (int i = 0; i < n_; ++i) {

--- a/array2d.hpp
+++ b/array2d.hpp
@@ -180,7 +180,7 @@ public:
         if (a_ == nullptr) {
             a_ = new T[N * count];
             n_ = count;
-        } else if (count > n_ || should_strip) {
+        } else if (count > std::size_t(n_) || should_strip) {
             this->resize(count, false);
             n_ = count;
         }
@@ -209,7 +209,7 @@ public:
 //     }
 
     void pack_to(std::vector<T>& buffer, std::size_t limit_size = 0) const {
-        std::size_t count = (limit_size > 0 && limit_size <= n_) ? limit_size : n_;
+        std::size_t count = (limit_size > 0 && limit_size <= std::size_t(n_)) ? limit_size : n_;
         std::size_t total_elements = count * N;
 
         buffer.resize(total_elements);
@@ -228,7 +228,7 @@ public:
 
 #ifdef ACC
     void pack_to_xyz_float(std::vector<float3>& buffer, std::size_t limit_size = 0) const {
-        std::size_t count = (limit_size > 0 && limit_size <= n_) ? limit_size : n_;
+        std::size_t count = (limit_size > 0 && limit_size <= std::size_t(n_)) ? limit_size : n_;
 
         if (buffer.size() < count)
             buffer.resize(count);

--- a/barycentric-fn.cxx
+++ b/barycentric-fn.cxx
@@ -32,6 +32,8 @@ Barycentric_transformation::Barycentric_transformation(const array_t &coord,
         compute_coeff2d(a, b, c, volume[e], coeff_[e]);
 #endif
     }
+
+    #pragma acc wait
 #ifdef NPROF_DETAIL
     nvtxRangePop();
 #endif
@@ -70,6 +72,8 @@ Barycentric_transformation::Barycentric_transformation(const int_vec &elem,
         compute_coeff2d(a, b, c, volume[e], coeff_[i]);
 #endif
     }
+
+    #pragma acc wait
 #ifdef NPROF_DETAIL
     nvtxRangePop();
 #endif
@@ -106,6 +110,8 @@ Barycentric_transformation::Barycentric_transformation(const array_t &coord,
         compute_coeff1d(a, b, area[e], coeff_[e]);
 #endif
     }
+
+    #pragma acc wait
 #ifdef NPROF_DETAIL
     nvtxRangePop();
 #endif

--- a/barycentric-fn.cxx
+++ b/barycentric-fn.cxx
@@ -32,8 +32,6 @@ Barycentric_transformation::Barycentric_transformation(const array_t &coord,
         compute_coeff2d(a, b, c, volume[e], coeff_[e]);
 #endif
     }
-
-    #pragma acc wait
 #ifdef NPROF_DETAIL
     nvtxRangePop();
 #endif
@@ -72,8 +70,6 @@ Barycentric_transformation::Barycentric_transformation(const int_vec &elem,
         compute_coeff2d(a, b, c, volume[e], coeff_[i]);
 #endif
     }
-
-    #pragma acc wait
 #ifdef NPROF_DETAIL
     nvtxRangePop();
 #endif
@@ -110,8 +106,6 @@ Barycentric_transformation::Barycentric_transformation(const array_t &coord,
         compute_coeff1d(a, b, area[e], coeff_[e]);
 #endif
     }
-
-    #pragma acc wait
 #ifdef NPROF_DETAIL
     nvtxRangePop();
 #endif

--- a/barycentric-fn.cxx
+++ b/barycentric-fn.cxx
@@ -141,13 +141,18 @@ template <typename T>
 void Barycentric_transformation::transform(T point, int e, double *result) const
 {
     ConstCoeffAccessor cf = coeff_[e];
+    // elem_dim_ is only ever NDIMS or NDIMS-1, so the 3 case cannot arise in a 2D build
+    // -- where `result` is a double[2] that this branch would write past the end of.
+#ifdef THREED
     if (elem_dim_ == 3) {
         for (int d=0; d<3; d++) {
             result[d] = cf[index3d(0,d)];
             for (int i=0; i<3; i++)
                 result[d] += cf[index3d(i+1,d)]*point[i];
         }
-    } else if (elem_dim_ == 2) {
+    } else
+#endif
+    if (elem_dim_ == 2) {
         for (int d=0; d<2; d++) {
             result[d] = cf[index2d(0,d)];
             for (int i=0; i<2; i++)
@@ -182,6 +187,8 @@ bool Barycentric_transformation::is_inside_elem(ConstArrayAccessor point, int el
 
 bool Barycentric_transformation::is_inside(const double *r) const
 {
+    // Guarded for the same reason as transform() above: in 2D `r` is a double[2].
+#ifdef THREED
     if (elem_dim_ == 3) {
         // 3D has larger round-off error in coeff_
         // => needs greater tolerance
@@ -192,7 +199,9 @@ bool Barycentric_transformation::is_inside(const double *r) const
             r[2] >= -tolerance &&
             (r[0] + r[1] + r[2]) <= 1 + tolerance)
             return 1;
-    } else if (elem_dim_ == 2) {
+    } else
+#endif
+    if (elem_dim_ == 2) {
         const double tolerance = 1e-12;
 
         if (r[0] >= -tolerance &&

--- a/barycentric-fn.hpp
+++ b/barycentric-fn.hpp
@@ -11,6 +11,11 @@ class Barycentric_transformation {
      *
      * The derivation of the formula can be found in
      * http://en.wikipedia.org/wiki/Barycentric_coordinate_system_(mathematics)
+     *
+     * The element-loop constructors fill coeff_ in an async ACC kernel
+     * (default queue): callers need an '#pragma acc wait' (or same-queue
+     * ordering) before any host read, any non-async device consumer, and
+     * destruction of the object or its input arrays.
      */
     typedef Array2D<double,NODES_PER_ELEM*NDIMS> coeff_t;
     typedef coeff_t::Accessor CoeffAccessor;

--- a/bc.cxx
+++ b/bc.cxx
@@ -92,7 +92,7 @@ double find_max_vbc(const BC &bc)
 
 
 void create_boundary_normals(const Variables &var, array_t &bnormals,
-                             std::map<std::pair<int,int>, double_vec>  &edge_vectors, double_vec& edge_vec, int_vec &edge_vec_idx)
+                             double_vec& edge_vec, int* edge_slot)
 {
     /* This subroutine finds the outward normal unit vectors of boundaries.
      * There are two types of boundaries: ibound{x,y,z}? and iboundn?.
@@ -160,6 +160,11 @@ void create_boundary_normals(const Variables &var, array_t &bnormals,
         }
     }
 
+    // -1 = this pair of boundaries shares no edge. Only pairs with facets on both sides
+    // get an entry, so the table is sparse and the absent case has to be representable.
+    std::fill_n(edge_slot, nbdrytypes * nbdrytypes, -1);
+    edge_vec.clear();
+
     for (int i=0; i<nbdrytypes; i++) {
         if (var.bfacets[i]->size() == 0) continue;
 
@@ -186,8 +191,7 @@ void create_boundary_normals(const Variables &var, array_t &bnormals,
             s[0] = 0;
             s[1] = 1;
 #endif
-            edge_vectors[std::make_pair(i, j)] = s;
-            edge_vec_idx.push_back(i*nbdrytypes + j);
+            edge_slot[i*nbdrytypes + j] = edge_vec.size() / NDIMS;
             edge_vec.push_back(s[0]);
             edge_vec.push_back(s[1]);
 #ifdef THREED
@@ -280,7 +284,6 @@ void apply_vbcs(const Param &param, const Variables &var, array_t &vel)
 #endif
 
     // diverging x-boundary
-    // const std::map<std::pair<int,int>, double*>  *edgevec = &(var.edge_vectors);
 
 
     int bc_x0 = bc.vbc_x0;
@@ -488,13 +491,11 @@ void apply_vbcs(const Param &param, const Variables &var, array_t &vel)
                                         v[d] += (var.vbc_values[ib] - vn) * n[d];  // setting normal velocity
                                 }
                                 else if (var.vbc_types[ic] == 1) {
-                                    const double *edge;
-                                    for (int j=0; j<var.edge_vec_idx.size();j++) {
-                                        int ei = var.edge_vec_idx[j]/nbdrytypes;
-                                        int ej = var.edge_vec_idx[j]%nbdrytypes;
-                                        if (ei == ic && ej == ib)
-                                            edge = &var.edge_vec[j*NDIMS];
-                                    }
+                                    // ic < ib, matching how create_boundary_normals keys the table.
+                                    const int slot = var.edge_slot[ic*nbdrytypes + ib];
+                                    if (slot < 0) continue;  // no shared edge, so no direction to project onto
+                                    const double *edge = &var.edge_vec[slot*NDIMS];
+
                                     double ve = 0;
                                     for (int d=0; d<NDIMS; d++)
                                         ve += v[d] * edge[d];
@@ -532,13 +533,11 @@ void apply_vbcs(const Param &param, const Variables &var, array_t &vel)
                                         v[d] += (var.vbc_values[ib] * fac - vn) * n[d];  // setting normal velocity
                                 }
                                 else if (var.vbc_types[ic] == 1) {
-                                    const double *edge;
-                                    for (int j=0; j<var.edge_vec_idx.size();j++) {
-                                        int ei = var.edge_vec_idx[j]/nbdrytypes;
-                                        int ej = var.edge_vec_idx[j]%nbdrytypes;
-                                        if (ei == ic && ej == ib)
-                                            edge = &var.edge_vec[j*NDIMS];
-                                    }
+                                    // ic < ib, matching how create_boundary_normals keys the table.
+                                    const int slot = var.edge_slot[ic*nbdrytypes + ib];
+                                    if (slot < 0) continue;  // no shared edge, so no direction to project onto
+                                    const double *edge = &var.edge_vec[slot*NDIMS];
+
                                     double ve = 0;
                                     for (int d=0; d<NDIMS; d++)
                                         ve += v[d] * edge[d];

--- a/bc.cxx
+++ b/bc.cxx
@@ -779,9 +779,10 @@ void apply_stress_bcs(const Param& param, const Variables& var, array_t& force)
             #pragma acc parallel loop gang vector async
             for (int j=0; j<nbdry_nodes; ++j) {
                 const int n = (*var.bnodes[i])[j];
-                const int_vec& sup = (*var.support)[n];
-                for (int k=0; k<sup.size(); ++k) {
-                    int e = sup[k];
+                const int npatch = var.support.size(n);
+                const int* patch = var.support.patch(n);
+                for (int k=0; k<npatch; ++k) {
+                    int e = patch[k];
                     int ibound = (*var.etmp_int)[e];
                     if (ibound < 0) continue;  // not a boundary element
 
@@ -1041,9 +1042,10 @@ namespace {
             for (int i=0; i<ntop; ++i) {
                 int n = top_nodes[i];
 #ifdef THREED
-                int_vec &surf_sup = (*var.surfinfo.node_and_elems)[i];
+                const int nsurf_sup = var.surfinfo.support_surf.size(i);
+                const int* surf_sup = var.surfinfo.support_surf.patch(i);
 
-                for (int j=0; j<surf_sup.size(); ++j) {
+                for (int j=0; j<nsurf_sup; ++j) {
                     int k = surf_sup[j];
                     total_dx[n] += (*var.etmp)[k];
 
@@ -1687,10 +1689,12 @@ void correct_surface_element(const Variables& var, double_vec& volume, double_ve
         #pragma acc parallel loop gang vector async
         for (int n=0;n<var.surfinfo.ntop;n++) {
             int nt = (*var.surfinfo.top_nodes)[n];
-            int_vec &sup = (*var.support)[nt];
-            volume_n[nt] = 0.;
-            for (size_t i=0;i<sup.size();i++)
-                volume_n[nt] += volume[sup[i]];
+            const int npatch = var.support.size(nt);
+            const int* patch = var.support.patch(nt);
+            double acc = 0.;
+            for (int i=0;i<npatch;i++)
+                acc += volume[patch[i]];
+            volume_n[nt] = acc;
         }
     }
 

--- a/bc.cxx
+++ b/bc.cxx
@@ -330,8 +330,11 @@ void apply_vbcs(const Param &param, const Variables &var, array_t &vel)
     if (param.control.PT_jump) {
         bc_vx0 = 0.0;
         bc_vx1 = 0.0;
+#ifdef THREED
+        // Only 3D has y boundaries to hold at rest; in 2D y is not a boundary direction.
         bc_vy0 = 0.0;
         bc_vy1 = 0.0;
+#endif
         bc_vz0 = 0.0;
         bc_vz1 = 0.0;
 #ifndef THREED

--- a/bc.cxx
+++ b/bc.cxx
@@ -199,6 +199,28 @@ void create_boundary_normals(const Variables &var, array_t &bnormals,
 #endif
         }
     }
+
+    // apply_vbcs projects the velocity onto this edge for any node flagged on both
+    // boundaries of a pair, from inside a device kernel that can neither report nor
+    // abort. A pair can be flagged on a node while the loop above skipped it -- either
+    // boundary having no facets is enough -- and the constraint is then dropped in
+    // silence. Report it here, the last place with somewhere to say it, for the pairs
+    // the kernel can actually ask about.
+    for (int ib=iboundn0; ib<=iboundn3; ib++) {
+        if (var.vbc_types[ib] != 1 && var.vbc_types[ib] != 11) continue;
+        for (int ic=iboundx0; ic<ib; ic++) {
+            if (var.vbc_types[ic] != 1) continue;
+            if (edge_slot[ic*nbdrytypes + ib] >= 0) continue;
+            for (int n=0; n<var.nnode; ++n) {
+                uint flag = (*var.bcflag)[n];
+                if (!(flag & (1U << ib)) || !(flag & (1U << ic))) continue;
+                std::cerr << "Warning: boundaries " << ic << " and " << ib << " meet at node "
+                          << n << " but share no edge; apply_vbcs leaves the edge-parallel "
+                          << "velocity constraint unapplied there\n";
+                break;
+            }
+        }
+    }
 }
 
 

--- a/bc.cxx
+++ b/bc.cxx
@@ -154,7 +154,7 @@ void create_boundary_normals(const Variables &var, array_t &bnormals,
 #ifdef THREED
                     std::cerr << bnormals[i][2] << " - " << normal[2] << '\n';
 #endif
-                    std::exit(1);
+                    die(EXIT_MESH_QUALITY);
                 }
             }
         }
@@ -1736,8 +1736,7 @@ void surface_processes(const Param& param, const Variables& var, array_t& coord,
         break;
     case 102:
 #ifdef THREED
-        std::cout << "3D deposition of sediment processes is not ready yet.";
-        exit(168);
+        die(EXIT_UNSUPPORTED_DIM, "3D deposition of sediment processes is not ready yet.");
 #else
         simple_diffusion(var);
         if (var.steps != 0) {
@@ -1749,7 +1748,7 @@ void surface_processes(const Param& param, const Variables& var, array_t& coord,
         break;
     default:
         std::cout << "Error: unknown surface process option: " << param.control.surface_process_option << '\n';
-        std::exit(1);
+        die(EXIT_CONFIG_VALUE);
     }
 
 #ifndef ACC

--- a/bc.cxx
+++ b/bc.cxx
@@ -646,7 +646,7 @@ void apply_stress_bcs(const Param& param, const Variables& var, array_t& force)
     //
 
 #ifndef ACC
-    #pragma omp parallel for
+    #pragma omp parallel for default(none) shared(var)
 #endif
     #pragma acc parallel loop gang vector async
     for (int e=0; e<var.nelem; ++e)

--- a/bc.cxx
+++ b/bc.cxx
@@ -1635,8 +1635,8 @@ void surface_plstrain_diffusion(const Param &param, \
 #endif
     double half_life = 1.e2 * YEAR2SEC;
     double lambha = 0.69314718056 / half_life; // ln2
-    // #pragma omp parallel for default(none)      \
-    //     shared(param, var, plstrain, lambha)
+    // Not parallelized: the loop is over top elements only and runs once per step.
+    // #pragma omp parallel for default(none) shared(param, var, plstrain, lambha)
     for (auto e=(*var.top_elems).begin();e<(*var.top_elems).end();e++) {
         // Find the most abundant marker mattype in this element
         int_vec &a = (*var.elemmarkers)[*e];

--- a/bc.cxx
+++ b/bc.cxx
@@ -807,7 +807,7 @@ void apply_stress_bcs_neumann(const Param& param, const Variables& var, array_t&
     nvtxRangePush(__FUNCTION__);
 #endif
 
-    #pragma wait // here is not ACC parallelized
+    #pragma acc wait
 
     // Apply general stress (Neumann) boundary conditions
     for (int i = 0; i < 6; ++i) {
@@ -1449,6 +1449,8 @@ namespace {
 #ifdef NPROF_DETAIL
         nvtxRangePush(__FUNCTION__);
 #endif
+        #pragma acc wait
+
         const array_t& coord = *var.coord;
         const SurfaceInfo& surfinfo = var.surfinfo;
         const int_vec& top_nodes = *surfinfo.top_nodes;

--- a/bc.hpp
+++ b/bc.hpp
@@ -4,7 +4,7 @@
 bool is_on_boundary(const Variables &var, int node);
 double find_max_vbc(const BC &bc);
 void create_boundary_normals(const Variables &var, array_t &bnormals,
-                             std::map<std::pair<int,int>, double_vec>  &edge_vectors, double_vec& edge_vec, int_vec &edge_vec_idx);
+                             double_vec& edge_vec, int* edge_slot);
 void apply_vbcs(const Param &param, const Variables &var, array_t &vel);
 void apply_stress_bcs(const Param& param, const Variables& var, array_t& force);
 void apply_stress_bcs_neumann(const Param& param, const Variables& var, array_t& force);

--- a/benchmarks-cores/Makefile
+++ b/benchmarks-cores/Makefile
@@ -53,7 +53,6 @@ VTK := 0
 NDIMS := 3
 INDIR := 0
 EXE := ../dynearthsol$(NDIMS)d
-FUNC := compute_mass
 NUM := 0
 DATE := $(shell date +%Y-%m-%d)
 HOST := $(shell hostname -s)
@@ -61,6 +60,16 @@ KERNEL := CPU
 ifeq ($(ACC), 1)
 	KERNEL := GPU
 	EXE := ../dynearthsol$(NDIMS)d.gpu
+endif
+
+# Reject a knob this Makefile does not know: a misspelled CASES= would otherwise
+# benchmark the default case and report a plausible-looking time.
+KNOWN_VARS = CASE FRAME OMP NDIMS ACC DEBUG NSYS VTK INDIR EXE NUM TFLAG \
+             ORIG CURR KERNEL
+CMDLINE_VARS = $(foreach v,$(.VARIABLES),$(if $(filter command line,$(origin $(v))),$(v)))
+UNKNOWN_VARS = $(filter-out $(KNOWN_VARS),$(CMDLINE_VARS))
+ifneq ($(UNKNOWN_VARS),)
+$(error unknown make variable(s): $(UNKNOWN_VARS). Known: $(KNOWN_VARS))
 endif
 
 MODELNAME := $(shell awk -F '=' '/^modelname/ {gsub(/^[ \t]+|[ \t]+/, "", $$2); print $$2}' $(CASE))

--- a/benchmarks-cores/test-3d-equ-tiny.cfg
+++ b/benchmarks-cores/test-3d-equ-tiny.cfg
@@ -8,10 +8,10 @@ output_step_interval = 100
 has_output_during_remeshing = no
 is_outputting_averaged_fields = no
 
-checkpoint_frame_interval = 5
+checkpoint_frame_interval = 1
 #is_restarting = yes
 #restarting_from_modelname = benchmark
-#restarting_from_frame = 120
+restarting_from_frame = 2
 
 [mesh]
 meshing_option = 1

--- a/binaryio.cxx
+++ b/binaryio.cxx
@@ -316,7 +316,7 @@ void BinaryInput::read_array(std::vector<T>& A, const char *name, std::size_t si
     }
 
     seek_to_array(name);
-    int n = std::fread(A.data(), sizeof(T), size, f);
+    const std::size_t n = std::fread(A.data(), sizeof(T), size, f);
 
     if (n != size) {
         std::cerr << "Error: cannot read array: " << name << '\n';
@@ -343,7 +343,7 @@ void BinaryInput::read_array(Array2D<T,N>& A, const char *name, std::size_t size
     if (buffer.size() < total_elements)
         buffer.resize(total_elements);
 
-    int n = std::fread(buffer.data(), sizeof(T), size * N, f);
+    const std::size_t n = std::fread(buffer.data(), sizeof(T), size * N, f);
     if (n != N * size) {
         std::cerr << "Error: cannot read array (buffered path): " << name << '\n';
         die(EXIT_IO_RW);

--- a/binaryio.cxx
+++ b/binaryio.cxx
@@ -5,6 +5,7 @@
 #include "constants.hpp"
 #include "parameters.hpp"
 #include "binaryio.hpp"
+#include "utils.hpp"
 #include "markerset.hpp"
 
 #ifdef WIN32
@@ -70,7 +71,7 @@ BinaryOutput::BinaryOutput(const char *filename, const bool rename_if_exists)
     f = std::fopen(filename, "wb");
     if (f == NULL) {
         std::cerr << "Error: cannot open file: " << filename << '\n';
-        std::exit(2);
+        die(EXIT_IO_OPEN);
     }
 
     header = new char[headerlen]();
@@ -111,12 +112,12 @@ void BinaryOutput::write_header(const char *name)
     if (len >= bsize) {
         std::cerr << "Error: exceeding buffer length at Output::write_array, name=" << name
                   << " eof_position=" << eof_pos << '\n';
-        std::exit(12);
+        die(EXIT_INTERNAL_ASSERT);
     }
     if (len >= headerlen - (hd_pos - header)*sizeof(char)) {
         std::cerr << "Error: exceeding header length at Output::write_array, name=" << name
                   << " eof_position=" << eof_pos << '\n';
-        std::exit(12);
+        die(EXIT_INTERNAL_ASSERT);
     }
     hd_pos = std::strncat(hd_pos, buffer, len);
 }
@@ -209,7 +210,7 @@ BinaryInput::BinaryInput(const char *filename)
     f = std::fopen(filename, "r");
     if (f == NULL) {
         std::cerr << "Error: cannot open file: " << filename << '\n';
-        std::exit(2);
+        die(EXIT_IO_OPEN);
     }
     read_header();
 }
@@ -234,8 +235,7 @@ void BinaryInput::read_header()
     char *header = new char[headerlen]();
     std::size_t n = std::fread(header, sizeof(char), headerlen, f);
     if (n != headerlen) {
-        std::cerr << "Error: error reading file header\n";
-        std::exit(2);
+        die(EXIT_IO_RW, "error reading file header");
     }
 
     /* Parse the content of header buffer */
@@ -247,7 +247,7 @@ void BinaryInput::read_header()
         std::cerr << "Error: mismatching revision string in header\n"
                   << "  Expect: " << revision_str
                   << "  Got: "<< line << '\n';
-        std::exit(1);
+        die(EXIT_IO_RESTART);
     }
 
     line = std::strtok(NULL, "\n");
@@ -257,7 +257,7 @@ void BinaryInput::read_header()
         if (tab == NULL) {
             std::cerr << "Error: error parsing file header\n"
                       << " Line is:" << line << '\n';
-            std::exit(1);
+            die(EXIT_IO_RW);
         }
         std::string name(line, tab-line);
         std::size_t loc;
@@ -277,7 +277,7 @@ void BinaryInput::seek_to_array(const char *name)
     auto it = offset.find(name);
     if (it == offset.end()) {
         std::cerr << "Error: no array with a name: " << name << '\n';
-        std::exit(1);
+        die(EXIT_IO_RESTART);
     }
     std::size_t loc = it->second;
     //std::cout << name << ' ' << loc << '\n';
@@ -292,7 +292,7 @@ void BinaryInput::read_scalar(T& A, const std::string& name)
     std::size_t n = std::fread(&A, sizeof(T), 1, f);
     if (n != 1) {
         std::cerr << "Error: cannot read scalar: " << name << '\n';
-        std::exit(1);
+        die(EXIT_IO_RW);
     }
 }
 
@@ -312,7 +312,7 @@ void BinaryInput::read_array(std::vector<T>& A, const char *name, std::size_t si
     size = size > 0 ? size : A.size();
     if (A.size() == 0) {
         std::cerr << "Error: array size is 0: " << name << '\n';
-        std::exit(1);
+        die(EXIT_IO_RW);
     }
 
     seek_to_array(name);
@@ -320,7 +320,7 @@ void BinaryInput::read_array(std::vector<T>& A, const char *name, std::size_t si
 
     if (n != size) {
         std::cerr << "Error: cannot read array: " << name << '\n';
-        std::exit(1);
+        die(EXIT_IO_RW);
     }
 }
 
@@ -333,7 +333,7 @@ void BinaryInput::read_array(Array2D<T,N>& A, const char *name, std::size_t size
     size = size > 0 ? size : A.size();
     if (A.size() == 0) {
         std::cerr << "Error: array size is 0: " << name << '\n';
-        std::exit(1);
+        die(EXIT_IO_RW);
     }
 
     seek_to_array(name);
@@ -346,7 +346,7 @@ void BinaryInput::read_array(Array2D<T,N>& A, const char *name, std::size_t size
     int n = std::fread(buffer.data(), sizeof(T), size * N, f);
     if (n != N * size) {
         std::cerr << "Error: cannot read array (buffered path): " << name << '\n';
-        std::exit(1);
+        die(EXIT_IO_RW);
     }
 
     A.load_from_buffer(buffer.data(), size, false);
@@ -695,7 +695,7 @@ void HDF5Output::write_array(const std::vector<T> &A, const char *name, hsize_t 
         } else if (len == nseg || len == etop) {
         } else {
             printf("name = %s\n", name);
-            std::exit(13);
+            die(EXIT_INTERNAL_ASSERT);
         }
     }
     std::string full_name = "/VTKHDF/" + block_base + "/" + mid + name;
@@ -743,7 +743,7 @@ void HDF5Output::write_array(const Array2D<T, N>& A, const char *name, hsize_t l
         } else if (len == nseg || len == etop) {
         } else {
             printf("name = %s\n", name);
-            std::exit(13);
+            die(EXIT_INTERNAL_ASSERT);
         }
     }
 
@@ -917,7 +917,7 @@ HDF5Input::HDF5Input(const char *filename)
     file_id = H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT);
     if (file_id < 0) {
         std::cerr << "Error: cannot open HDF5 file for reading: " << filename << "\n";
-        std::exit(1);
+        die(EXIT_IO_OPEN);
     }
 
     read_header();
@@ -926,8 +926,7 @@ HDF5Input::HDF5Input(const char *filename)
 void HDF5Input::read_header()
 {
     if (H5Aexists(file_id, "ndims") <= 0) {
-        std::cerr << "Error: missing attribute ndims in HDF5 file\n";
-        std::exit(1);
+        die(EXIT_IO_RESTART, "missing attribute ndims in HDF5 file");
     }
 
     hid_t attr = H5Aopen(file_id, "ndims", H5P_DEFAULT);
@@ -941,12 +940,11 @@ void HDF5Input::read_header()
     if (ndims != NDIMS) {
         std::cerr << "Error: mismatching ndims in HDF5 file\n"
                   << "  Expect: " << NDIMS << "  Got: " << ndims << '\n';
-        std::exit(1);
+        die(EXIT_IO_RESTART);
     }
 
     if (H5Aexists(file_id, "revision") <= 0) {
-        std::cerr << "Error: missing attribute revision in HDF5 file\n";
-        std::exit(1);
+        die(EXIT_IO_RESTART, "missing attribute revision in HDF5 file");
     }
 
     attr = H5Aopen(file_id, "revision", H5P_DEFAULT);
@@ -960,7 +958,7 @@ void HDF5Input::read_header()
     if (revision != BINARY_FILE_REVISION) {
         std::cerr << "Error: mismatching revision in HDF5 file\n"
                   << "  Expect: " << BINARY_FILE_REVISION << "  Got: " << revision << '\n';
-        std::exit(1);
+        die(EXIT_IO_RESTART);
     }
 }
 
@@ -984,25 +982,25 @@ void HDF5Input::read_scalar(T& A, const std::string& name)
     hid_t dset_id = H5Dopen2(file_id, name.c_str(), H5P_DEFAULT);
     if (dset_id < 0) {
         std::cerr << "Error: cannot open dataset: " << name << "\n";
-        std::exit(1);
+        die(EXIT_IO_RW);
     }
     hid_t space_id = H5Dget_space(dset_id);
     if (space_id < 0) {
         H5Dclose(dset_id);
         std::cerr << "Error: cannot get dataspace for " << name << "\n";
-        std::exit(1);
+        die(EXIT_IO_RW);
     }
     int rank = H5Sget_simple_extent_ndims(space_id);
     if (rank < 0) {
         H5Sclose(space_id); H5Dclose(dset_id);
         std::cerr << "Error: cannot get rank for " << name << "\n";
-        std::exit(1);
+        die(EXIT_IO_RESTART);
     }
     if (rank == 0 || rank > 1) {
         H5Sclose(space_id); H5Dclose(dset_id);
         std::cerr << "Error: dataset rank mismatch for " << name
                   << ", expected rank 1, got " << rank << "\n";
-        std::exit(1);
+        die(EXIT_IO_RW);
     }
 
     hid_t mspace_id =  H5Screate(H5S_SCALAR);
@@ -1010,7 +1008,7 @@ void HDF5Input::read_scalar(T& A, const std::string& name)
     if (mspace_id < 0) {
         H5Sclose(space_id); H5Dclose(dset_id);
         std::cerr << "Error: cannot create memspace for " << name << "\n";
-        std::exit(1);
+        die(EXIT_IO_RW);
     }
 
     hid_t dtype_id = H5Native<T>::id();
@@ -1018,7 +1016,7 @@ void HDF5Input::read_scalar(T& A, const std::string& name)
     if (H5Dread(dset_id, dtype_id, mspace_id, space_id, H5P_DEFAULT, &A) < 0) {
         H5Sclose(mspace_id); H5Sclose(space_id); H5Dclose(dset_id);
         std::cerr << "Error: failed to read dataset: " << name << "\n";
-        std::exit(1);
+        die(EXIT_IO_RW);
     }
 
     H5Sclose(mspace_id);
@@ -1037,33 +1035,33 @@ void HDF5Input::read_array(std::vector<T>& A, const char *name, std::size_t size
     size = size > 0 ? size : A.size();
     if (size == 0) {
         std::cerr << "Error: array size is 0: " << name << '\n';
-        std::exit(1);
+        die(EXIT_IO_RW);
     }
 
     hid_t dset_id = H5Dopen2(file_id, name, H5P_DEFAULT);
     if (dset_id < 0) {
         std::cerr << "Error: cannot open dataset: " << name << "\n";
-        std::exit(1);
+        die(EXIT_IO_RW);
     }
     hid_t space_id = H5Dget_space(dset_id);
     if (space_id < 0) {
         H5Dclose(dset_id);
         std::cerr << "Error: cannot get dataspace for " << name << "\n";
-        std::exit(1);
+        die(EXIT_IO_RW);
     }
     int rank = H5Sget_simple_extent_ndims(space_id);
     if (rank != 1) {
         H5Sclose(space_id); H5Dclose(dset_id);
         std::cerr << "Error: dataset rank mismatch for " << name
                   << ", expected rank 0 or 1, got " << rank << "\n";
-        std::exit(1);
+        die(EXIT_IO_RESTART);
     }
     hsize_t dims[1];
     H5Sget_simple_extent_dims(space_id, dims, nullptr);
     if (dims[0] != size) {
         std::cerr << "Error: array size is not matched: " << name
                   << " (file dim = " << dims[0] << ", expected = " << size << ")\n";
-        std::exit(1);
+        die(EXIT_IO_RW);
     }
 
     hid_t mspace_id = H5Screate_simple(1, dims, nullptr);
@@ -1072,7 +1070,7 @@ void HDF5Input::read_array(std::vector<T>& A, const char *name, std::size_t size
     if (H5Dread(dset_id, dtype_id, mspace_id, space_id, H5P_DEFAULT, A.data()) < 0) {
         H5Sclose(mspace_id); H5Sclose(space_id); H5Dclose(dset_id);
         std::cerr << "Error: failed to read dataset: " << name << "\n";
-        std::exit(1);
+        die(EXIT_IO_RW);
     }
 
     H5Sclose(mspace_id);
@@ -1089,25 +1087,25 @@ void HDF5Input::read_array(Array2D<T,N>& A, const char *name, std::size_t size)
     size = size > 0 ? size : A.size();
     if (A.size() == 0) {
         std::cerr << "Error: array size is 0: " << name << '\n';
-        std::exit(1);
+        die(EXIT_IO_RW);
     }
 
     hid_t dset_id = H5Dopen2(file_id, name, H5P_DEFAULT);
     if (dset_id < 0) {
         std::cerr << "Error: cannot open dataset: " << name << "\n";
-        std::exit(1);
+        die(EXIT_IO_RW);
     }
     hid_t space_id = H5Dget_space(dset_id);
     if (space_id < 0) {
         H5Dclose(dset_id);
         std::cerr << "Error: cannot get dataspace for " << name << "\n";
-        std::exit(1);
+        die(EXIT_IO_RW);
     }
     int rank = H5Sget_simple_extent_ndims(space_id);
     if (rank != 2) {
         std::cerr << "Error: dataset rank mismatch for " << name 
                   << ", expected 2 dims, got " << rank << '\n';
-        std::exit(1);
+        die(EXIT_IO_RESTART);
     }
 
     hsize_t dims[2];
@@ -1116,7 +1114,7 @@ void HDF5Input::read_array(Array2D<T,N>& A, const char *name, std::size_t size)
         std::cerr << "Error: dataset dimensions mismatch for " << name
                   << ": file dims = (" << dims[0] << ", " << dims[1]
                   << "), expected (" << size << ", " << N << ")\n";
-        std::exit(1);
+        die(EXIT_IO_RW);
     }
     hid_t mspace_id = H5Screate_simple(2, dims, nullptr);
     hid_t dtype_id = H5Native<T>::id();
@@ -1129,7 +1127,7 @@ void HDF5Input::read_array(Array2D<T,N>& A, const char *name, std::size_t size)
     if (H5Dread(dset_id, dtype_id, mspace_id, space_id, H5P_DEFAULT, buffer.data()) < 0) {
         H5Sclose(mspace_id); H5Sclose(space_id); H5Dclose(dset_id);
         std::cerr << "Error: failed to read dataset: " << name << "\n";
-        std::exit(1);
+        die(EXIT_IO_RW);
     }
 
     A.load_from_buffer(buffer.data(), size, false);

--- a/brc-interpolation.cxx
+++ b/brc-interpolation.cxx
@@ -157,6 +157,9 @@ void prepare_interpolation(const Param& param, const Variables &var,
 
     array_t block_queries;
 
+    // bary's coeff_ is filled by an async ACC kernel; it is read on the host below
+    #pragma acc wait
+
     for (int b = 0; b < nblocks; b++) {
         int start = b * nodes_per_block;
         int end = std::min((b + 1) * nodes_per_block, var.nnode);

--- a/brc-interpolation.cxx
+++ b/brc-interpolation.cxx
@@ -103,7 +103,7 @@ void prepare_interpolation(const Param& param, const Variables &var,
                            const Barycentric_transformation &bary,
                            const array_t &old_coord,
                            const conn_t &old_connectivity,
-                           const int_vec2D &old_support,
+                           const Support &old_support,
                            brc_t &brc, int_vec &el)
 {
 #ifdef NPROF_DETAIL
@@ -188,7 +188,8 @@ void prepare_interpolation(const Param& param, const Variables &var,
             double dd = neighbors[local_i].dist2;
 
             // elements surrounding nn
-            const int_vec &nn_elem = old_support[nn];
+            const int nn_nelem = old_support.size(nn);
+            const int* nn_elem = old_support.patch(nn);
 
         // std::cout << i << " ";
         // print(std::cout, q, NDIMS);
@@ -211,7 +212,7 @@ void prepare_interpolation(const Param& param, const Variables &var,
 
             // loop over (old) elements surrounding nn to find
             // the element that is enclosing q
-            for (std::size_t j=0; j<nn_elem.size(); j++) {
+            for (int j=0; j<nn_nelem; j++) {
                 e = nn_elem[j];
                 bary.transform(q, e, r);
                 if (bary.is_inside(r)) {
@@ -243,11 +244,11 @@ void prepare_interpolation(const Param& param, const Variables &var,
                 * the capped search does not find q, it may be outside the old domain and
                 * will fall through to the nearest-node fallback below.
                 */
-                std::unordered_set<int> visited(nn_elem.begin(), nn_elem.end());
-                int_vec frontier(nn_elem.begin(), nn_elem.end());
+                std::unordered_set<int> visited(nn_elem, nn_elem + nn_nelem);
+                int_vec frontier(nn_elem, nn_elem + nn_nelem);
                 // Track the element where q is least outside (highest min bary coord).
                 // Used post-BFS to distinguish boundary-face vs. clearly-outside vs. bug.
-                int    best_e_bfs    = nn_elem.empty() ? 0 : nn_elem[0];
+                int    best_e_bfs    = (nn_nelem == 0) ? 0 : nn_elem[0];
                 double best_min_bary = -1e30;
 
                 const int MAX_LAYERS = 3;
@@ -258,8 +259,9 @@ void prepare_interpolation(const Param& param, const Variables &var,
                         for (int m=0; m<NODES_PER_ELEM; m++) {
                             // np is a node close to q
                             int np = conn[m];
-                            const int_vec &np_elem = old_support[np];
-                            for (std::size_t jj=0; jj<np_elem.size(); jj++) {
+                            const int np_nelem = old_support.size(np);
+                            const int* np_elem = old_support.patch(np);
+                            for (int jj=0; jj<np_nelem; jj++) {
                                 int candidate = np_elem[jj];
                                 if (!visited.insert(candidate).second) continue;
                                 bary.transform(q, candidate, r);
@@ -349,7 +351,7 @@ void barycentric_node_interpolation(const Param& param, Variables &var,
 
     int_vec el(n);
     brc_t brc(n);
-    prepare_interpolation(param, var, bary, old_coord, old_connectivity, *var.support, brc, el);
+    prepare_interpolation(param, var, bary, old_coord, old_connectivity, var.support, brc, el);
 
     double_vec *new_temperature = new double_vec(n);
     interpolate_field(brc, el, old_connectivity, *var.temperature, *new_temperature, n);
@@ -424,7 +426,7 @@ void barycentric_node_interpolation_forT(const Param& param, const Variables &va
                                          const Barycentric_transformation &bary,
                                          const array_t &input_coord,
                                          const conn_t &input_connectivity,
-                                         const int_vec2D &input_support,
+                                         const Support &input_support,
 					 const double_vec &inputtemperature,
 					 double_vec &outputtemperature)
 {

--- a/brc-interpolation.cxx
+++ b/brc-interpolation.cxx
@@ -433,4 +433,6 @@ void barycentric_node_interpolation_forT(const Param& param, const Variables &va
     prepare_interpolation(param, var, bary, input_coord, input_connectivity, input_support, brc, el);
 
     interpolate_field(brc, el, input_connectivity, inputtemperature, outputtemperature, var.nnode);
+
+    #pragma acc wait
 }

--- a/brc-interpolation.hpp
+++ b/brc-interpolation.hpp
@@ -10,7 +10,7 @@ void barycentric_node_interpolation_forT(const Param& param, const Variables &va
                                          const Barycentric_transformation &bary,
                                          const array_t &input_coord,
                                          const conn_t &input_connectivity,
-                                         const int_vec2D &input_support,
+                                         const Support &input_support,
                                          const double_vec &inputtemperature,
                                          double_vec &outputtemperature);
 

--- a/dynearthsol.cxx
+++ b/dynearthsol.cxx
@@ -265,7 +265,7 @@ void restart(const Param& param, Variables& var)
         if (!got_meta) {
             std::cerr << "Error: frame " << param.sim.restarting_from_frame
                     << " not found in " << filename << ".\n";
-            exit(2);
+            die(EXIT_IO_RESTART);
         }
     } else {
         std::cerr << "Warning: cannot open info file " << filename
@@ -281,7 +281,7 @@ void restart(const Param& param, Variables& var)
         } else {
             std::cerr << "Error: cannot read frame metadata from " << filename
                       << " and " << filename_save << " has none embedded.\n";
-            std::exit(2);
+            die(EXIT_IO_RESTART);
         }
     }
 

--- a/dynearthsol.cxx
+++ b/dynearthsol.cxx
@@ -617,8 +617,10 @@ int main(int argc, const char* argv[])
     Param param;
     get_input_parameters(argv[1], param);
 
-    report_cpu_runtime_status();
-    report_openacc_runtime_status();
+    // Selects the offload device, so it must precede any compute.
+    init_offload_device();
+    report_host_runtime_status();
+    report_device_runtime_status();
 
     //
     // run simulation

--- a/dynearthsol.cxx
+++ b/dynearthsol.cxx
@@ -186,6 +186,9 @@ void init(const Param& param, Variables& var)
     #pragma acc wait
 
     *var.volume_old = *var.volume;
+    // Must precede apply_vbcs: it is the only writer of edge_vec/edge_slot, which
+    // apply_vbcs reads for any node on two boundaries at once.
+    create_boundary_normals(var, *var.bnormals, var.edge_vec, var.edge_slot);
     apply_vbcs(param, var, *var.vel); // Global-velocity scaling needs boundary conditions before compute_mass.
     var.dt = compute_dt(param, var);  // Global-velocity scaling needs dt before compute_mass.
     compute_mass(param, var, var.max_vbc_val, *var.volume_n, *var.mass, *var.tmass, *var.hmass, *var.ymass, *var.tmp_result);
@@ -195,8 +198,6 @@ void init(const Param& param, Variables& var)
 #endif
 
 
-    create_boundary_normals(var, *var.bnormals, var.edge_vectors, var.edge_vec, var.edge_vec_idx);
-    // apply_vbcs(param, var, *var.vel); move to above compute_mass
 
 
     // temperature should be init'd before stress and strain
@@ -393,7 +394,7 @@ void restart(const Param& param, Variables& var)
     // require max_global_vel_mag, var.volume, and var.temperature to be loaded before
     compute_mass(param, var, var.max_vbc_val, *var.volume_n, *var.mass, *var.tmass, *var.hmass, *var.ymass, *var.tmp_result);
 
-    create_boundary_normals(var, *var.bnormals, var.edge_vectors, var.edge_vec, var.edge_vec_idx);
+    create_boundary_normals(var, *var.bnormals, var.edge_vec, var.edge_slot);
 
     apply_vbcs(param, var, *var.vel);
 

--- a/dynearthsol.cxx
+++ b/dynearthsol.cxx
@@ -862,11 +862,8 @@ int main(int argc, const char* argv[])
         }
 
 
-        // if(param.control.has_hydraulic_diffusion && var.steps > 1) // ignoring poroelastic effect due to inital imbalance 
-        if(param.control.has_hydraulic_diffusion) { // ignoring poroelastic effect due to inital imbalance
-            #pragma acc wait // following founction is not ACC parallelized
+        if(param.control.has_hydraulic_diffusion)
             update_pore_pressure(param, var, *var.ppressure, *var.dppressure, *var.ntmp, *var.tmp_result, *var.stress, *var.old_mean_stress);
-        }
 
         apply_vbcs(param, var, *var.vel);
         if (param.control.has_moving_mesh)

--- a/dynearthsol.cxx
+++ b/dynearthsol.cxx
@@ -202,6 +202,8 @@ void init(const Param& param, Variables& var)
 
     // temperature should be init'd before stress and strain
     initial_temperature(param, var, *var.temperature, *var.radiogenic_source, var.bottom_temperature, *var.markersets[0], *var.elemmarkers, *var.markers_in_elem);
+    // initial_temperature() reassigns mantle to asthenosphere, moving elemmarkers.
+    var.mat->refresh_elem_cache();
     initial_stress_state(param, var, *var.stress, *var.stressyy, *var.old_mean_stress, *var.strain, var.compensation_pressure);
     // initial_stress_state_1d_load(param, var, *var.stress, *var.stressyy, *var.old_mean_stress, *var.strain, var.compensation_pressure);
     if(param.control.has_hydraulic_diffusion)
@@ -472,6 +474,9 @@ void update_mesh(const Param& param, Variables& var)
 #endif
 
     compute_volume(var, *var.volume);
+
+    // surface_processes() above can move elemmarkers via correct_surface_marker().
+    var.mat->refresh_elem_cache();
 
     if (param.control.use_global_velocity_scaling) {
         var.dt = compute_dt(param, var);
@@ -765,6 +770,8 @@ int main(int argc, const char* argv[])
 #endif
         var.steps ++;
         var.time += var.dt;
+        // Pick up what the previous step's phase changes and remeshing moved.
+        var.mat->refresh_elem_cache();
         // dt_copy = 0.0; dt_copy += var.dt;
         if (param.control.has_thermal_diffusion)
             update_temperature(param, var, *var.temperature, *var.tmp_result);
@@ -877,6 +884,8 @@ int main(int argc, const char* argv[])
             // The functions inside this if-block are expensive in computation is expensive,
             // and only changes slowly. Don't have to do it every time step
             phase_changes(param, var);
+            // phase_changes() moved elemmarkers; compute_dt() below reads them.
+            var.mat->refresh_elem_cache();
 
             if (param.control.has_hydration_processes)
                 advect_hydrous_markers(param, var, 10*var.dt,

--- a/fields.cxx
+++ b/fields.cxx
@@ -299,9 +299,11 @@ void update_pore_pressure(const Param &param, const Variables &var,
     // Initialize diff_max_local for reduction
     double diff_max_local = 1.0e-38;
 
+#ifndef ACC
     #pragma omp parallel for default(none) shared(var, ppressure, tmp_result, stress, old_mean_stress, param) \
         reduction(max:diff_max_local)
-    // #pragma acc parallel loop reduction(max:diff_max_local)
+#endif
+        #pragma acc parallel loop gang vector reduction(max:diff_max_local) async
     for (int e = 0; e < var.nelem; e++) {
         ConstConnAccessor conn = (*var.connectivity)[e];
         ElemCacheAccessor tr = tmp_result[e];
@@ -362,11 +364,10 @@ void update_pore_pressure(const Param &param, const Variables &var,
         }
     }
 
-    // Update global hydro_diff_max after the loop
-    var.mat->hydro_diff_max = diff_max_local;
-
+#ifndef ACC
     #pragma omp parallel for default(none) shared(param, var, tdot, ppressure, dppressure, tmp_result)
-    // #pragma acc parallel loop
+#endif
+    #pragma acc parallel loop gang vector async
     for (int n = 0; n < var.nnode; n++) {
         tdot[n] = 0.0;
         {
@@ -393,6 +394,9 @@ void update_pore_pressure(const Param &param, const Variables &var,
             
     }
 
+    #pragma acc wait
+    // Update global hydro_diff_max after the loop
+    var.mat->hydro_diff_max = diff_max_local;
 #ifdef NPROF
     nvtxRangePop();
 #endif

--- a/fields.cxx
+++ b/fields.cxx
@@ -185,6 +185,9 @@ void reallocate_variables(const Param& param, Variables& var)
         var.old_mean_stress = new double_vec(var.nelem);
     }
 
+    // Must run AFTER remap_markers(), which deletes and recreates *var.elemmarkers:
+    // MatProps binds it by REFERENCE and its constructor seeds the property-mean cache.
+    // Called earlier the cache is built from empty counts -- wrong means, not a crash.
     delete var.mat;
     var.mat = new MatProps(param, var);
 

--- a/fields.cxx
+++ b/fields.cxx
@@ -572,7 +572,7 @@ static void apply_damping(const Param& param, const Variables& var, array_t& for
         break;
     default:
         std::cerr << "Error: unknown damping_option: " << param.control.damping_option << '\n';
-        std::exit(1);
+        die(EXIT_CONFIG_VALUE);
     }
 #ifdef NPROF_DETAIL
     nvtxRangePop();

--- a/fields.cxx
+++ b/fields.cxx
@@ -301,8 +301,9 @@ void update_pore_pressure(const Param &param, const Variables &var,
     // Initialize diff_max_local for reduction
     double diff_max_local = 1.0e-38;
 
-    #pragma omp parallel for default(none) shared(var, ppressure, tmp_result, stress, old_mean_stress, param, diff_max_local)
-    // #pragma acc parallel loop
+    #pragma omp parallel for default(none) shared(var, ppressure, tmp_result, stress, old_mean_stress, param) \
+        reduction(max:diff_max_local)
+    // #pragma acc parallel loop reduction(max:diff_max_local)
     for (int e = 0; e < var.nelem; e++) {
         ConstConnAccessor conn = (*var.connectivity)[e];
         ElemCacheAccessor tr = tmp_result[e];

--- a/fields.cxx
+++ b/fields.cxx
@@ -245,17 +245,12 @@ void update_temperature(const Param &param, const Variables &var,
             else {
                 double tdot = 0;
 
-                for( auto e = (*var.support)[n].begin(); e < (*var.support)[n].end(); ++e) {
-                    ConstConnAccessor conn = (*var.connectivity)[*e];
-                    ConstElemCacheAccessor tr = tmp_result[*e];
-                    bool found = false;
-                    for (int i=0;i<NODES_PER_ELEM&&!found;i++) {
-                        if (n == conn[i]) {
-                            tdot += tr[i];
-                            found= true;
-                        }
-                    }
-                }
+                // Same element order, so bit-identical; saves ~100 probes/node in 3D.
+                const int npatch = var.support.size(n);
+                const int* patch = var.support.patch(n);
+                const int* lpatch = var.support.local(n);
+                for (int k=0; k<npatch; ++k)
+                    tdot += tmp_result[patch[k]][lpatch[k]];
                 // Combining temperature update and bc in the same loop for efficiency,
                 // since only the top boundary has Dirichlet bc, and all the other boundaries
                 // have no heat flux bc.
@@ -371,15 +366,12 @@ void update_pore_pressure(const Param &param, const Variables &var,
     // #pragma acc parallel loop
     for (int n = 0; n < var.nnode; n++) {
         tdot[n] = 0.0;
-        for (auto e = (*var.support)[n].begin(); e < (*var.support)[n].end(); ++e) {
-            ConstConnAccessor conn = (*var.connectivity)[*e];
-            ConstElemCacheAccessor tr = tmp_result[*e];
-            for (int i = 0; i < NODES_PER_ELEM; i++) {
-                if (n == conn[i]) {
-                    tdot[n] += tr[i];
-                    break;
-                }
-            }
+        {
+            const int npatch = var.support.size(n);
+            const int* patch = var.support.patch(n);
+            const int* lpatch = var.support.local(n);
+            for (int k = 0; k < npatch; ++k)
+                tdot[n] += tmp_result[patch[k]][lpatch[k]];
         }
 
         // Update pore pressure for non-boundary nodes
@@ -662,18 +654,16 @@ void update_force(const Param& param, const Variables& var, array_t& force, arra
             f = 0;
             ArrayAccessor f_residual = force_residual[n];
             f_residual = 0;
-            for( auto e = (*var.support)[n].begin(); e < (*var.support)[n].end(); ++e) {
-                ConstConnAccessor conn = (*var.connectivity)[*e];
-                ConstElemCacheAccessor tr = tmp_result[*e];
-                for (int i=0;i<NODES_PER_ELEM;i++) {
-                    if (n == conn[i]) {
-                        for (int j=0;j<NDIMS;j++)
-                        {
-                            f[j] -= tr[i+NODES_PER_ELEM*j];
-                            f_residual[j] = tr[i+NODES_PER_ELEM*j];
-                        }
-                        break;
-                    }
+            const int npatch = var.support.size(n);
+            const int* patch = var.support.patch(n);
+            const int* lpatch = var.support.local(n);
+            for (int k=0;k<npatch;++k) {
+                ConstElemCacheAccessor tr = tmp_result[patch[k]];
+                const int i = lpatch[k];
+                for (int j=0;j<NDIMS;j++)
+                {
+                    f[j] -= tr[i+NODES_PER_ELEM*j];
+                    f_residual[j] = tr[i+NODES_PER_ELEM*j];
                 }
             }
         }

--- a/geometry.cxx
+++ b/geometry.cxx
@@ -723,7 +723,7 @@ void SurfaceTopo::build(const Param& param, const Variables& var)
     const double x0 = x0g, L = Lg;
     const SurfaceTopo& topo = *this;
     #pragma omp parallel for default(none) \
-        shared(s, M, dxg, antialias, x0, L, topo) reduction(max:hmax)
+        shared(s, M, topo) firstprivate(dxg, antialias, x0, L) reduction(max:hmax)
     for (int i = 0; i < M; ++i) {
         const double xi = x0 + L * i / (M - 1);
         if (antialias) {
@@ -759,7 +759,7 @@ void SurfaceTopo::build(const Param& param, const Variables& var)
     // `this`, which default(none) does not police, so naming them would not check
     // anything.
     #pragma omp parallel default(none) \
-        shared(s, a, am, cmiT, M, ND, pn)
+        shared(s, a, am, cmiT, M) firstprivate(ND, pn)
     {
         // DCT-I forward: a_m = 2/(M-1) * sum''_i s_i cos(pi m i/(M-1))  (half ends)
         #pragma omp for

--- a/geometry.cxx
+++ b/geometry.cxx
@@ -229,10 +229,12 @@ void compute_dvoldt(const Variables &var, double_vec &dvoldt, double_vec &etmp)
 #endif
     #pragma acc parallel loop gang vector async
     for (int n=0;n<var.nnode;n++) {
-        dvoldt[n] = 0.;
-        for( auto e = (*var.support)[n].begin(); e < (*var.support)[n].end(); ++e)
-	        dvoldt[n] += etmp[*e];
-        dvoldt[n] /= (*var.volume_n)[n];
+        const int npatch = var.support.size(n);
+        const int* patch = var.support.patch(n);
+        double acc = 0.;
+        for (int i=0; i<npatch; ++i)
+            acc += etmp[patch[i]];
+        dvoldt[n] = acc / (*var.volume_n)[n];
     }
 
     // std::cout << "dvoldt:\n";
@@ -298,10 +300,12 @@ void NMD_stress(const Variables &var, tensor_t& stress, double_vec &dp_nd, doubl
 #endif
     #pragma acc parallel loop gang vector async
     for (int n=0;n<var.nnode;n++) {
-        dp_nd[n] = 0;
-        for( auto e = (*var.support)[n].begin(); e < (*var.support)[n].end(); ++e)
-            dp_nd[n] += etmp[*e];
-        dp_nd[n] /= (*var.volume_n)[n];
+        const int npatch = var.support.size(n);
+        const int* patch = var.support.patch(n);
+        double acc = 0;
+        for (int i=0; i<npatch; ++i)
+            acc += etmp[patch[i]];
+        dp_nd[n] = acc / (*var.volume_n)[n];
     }
 
     // dp_el is the averaged (i.e. smoothed) dp_nd on the element.
@@ -482,10 +486,10 @@ static void spr_fused_fields(const Variables &var,
     #pragma acc parallel loop gang vector async copyin(in_ptrs[0:num_fields], \
                 in_strides[0:num_fields], out_ptrs[0:num_fields], out_strides[0:num_fields])
     for (int i = 0; i < var.nnode; ++i) {
-        const int npatch = var.sup.size(i);
+        const int npatch = var.support.size(i);
 
         double smin[MAX_SPR_FIELDS], smax[MAX_SPR_FIELDS];
-        const int* patch = var.sup.patch(i);
+        const int* patch = var.support.patch(i);
         const int e0 = patch[0];
         
         #pragma acc loop seq
@@ -616,7 +620,7 @@ static void spr_fused_fields(const Variables &var,
                 // if the matrix is degenerate, the polynomial fit is unreliable. 
                 // Fall back to volume-weighted average, which is stable but less accurate. 
                 // The clamping range is still valid since it's based on the patch values.
-                spr_volume_weighted_avg_strided(var.sup.size(i), var.sup.patch(i),
+                spr_volume_weighted_avg_strided(var.support.size(i), var.support.patch(i),
                                                 *var.volume, in_ptrs[f], in_strides[f]);
 
             out_ptrs[f][i * out_strides[f]] = temp_val;
@@ -1202,7 +1206,7 @@ void center_stress_to_ref(const Param &param, const Variables &var,
     //    Without it the copy carries the source's lithostat and lands ~rho*g*dz
     //    wrong.
     //
-    // Must run before prepare_interpolation (reads old var.stress, *var.support,
+    // Must run before prepare_interpolation (reads old var.stress, var.support,
     // old_coord, old_connectivity — all still old here). Undone by
     // restore_stress_from_ref on the new mesh.
     // ----------------------------------------------------------------
@@ -1847,8 +1851,10 @@ void compute_mass(const Param &param, const Variables &var,
             hmass[n]=0;
             ymass[n]=0;
         
-            for( auto e = (*var.support)[n].begin(); e < (*var.support)[n].end(); ++e) {
-                ConstElemCacheAccessor tr = tmp_result[*e];
+            const int npatch = var.support.size(n);
+            const int* patch = var.support.patch(n);
+            for (int i=0; i<npatch; ++i) {
+                ConstElemCacheAccessor tr = tmp_result[patch[i]];
                 volume_n[n] += tr[0];
                 mass[n] += tr[1];
                 if (param.control.has_thermal_diffusion)

--- a/geometry.cxx
+++ b/geometry.cxx
@@ -1633,7 +1633,7 @@ double compute_dt(const Param& param, Variables& var)
         std::cerr << "Error: dt <= 0!  " << dt_maxwell << " " << dt_diffusion
                   << " " << dt_hydro_diffusion << " " << dt_advection << " " << dt_elastic << "\n";
         var.output->write_exact_error(var);
-        std::exit(11);
+        die(EXIT_RUNTIME_NAN);
     }
     
 #ifdef NPROF
@@ -1773,7 +1773,7 @@ void compute_mass(const Param &param, const Variables &var,
             std::cerr << "Error: pseudo speed is too slow, increase mass scaling!  "
                       << "pseudo_speed = " << pseudo_speed << " m/s, hydraulic diffusivity of "
                       << "reference material " << mt << " = " << diff_ref << " m^2/s\n";
-            std::exit(11);
+            die(EXIT_CONFIG_VALUE);
         }
     }
 

--- a/geometry.cxx
+++ b/geometry.cxx
@@ -711,19 +711,26 @@ void SurfaceTopo::build(const Param& param, const Variables& var)
     // profile rather than the node maximum.
     const bool antialias = (M_nyquist > M);
     const double dxg = Lg / (M - 1);
+    // The members and member calls this loop needs, reached through locals instead of the
+    // implicit this. nvc++ answers a class member inside default(none) by ignoring the
+    // clause outright ("ignoring default(none): class member has been declared SHARED"),
+    // which silently stops it checking the whole region; g++ accepts it and says nothing.
+    // Naming everything keeps the clause doing its job on both.
+    const double x0 = x0g, L = Lg;
+    const SurfaceTopo& topo = *this;
     #pragma omp parallel for default(none) \
-        shared(s, M, dxg, antialias) reduction(max:hmax)
+        shared(s, M, dxg, antialias, x0, L, topo) reduction(max:hmax)
     for (int i = 0; i < M; ++i) {
-        const double xi = x0g + Lg * i / (M - 1);
+        const double xi = x0 + L * i / (M - 1);
         if (antialias) {
             // The DCT-I samples include both endpoints, so the end cells are half
             // as wide as the interior ones.
-            s[i] = elev_avg(std::max(xi - 0.5 * dxg, x0g),
-                            std::min(xi + 0.5 * dxg, x0g + Lg));
+            s[i] = topo.elev_avg(std::max(xi - 0.5 * dxg, x0),
+                                 std::min(xi + 0.5 * dxg, x0 + L));
         }
         else {
             const double q[NDIMS] = {xi, 0.0};
-            s[i] = elev(q);
+            s[i] = topo.elev(q);
         }
         hmax = std::max(hmax, std::abs(s[i]));
     }

--- a/geometry.cxx
+++ b/geometry.cxx
@@ -1753,37 +1753,28 @@ void compute_mass(const Param &param, const Variables &var,
     const double pseudo_speed = max_vbc_val * param.control.inertial_scaling; // for non-ATP using max velocity on boundary
     const double pseudo_speed_ATP = var.max_global_vel_mag * param.control.inertial_scaling; // for ATP using global max velocity
 
-    double diff_e;
+    if (param.control.has_hydraulic_diffusion) {
+        // Index the per-material arrays: the MatProps accessors take an ELEMENT index.
+        // LIMITATION: compares m/s against m^2/s (wants a length, diff/minl) and covers
+        // only mattype_ref, not the domain-wide max that dt_hydro_diffusion uses.
+        const int mt = param.mat.mattype_ref;
+        const double perm_m = param.mat.hydraulic_perm[mt];               // Intrinsic permeability
+        const double mu_m = param.mat.fluid_visc[mt];                     // Fluid dynamic viscosity
+        const double alpha_b = param.mat.biot_coeff[mt];                  // Biot coefficient
+        const double phi_m = param.mat.porosity[mt];                      // Porosity
+        const double comp_fluid = 1.0 / param.mat.fluid_bulk_modulus[mt]; // Fluid compressibility
+        const double matrix_comp = 1.0 / (param.mat.bulk_modulus[mt] + 4.0*param.mat.shear_modulus[mt]/3.0);
 
-    #pragma acc serial async
-    {
-        // Retrieve hydraulic properties for the element
-        double perm_e = var.mat->perm(param.mat.mattype_ref);                // Intrinsic permeability 
-        double mu_e = var.mat->mu_fluid(param.mat.mattype_ref);              // Fluid dynamic viscosity
-        double alpha_b = var.mat->alpha_biot(param.mat.mattype_ref);         // Biot coefficient
-        double rho_f = var.mat->rho_fluid(param.mat.mattype_ref);            // Fluid density
-        double phi_e = var.mat->phi(param.mat.mattype_ref);        // Element porosity
-        double comp_fluid = var.mat->beta_fluid(param.mat.mattype_ref);        // fluid comporessibility
-        double bulkm = var.mat->bulkm(param.mat.mattype_ref);
-        double shearm = var.mat->shearm(param.mat.mattype_ref);
-        double matrix_comp = 1.0 / (bulkm +4.0*shearm/3.0);
+        // As reduced into mat->hydro_diff_max by update_pore_pressure(); the specific
+        // weight cancels between conductivity and storage, so it is not carried.
+        const double diff_ref = perm_m / (mu_m * (phi_m * comp_fluid + alpha_b * matrix_comp));
 
-        rho_f = 1000.0; 
-        double gamma_w = rho_f * param.control.gravity; // specific weight
-        
-        // Hydraulic conductivity using permeability and viscosity
-        double hydraulic_conductivity = perm_e * gamma_w / mu_e;
-        
-        // Compute element diffusivity and update max using reduction
-        diff_e = hydraulic_conductivity / (phi_e * comp_fluid + alpha_b * matrix_comp) / gamma_w;
-    }
-
-    #pragma acc wait
-
-    if (pseudo_speed < diff_e && param.control.has_hydraulic_diffusion)
-    {
-        std::cout << "pseudo speed is too slow, increase mass scaling" << std::endl;
-        std::exit(11);
+        if (pseudo_speed < diff_ref) {
+            std::cerr << "Error: pseudo speed is too slow, increase mass scaling!  "
+                      << "pseudo_speed = " << pseudo_speed << " m/s, hydraulic diffusivity of "
+                      << "reference material " << mt << " = " << diff_ref << " m^2/s\n";
+            std::exit(11);
+        }
     }
 
 #ifndef ACC

--- a/geometry.cxx
+++ b/geometry.cxx
@@ -1145,7 +1145,8 @@ void compute_spr_blend_weight(const Param &param, const Variables &var)
         // Host loop: visc()/shearm() read the host-side MatProps.
         #pragma acc wait
 #ifndef ACC
-        #pragma omp parallel for default(none) shared(param, var, dt_remesh, lde0, lde1)
+        #pragma omp parallel for default(none) shared(param, var) \
+                firstprivate(dt_remesh, lde0, lde1)
 #endif
         for (int e = 0; e < var.nelem; ++e) {
             const double t_maxwell = var.mat->visc(e) / var.mat->shearm(e);
@@ -1303,7 +1304,8 @@ void spr_node_to_elem(const Param &param, const Variables &var,
     const double rho_w_g = param.bc.has_water_loading
                          ? param.bc.sea_water_density * param.control.gravity : 0.0;
 #ifndef ACC
-    #pragma omp parallel for default(none) shared(param, var, topo, sea_level, rho_w_g)
+    #pragma omp parallel for default(none) shared(param, var, topo) \
+            firstprivate(sea_level, rho_w_g)
 #endif
     #pragma acc parallel loop gang vector async
     for (int i = 0; i < var.surfinfo.ntop; ++i) {
@@ -1492,8 +1494,8 @@ double compute_dt(const Param& param, Variables& var)
 #ifndef ACC
     #pragma omp parallel for reduction(min:minl, dt_maxwell, dt_diffusion, dt_hydro_diffusion, global_dt_min) \
         reduction(max: global_max_vem) \
-        default(none) shared(param, var) //, velocity_x_element, velocity_y_element, velocity_z_element) \
-        private(vx_element, vy_element, vz_element)
+        default(none) shared(param, var)
+    // No private() clause needed: vx/vy/vz_element are declared inside the loop.
 #endif
     #pragma acc parallel loop gang vector reduction(min:minl, dt_maxwell, dt_diffusion, dt_hydro_diffusion, global_dt_min) \
         reduction(max: global_max_vem) async

--- a/geometry.cxx
+++ b/geometry.cxx
@@ -145,7 +145,7 @@ void compute_volume(const array_t &coord, const conn_t &connectivity,
         shared(coord, connectivity, volume)
 #endif
     #pragma acc parallel loop gang vector async
-    for (int e=0; e<volume.size(); ++e) {
+    for (int e=0; e<int(volume.size()); ++e) {
         int n0 = connectivity[e][0];
         int n1 = connectivity[e][1];
         int n2 = connectivity[e][2];

--- a/geometry.cxx
+++ b/geometry.cxx
@@ -1660,8 +1660,7 @@ double compute_dt(const Param& param, Variables& var)
 //     double dt_hydro_diffusion = std::numeric_limits<double>::max();
 //     double minl = std::numeric_limits<double>::max();
 
-//     #pragma omp parallel for reduction(min:minl,dt_maxwell,dt_diffusion,dt_hydro_diffusion)    \
-//         default(none) shared(param,var)
+//     #pragma omp parallel for reduction(min:minl,dt_maxwell,dt_diffusion,dt_hydro_diffusion) default(none) shared(param,var)
 //     // #pragma acc parallel loop reduction(min:minl, dt_maxwell, dt_diffusion,dt_hydro_diffusion)
 //     for (int e=0; e<var.nelem; ++e) {
 //         int n0 = (*var.connectivity)[e][0];

--- a/geometry.cxx
+++ b/geometry.cxx
@@ -929,7 +929,7 @@ void SurfaceTopo::build(const Param& param, const Variables& var)
     double_vec T((size_t)M * M, 0.0), A((size_t)M * M, 0.0);
     heff.assign((size_t)M * M * ND, 0.0);
     #pragma omp parallel default(none) \
-        shared(cmi, T, A, M, ND, pn)
+        shared(cmi, T, A, M) firstprivate(ND, pn)
     {
         #pragma omp for
         for (int m = 0; m < M; ++m) {

--- a/ic-read-temp.cxx
+++ b/ic-read-temp.cxx
@@ -21,7 +21,6 @@ void read_external_temperature_from_comsol(const Param &param,
     {
         std::ifstream inputFile(param.ic.Temp_filename.c_str());
         std::string line;
-        int i = 0;
 
         while(std::getline(inputFile, line)) {
             if (!line.length() || line[0] == '%')
@@ -38,8 +37,6 @@ void read_external_temperature_from_comsol(const Param &param,
             ys.push_back(y);
             zs.push_back(z);
             Ts.push_back(T);
-
-            ++i;
         }
     }
 

--- a/ic-read-temp.cxx
+++ b/ic-read-temp.cxx
@@ -120,7 +120,7 @@ void read_external_temperature_from_comsol(const Param &param,
     /* Write nodes to conn_t connectivity(nelem).*/
     int nelem = es.size();
     conn_t input_connectivity(nelem);	// connectivity[elem#][0-NODES_PER_ELEM-1]
-    int_vec2D input_support(nnodes); //create input_support
+    int_vec input_sup_idx(nnodes + 1, 0);   // CSR row-pointers for the input mesh
     for (size_t m=0; m<es.size(); ++m) {
   	input_connectivity[m][0] = n0s[m];
    	input_connectivity[m][1] = n1s[m];
@@ -130,9 +130,25 @@ void read_external_temperature_from_comsol(const Param &param,
 #endif
 	ConstConnAccessor conn = input_connectivity[m];
 	for (size_t l=0; l<NODES_PER_ELEM; ++l) {
-	    (input_support)[conn[l]].push_back(m);
+	    input_sup_idx[conn[l] + 1]++;
 	}
     }
+    // prefix-sum the counts into start offsets, then fill
+    for (int n=1; n<=nnodes; ++n) input_sup_idx[n] += input_sup_idx[n-1];
+    int_vec input_sup_arr(input_sup_idx[nnodes]);
+    {
+        int_vec cursor(input_sup_idx.begin(), input_sup_idx.end() - 1);
+        for (size_t m=0; m<es.size(); ++m) {
+            ConstConnAccessor conn = input_connectivity[m];
+            for (size_t l=0; l<NODES_PER_ELEM; ++l)
+                input_sup_arr[cursor[conn[l]]++] = m;
+        }
+    }
+    // lidx left empty: prepare_interpolation reads element ids only.
+    Support input_support;
+    input_support.arr_data.swap(input_sup_arr);
+    input_support.idx_data.swap(input_sup_idx);
+    input_support.rebind();
     double_vec volume(es.size());
     compute_volume(input_coord, input_connectivity, volume);
     //print(std::cout, volume);

--- a/ic.cxx
+++ b/ic.cxx
@@ -370,13 +370,10 @@ void initial_stress_state_1d_load(const Param &param, const Variables &var,
         return;
     }
 
-    // lithostatic condition for stress and strain
-    double rho = var.mat->rho(0);
-    if (param.control.has_hydraulic_diffusion) {
-        // Modified density considering porosity for hydraulic diffusion
-        rho = var.mat->rho(0) * (1 - var.mat->phi(0)) + 1000.0 * var.mat->phi(0);
-    }
-
+    // Lithostatic stress and strain. loading_zz below -- the 1D surface load this variant
+    // exists to add -- is still held at zero, so what this writes is the plain lithostatic
+    // state, the same as initial_stress_state(). The load term's density would be
+    // var.mat->rho(0), porosity-weighted with water under has_hydraulic_diffusion.
     double ks = var.mat->bulkm(0);
     double mu = var.mat->shearm(0);
     double lame = ks - (2.0 / 3.0) * mu;

--- a/ic.cxx
+++ b/ic.cxx
@@ -628,7 +628,7 @@ void initial_weak_zone(const Param &param, const Variables &var,
     }
     default:
         std::cerr << "Error: unknown weakzone_option: " << param.ic.weakzone_option << '\n';
-        std::exit(1);
+        die(EXIT_CONFIG_VALUE);
     }
 
     #pragma acc parallel loop gang vector
@@ -1015,7 +1015,7 @@ void initial_temperature(const Param &param, const Variables &var,
         break;
     default:
         std::cout << "Error: unknown ic.temperature option: " << param.ic.temperature_option << '\n';
-        std::exit(1);
+        die(EXIT_CONFIG_VALUE);
     }
 
     double max_temp = 0.0;

--- a/ic.cxx
+++ b/ic.cxx
@@ -806,9 +806,10 @@ void radiogenic_heat_and_adiabat(const Param &param, const Variables &var, doubl
                 if ( z >= layer_bdy[i])
                     rs = hp[i];
 
-            int_vec &sup = (*var.support)[n];
-            for (int i=0;i<sup.size();i++)
-                radiogenic_source[sup[i]] += rs/NODES_PER_ELEM;
+            const int npatch = var.support.size(n);
+            const int* patch = var.support.patch(n);
+            for (int i=0;i<npatch;i++)
+                radiogenic_source[patch[i]] += rs/NODES_PER_ELEM;
         }
 
         temperature[n] = t;

--- a/input.cxx
+++ b/input.cxx
@@ -1031,6 +1031,14 @@ static void validate_parameters(const po::variables_map &vm, Param &p)
         }
     }
 
+    // Both are modulo divisors, the first one just below, so a zero is a SIGFPE.
+    if (p.mesh.quality_check_step_interval < 1) {
+        die(EXIT_CONFIG_VALUE, "mesh.quality_check_step_interval must be positive.");
+    }
+    if (p.sim.checkpoint_frame_interval < 1) {
+        die(EXIT_CONFIG_VALUE, "sim.checkpoint_frame_interval must be positive.");
+    }
+
     if (p.sim.is_outputting_averaged_fields == true)
         if (vm.count("sim.output_step_interval") &&
             p.sim.output_step_interval%p.mesh.quality_check_step_interval !=0) {

--- a/input.cxx
+++ b/input.cxx
@@ -326,9 +326,10 @@ static void declare_parameters(po::options_description &cfg,
 
         ("control.ref_pressure_option", po::value<int>(&p.control.ref_pressure_option)->default_value(0),
          "How to define reference pressure?\n"
-         "0: using density of the 0-th element to compute lithostatic pressure.\n"
+         "0: using density of the mat.mattype_ref-th material to compute lithostatic pressure.\n"
          "1: computing reference pressure from the PREM model.\n"
-         "2: computing reference pressure from the PREM model, modified for continent.\n")
+         "2: computing reference pressure from the PREM model, modified for continent.\n"
+         "Any other value is rejected at startup.\n")
 //        ("control.surface_pressure_correction", po::value<bool>(&p.control.surface_pressure_correction)->default_value(false),
 //         "Correct the pressure of surface elements"
 //         "which has positive stress 1st invariant"
@@ -1318,6 +1319,13 @@ static void validate_parameters(const po::variables_map &vm, Param &p)
         }
         if ( p.control.damping_factor < 0 || p.control.damping_factor > 1 ) {
             std::cerr << "Error: control.damping_factor must be between 0 and 1.\n";
+            std::exit(1);
+        }
+        // ref_pressure() is 'acc routine seq' and cannot reject an option itself; it
+        // returns 0. Keep this range in step with its branches and the help above.
+        if (p.control.ref_pressure_option < 0 || p.control.ref_pressure_option > 2) {
+            std::cerr << "Error: control.ref_pressure_option must be 0, 1, or 2 (got "
+                      << p.control.ref_pressure_option << ").\n";
             std::exit(1);
         }
 

--- a/input.cxx
+++ b/input.cxx
@@ -919,12 +919,12 @@ static void read_parameters_from_file
     }
     catch (const boost::program_options::multiple_occurrences& e) {
         std::cerr << e.what() << " from option: " << e.get_option_name() << '\n';
-        std::exit(1);
+        die(EXIT_CONFIG_VALUE);
     }
     catch (std::exception& e) {
         std::cerr << "Error reading config_file '" << filename << "'\n";
         std::cerr << e.what() << "\n";
-        std::exit(1);
+        die(EXIT_CONFIG);
     }
 }
 
@@ -973,7 +973,7 @@ static void get_numbers(const po::variables_map &vm, const char *name,
 {
     if ( ! vm.count(name) ) {
         std::cerr << "Error: " << name << " is not provided.\n";
-        std::exit(1);
+        die(EXIT_CONFIG_VALUE);
     }
 
     std::string str = vm[name].as<std::string>();
@@ -991,7 +991,7 @@ static void get_numbers(const po::variables_map &vm, const char *name,
     if (err) {
         std::cerr << "Error: incorrect format for " << name << ",\n"
                   << "       must be '[d0, d1, d2, ...]'\n";
-        std::exit(1);
+        die(EXIT_CONFIG_VALUE);
     }
 }
 
@@ -1004,8 +1004,7 @@ static void validate_parameters(const po::variables_map &vm, Param &p)
     // stopping condition and output interval are based on either model time or step
     //
     if ( ! (vm.count("sim.max_steps") || vm.count("sim.max_time_in_yr")) ) {
-        std::cerr << "Must provide either sim.max_steps or sim.max_time_in_yr\n";
-        std::exit(1);
+        die(EXIT_CONFIG, "Must provide either sim.max_steps or sim.max_time_in_yr");
     }
     if ( ! vm.count("sim.max_steps") )
         p.sim.max_steps = std::numeric_limits<int>::max();
@@ -1013,8 +1012,7 @@ static void validate_parameters(const po::variables_map &vm, Param &p)
         p.sim.max_time_in_yr = std::numeric_limits<double>::max();
 
     if ( ! (vm.count("sim.output_step_interval") || vm.count("sim.output_time_interval_in_yr")) ) {
-        std::cerr << "Must provide either sim.output_step_interval or sim.output_time_interval_in_yr\n";
-        std::exit(1);
+        die(EXIT_CONFIG, "Must provide either sim.output_step_interval or sim.output_time_interval_in_yr");
     }
     if ( ! vm.count("sim.output_step_interval") )
         p.sim.output_step_interval = std::numeric_limits<int>::max();
@@ -1026,20 +1024,17 @@ static void validate_parameters(const po::variables_map &vm, Param &p)
     //
     if (p.sim.is_restarting) {
         if ( ! vm.count("sim.restarting_from_modelname") ) {
-            std::cerr << "Must provide sim.restarting_from_modelname when restarting.\n";
-            std::exit(1);
+            die(EXIT_CONFIG, "Must provide sim.restarting_from_modelname when restarting.");
         }
         if ( ! vm.count("sim.restarting_from_frame") ) {
-            std::cerr << "Must provide sim.restarting_from_frame when restarting.\n";
-            std::exit(1);
+            die(EXIT_CONFIG, "Must provide sim.restarting_from_frame when restarting.");
         }
     }
 
     if (p.sim.is_outputting_averaged_fields == true)
         if (vm.count("sim.output_step_interval") &&
             p.sim.output_step_interval%p.mesh.quality_check_step_interval !=0) {
-            std::cerr << "sim.output_step_interval must be a multiple of mesh.quality_check_step_interval!.\n";
-            std::exit(1);
+            die(EXIT_CONFIG_VALUE, "sim.output_step_interval must be a multiple of mesh.quality_check_step_interval!.");
     }
 
     // Ensure info_display_step_interval is a multiple of quality_check_step_interval
@@ -1052,15 +1047,13 @@ static void validate_parameters(const po::variables_map &vm, Param &p)
                   << p.sim.info_display_step_interval
                   << " (must be a multiple of quality_check_step_interval="
                   << q << ")\n";
-        std::exit(1);
+        die(EXIT_CONFIG_VALUE);
     }
     if (p.sim.earthquake_output_step_interval < 1) {
-        std::cerr << "Error: sim.earthquake_output_step_interval must be >= 1.\n";
-        std::exit(1);
+        die(EXIT_CONFIG_VALUE, "sim.earthquake_output_step_interval must be >= 1.");
     }
     if (p.sim.earthquake_start_factor <= 0 || p.sim.earthquake_end_factor <= 0) {
-        std::cerr << "Error: sim.earthquake_start_factor and sim.earthquake_end_factor must be > 0.\n";
-        std::exit(1);
+        die(EXIT_CONFIG_VALUE, "sim.earthquake_start_factor and sim.earthquake_end_factor must be > 0.");
     }
     if (p.sim.earthquake_start_factor <= p.sim.earthquake_end_factor) {
         std::cerr << "Warning: sim.earthquake_start_factor <= sim.earthquake_end_factor; "
@@ -1070,14 +1063,12 @@ static void validate_parameters(const po::variables_map &vm, Param &p)
     // these parameters are required in mesh.meshing_elem_shape >= 1
 #ifdef THREED
     if (p.mesh.meshing_elem_shape == 2) {
-        std::cerr << "Error: mesh.meshing_elem_shape == 2 is not available in 3D.\n";
-        std::exit(1);
+        die(EXIT_UNSUPPORTED_DIM, "mesh.meshing_elem_shape == 2 is not available in 3D.");
     }
 #endif
     if (p.mesh.meshing_elem_shape >= 1) {
         if ( p.mesh.meshing_option != 1) {
-            std::cerr << "Error: mesh.meshing_elem_shape >= 1 is only for mesh.meshing_option == 1.\n";
-            std::exit(1);
+            die(EXIT_UNSUPPORTED_DIM, "mesh.meshing_elem_shape >= 1 is only for mesh.meshing_option == 1.");
         }
     }
 
@@ -1095,7 +1086,7 @@ static void validate_parameters(const po::variables_map &vm, Param &p)
                   << "mesh.refined_zoney, "
 #endif
                   << "mesh.refined_zonez.\n";
-        std::exit(1);
+        die(EXIT_CONFIG);
         }
 
         /* get 2 numbers from the string */
@@ -1107,7 +1098,7 @@ static void validate_parameters(const po::variables_map &vm, Param &p)
         if (err || tmp[0] < 0 || tmp[1] > 1 || tmp[0] > tmp[1]) {
             std::cerr << "Error: incorrect value for mesh.refine_zonex,\n"
                       << "       must in this format '[d0, d1]', 0 <= d0 <= d1 <= 1.\n";
-            std::exit(1);
+            die(EXIT_CONFIG_VALUE);
         }
         p.mesh.refined_zonex.first = tmp[0];
         p.mesh.refined_zonex.second = tmp[1];
@@ -1117,7 +1108,7 @@ static void validate_parameters(const po::variables_map &vm, Param &p)
         if (err || tmp[0] < 0 || tmp[1] > 1 || tmp[0] > tmp[1]) {
             std::cerr << "Error: incorrect value for mesh.refine_zoney,\n"
                       << "       must in this format '[d0, d1]', 0 <= d0 <= d1 <= 1.\n";
-            std::exit(1);
+            die(EXIT_CONFIG_VALUE);
         }
         p.mesh.refined_zoney.first = tmp[0];
         p.mesh.refined_zoney.second = tmp[1];
@@ -1127,21 +1118,19 @@ static void validate_parameters(const po::variables_map &vm, Param &p)
         if (err || tmp[0] < 0 || tmp[1] > 1 || tmp[0] > tmp[1]) {
             std::cerr << "Error: incorrect value for mesh.refine_zonez,\n"
                       << "       must in this format '[d0, d1]', 0 <= d0 <= d1 <= 1.\n";
-            std::exit(1);
+            die(EXIT_CONFIG_VALUE);
         }
         p.mesh.refined_zonez.first = tmp[0];
         p.mesh.refined_zonez.second = tmp[1];
     }
 
     if (p.mesh.smallest_size > p.mesh.largest_size) {
-        std::cerr << "Error: mesh.smallest_size is greater than mesh.largest_size.\n";
-        std::exit(1);
+        die(EXIT_CONFIG_VALUE, "mesh.smallest_size is greater than mesh.largest_size.");
     }
 
     if (p.mesh.remesh_deborah_min <= 0 ||
         p.mesh.remesh_deborah_min >= p.mesh.remesh_deborah_max) {
-        std::cerr << "Error: mesh.remesh_deborah_min must be positive and less than mesh.remesh_deborah_max.\n";
-        std::exit(1);
+        die(EXIT_CONFIG_VALUE, "mesh.remesh_deborah_min must be positive and less than mesh.remesh_deborah_max.");
     }
 
     //
@@ -1149,12 +1138,10 @@ static void validate_parameters(const po::variables_map &vm, Param &p)
     //
     {
         if (p.monitor.step_interval < 1) {
-            std::cerr << "Error: monitor.step_interval must be >= 1.\n";
-            std::exit(1);
+            die(EXIT_CONFIG_VALUE, "monitor.step_interval must be >= 1.");
         }
         if (p.monitor.num_points < 0) {
-            std::cerr << "Error: monitor.num_points must be >= 0.\n";
-            std::exit(1);
+            die(EXIT_CONFIG_VALUE, "monitor.num_points must be >= 0.");
         }
 
         get_numbers(vm, "monitor.points_x", p.monitor.points_x, p.monitor.num_points);
@@ -1174,8 +1161,7 @@ static void validate_parameters(const po::variables_map &vm, Param &p)
 #endif
 
         if (p.monitor.enabled && p.monitor.num_points <= 0) {
-            std::cerr << "Error: monitor.enabled=true requires monitor.num_points > 0.\n";
-            std::exit(1);
+            die(EXIT_CONFIG_VALUE, "monitor.enabled=true requires monitor.num_points > 0.");
         }
 
         if (p.monitor.points_unit == "mm")
@@ -1187,8 +1173,7 @@ static void validate_parameters(const po::variables_map &vm, Param &p)
         else if (p.monitor.points_unit == "km")
             p.monitor.points_scale_to_m = 1e3;
         else {
-            std::cerr << "Error: monitor.points_unit must be one of mm, cm, m, km.\n";
-            std::exit(1);
+            die(EXIT_CONFIG_VALUE, "monitor.points_unit must be one of mm, cm, m, km.");
         }
 
         for (int i = 0; i < p.monitor.num_points; ++i) {
@@ -1207,8 +1192,7 @@ static void validate_parameters(const po::variables_map &vm, Param &p)
         else if (rebind_mode == "pre_remesh_coord")
             p.monitor.remesh_rebind_mode = monitor_rebind_pre_remesh_coord;
         else {
-            std::cerr << "Error: monitor.remesh_rebind_mode must be initial_coord or pre_remesh_coord.\n";
-            std::exit(1);
+            die(EXIT_CONFIG_VALUE, "monitor.remesh_rebind_mode must be initial_coord or pre_remesh_coord.");
         }
 
         const bool any_monitor_output =
@@ -1232,15 +1216,13 @@ static void validate_parameters(const po::variables_map &vm, Param &p)
             p.monitor.output_state_variable;
 
         if (p.monitor.enabled && !any_monitor_output) {
-            std::cerr << "Error: monitor.enabled=true requires at least one monitor.output_* = true.\n";
-            std::exit(1);
+            die(EXIT_CONFIG_VALUE, "monitor.enabled=true requires at least one monitor.output_* = true.");
         }
     }
 
 #ifdef THREED
     if (p.mesh.remeshing_option == 2) {
-        std::cerr << "Error: mesh.remeshing_option=2 is not available in 3D.\n";
-        std::exit(1);
+        die(EXIT_UNSUPPORTED_DIM, "mesh.remeshing_option=2 is not available in 3D.");
     }
 #endif
 
@@ -1274,38 +1256,30 @@ static void validate_parameters(const po::variables_map &vm, Param &p)
 
 #ifdef THREED
         if ( p.bc.vbc_z0 > 3) {
-            std::cerr << "Error: bc.vbc_z0 is not 0, 1, 2, or 3.\n";
-            std::exit(1);
+            die(EXIT_CONFIG_VALUE, "bc.vbc_z0 is not 0, 1, 2, or 3.");
         }
         if ( p.bc.vbc_z1 > 3) {
-            std::cerr << "Error: bc.vbc_z1 is not 0, 1, 2, or 3.\n";
-            std::exit(1);
+            die(EXIT_CONFIG_VALUE, "bc.vbc_z1 is not 0, 1, 2, or 3.");
         }
 #else
         if ( p.bc.vbc_z0 > 4) {
-            std::cerr << "Error: bc.vbc_z0 is not 0, 1, 2, 3, or 4.\n";
-            std::exit(1);
+            die(EXIT_CONFIG_VALUE, "bc.vbc_z0 is not 0, 1, 2, 3, or 4.");
         }
         if ( p.bc.vbc_z1 > 4) {
-            std::cerr << "Error: bc.vbc_z1 is not 0, 1, 2, 3, or 4.\n";
-            std::exit(1);
+            die(EXIT_CONFIG_VALUE, "bc.vbc_z1 is not 0, 1, 2, 3, or 4.");
         }
 #endif
         if ( p.bc.vbc_n0 != 1 && p.bc.vbc_n0 != 3 && p.bc.vbc_n0 != 11 && p.bc.vbc_n0 != 13 ) {
-            std::cerr << "Error: bc.vbc_n0 is not 1, 3, 11, or 13.\n";
-            std::exit(1);
+            die(EXIT_CONFIG_VALUE, "bc.vbc_n0 is not 1, 3, 11, or 13.");
         }
         if ( p.bc.vbc_n1 != 1 && p.bc.vbc_n1 != 3 && p.bc.vbc_n1 != 11 && p.bc.vbc_n1 != 13 ) {
-            std::cerr << "Error: bc.vbc_n1 is not 1, 3, 11, or 13.\n";
-            std::exit(1);
+            die(EXIT_CONFIG_VALUE, "bc.vbc_n1 is not 1, 3, 11, or 13.");
         }
         if ( p.bc.vbc_n2 != 1 && p.bc.vbc_n2 != 3 && p.bc.vbc_n2 != 11 && p.bc.vbc_n2 != 13 ) {
-            std::cerr << "Error: bc.vbc_n2 is not 1, 3, 11, or 13.\n";
-            std::exit(1);
+            die(EXIT_CONFIG_VALUE, "bc.vbc_n2 is not 1, 3, 11, or 13.");
         }
         if ( p.bc.vbc_n3 != 1 && p.bc.vbc_n3 != 3 && p.bc.vbc_n3 != 11 && p.bc.vbc_n3 != 13 ) {
-            std::cerr << "Error: bc.vbc_n3 is not 1, 3, 11, or 13.\n";
-            std::exit(1);
+            die(EXIT_CONFIG_VALUE, "bc.vbc_n3 is not 1, 3, 11, or 13.");
         }
     }
 
@@ -1314,19 +1288,17 @@ static void validate_parameters(const po::variables_map &vm, Param &p)
     //
     {
         if ( p.control.dt_fraction < 0 || p.control.dt_fraction > 1 ) {
-            std::cerr << "Error: control.dt_fraction must be between 0 and 1.\n";
-            std::exit(1);
+            die(EXIT_CONFIG_VALUE, "control.dt_fraction must be between 0 and 1.");
         }
         if ( p.control.damping_factor < 0 || p.control.damping_factor > 1 ) {
-            std::cerr << "Error: control.damping_factor must be between 0 and 1.\n";
-            std::exit(1);
+            die(EXIT_CONFIG_VALUE, "control.damping_factor must be between 0 and 1.");
         }
         // ref_pressure() is 'acc routine seq' and cannot reject an option itself; it
         // returns 0. Keep this range in step with its branches and the help above.
         if (p.control.ref_pressure_option < 0 || p.control.ref_pressure_option > 2) {
             std::cerr << "Error: control.ref_pressure_option must be 0, 1, or 2 (got "
                       << p.control.ref_pressure_option << ").\n";
-            std::exit(1);
+            die(EXIT_CONFIG_VALUE);
         }
 
     }
@@ -1360,14 +1332,13 @@ static void validate_parameters(const po::variables_map &vm, Param &p)
             if (! std::is_sorted(p.ic.mattype_layer_depths.begin(), p.ic.mattype_layer_depths.end())) {
                 std::cerr << "Error: the content of ic.mattype_layer_depths is not ordered from"
                     " small to big values.\n";
-                std::exit(1);
+                die(EXIT_CONFIG_VALUE);
             }
         }
 
         if (p.ic.temperature_option == 3) {
             if (p.ic.radiogenic_heat_dome_width == 0) {
-                std::cerr << "Error: ic.radiogenic_heat_dome_width must be greater than 0 for ic.temperature_option=3.\n";
-                std::exit(1);
+                die(EXIT_CONFIG_VALUE, "ic.radiogenic_heat_dome_width must be greater than 0 for ic.temperature_option=3.");
             }
         }
     }
@@ -1402,7 +1373,7 @@ static void validate_parameters(const po::variables_map &vm, Param &p)
             p.mat.rheol_type = MatProps::rh_evp_rsf;
         else {
             std::cerr << "Error: unknown rheology: '" << str << "'\n";
-            std::exit(1);
+            die(EXIT_CONFIG_VALUE);
         }
 
         if ((p.mat.rheol_type & MatProps::rh_rsf) && !p.control.use_global_velocity_scaling) {
@@ -1418,17 +1389,14 @@ static void validate_parameters(const po::variables_map &vm, Param &p)
 #endif
 
         if (p.mat.phase_change_option != 0 && p.mat.nmat == 1) {
-            std::cerr << "Error: mat.phase_change_option is chosen, but mat.num_materials is 1.\n";
-            std::exit(1);
+            die(EXIT_CONFIG_VALUE, "mat.phase_change_option is chosen, but mat.num_materials is 1.");
         }
         if (p.mat.phase_change_option == 1 && p.mat.nmat < 8) {
-            std::cerr << "Error: mat.phase_change_option is 1, but mat.num_materials is less than 8.\n";
-            std::exit(1);
+            die(EXIT_CONFIG_VALUE, "mat.phase_change_option is 1, but mat.num_materials is less than 8.");
         }
 
         if (p.mat.nmat < 1) {
-            std::cerr << "Error: mat.num_materials must be greater than 0.\n";
-            std::exit(1);
+            die(EXIT_CONFIG_VALUE, "mat.num_materials must be greater than 0.");
         }
 
         // mattype_ref indexes the per-material arrays directly in ref_pressure(),
@@ -1437,7 +1405,7 @@ static void validate_parameters(const po::variables_map &vm, Param &p)
             std::cerr << "Error: mat.mattype_ref (" << p.mat.mattype_ref
                       << ") must be within [0, mat.num_materials-1] = [0, "
                       << p.mat.nmat - 1 << "].\n";
-            std::exit(1);
+            die(EXIT_CONFIG_VALUE);
         }
 
         if (p.mat.nmat == 1 && p.control.ref_pressure_option != 0) {
@@ -1501,8 +1469,7 @@ static void validate_parameters(const po::variables_map &vm, Param &p)
         get_numbers(vm, "mat.characteristic_velocity", p.mat.characteristic_velocity, p.mat.nmat, -1);
         get_numbers(vm, "mat.characteristic_distance", p.mat.characteristic_distance, p.mat.nmat, -1);
         if (p.mat.state_var_model < 0 || p.mat.state_var_model > 2) {
-            std::cerr << "Error: mat.state_var_model must be 0, 1, or 2.\n";
-            std::exit(1);
+            die(EXIT_CONFIG_VALUE, "mat.state_var_model must be 0, 1, or 2.");
         }
         if (p.mat.rheol_type & MatProps::rh_rsf) {
             for (int m = 0; m < p.mat.nmat; ++m) {
@@ -1510,13 +1477,13 @@ static void validate_parameters(const po::variables_map &vm, Param &p)
                     p.mat.characteristic_velocity[m] <= 0.0) {
                     std::cerr << "Error: mat.characteristic_velocity must be > 0 for RSF materials "
                               << "(material index " << m << ").\n";
-                    std::exit(1);
+                    die(EXIT_CONFIG_VALUE);
                 }
                 if (!std::isfinite(p.mat.characteristic_distance[m]) ||
                     p.mat.characteristic_distance[m] <= 0.0) {
                     std::cerr << "Error: mat.characteristic_distance must be > 0 for RSF materials "
                               << "(material index " << m << ").\n";
-                    std::exit(1);
+                    die(EXIT_CONFIG_VALUE);
                 }
             }
         }
@@ -1535,7 +1502,9 @@ void get_input_parameters(const char* filename, Param& p)
     if (std::strncmp(filename, "-h", 3) == 0 ||
         std::strncmp(filename, "--help", 7) == 0) {
         std::cout << cfg;
-        std::exit(0);
+        // Not die(): that prints an "[DES exit N] <category>" banner meant for
+        // failures, and --help is a successful run with nothing to diagnose.
+        std::exit(EXIT_OK);
     }
     read_parameters_from_file(filename, cfg, vm);
     validate_parameters(vm, p);

--- a/input.cxx
+++ b/input.cxx
@@ -780,7 +780,7 @@ static void declare_parameters(po::options_description &cfg,
         ("mat.num_materials", po::value<int>(&p.mat.nmat)->default_value(1),
          "Number of material types")
         ("mat.mattype_ref", po::value<int>(&p.mat.mattype_ref)->default_value(0),
-         "Index of reference material. For compute_dt(), ref_pressure()")
+         "Index of reference material. For compute_dt(), compute_mass() and ref_pressure()")
         ("mat.mattype_mantle", po::value<int>(&p.mat.mattype_mantle)->default_value(0),
          "Index of mantle material. For continental thermal gradient")
         ("mat.mattype_depleted_mantle", po::value<int>(&p.mat.mattype_depleted_mantle)->default_value(0),
@@ -1420,6 +1420,15 @@ static void validate_parameters(const po::variables_map &vm, Param &p)
 
         if (p.mat.nmat < 1) {
             std::cerr << "Error: mat.num_materials must be greater than 0.\n";
+            std::exit(1);
+        }
+
+        // mattype_ref indexes the per-material arrays directly in ref_pressure(),
+        // compute_dt() and compute_mass(), so it must be a valid material.
+        if (p.mat.mattype_ref < 0 || p.mat.mattype_ref >= p.mat.nmat) {
+            std::cerr << "Error: mat.mattype_ref (" << p.mat.mattype_ref
+                      << ") must be within [0, mat.num_materials-1] = [0, "
+                      << p.mat.nmat - 1 << "].\n";
             std::exit(1);
         }
 

--- a/markerset.cxx
+++ b/markerset.cxx
@@ -481,11 +481,14 @@ void MarkerSet::remap_marker(const Variables &var, const double *m_coord, \
 //    std::cout << "Try to remap in ";
     for (int i = 0; i < NODES_PER_ELEM; i++) {
         int n = conn[i];        
-        for(auto ee = (*var.support)[n].begin(); ee < (*var.support)[n].end(); ++ee) {
-            if (searched[*ee]) continue;
-            searched[*ee]=1;
+        const int npatch = var.support.size(n);
+        const int* patch = var.support.patch(n);
+        for (int pi = 0; pi < npatch; ++pi) {
+            const int ee_v = patch[pi];
+            if (searched[ee_v]) continue;
+            searched[ee_v]=1;
 
-            ConstArrayIndirectAccessor coord = var.coord->view_const((*var.connectivity)[*ee]);
+            ConstArrayIndirectAccessor coord = var.coord->view_const((*var.connectivity)[ee_v]);
 
             double volume = compute_volume(coord);
             Barycentric_transformation bary(coord, volume);
@@ -495,7 +498,7 @@ void MarkerSet::remap_marker(const Variables &var, const double *m_coord, \
                 for (int j=0; j<NDIMS; j++)
                     new_eta[j] = eta[j];
 
-                new_elem = *ee;
+                new_elem = ee_v;
                 inc = 1;
                 return;
             }
@@ -1211,15 +1214,18 @@ namespace {
                 // Looping over all neighboring elements (excluding self)
                 for( int kk = 0; kk < NODES_PER_ELEM; kk++) {
                     int n = (*var.connectivity)[e][kk]; // node of this element
-                    for( auto ee = (*var.support)[n].begin(); ee < (*var.support)[n].end(); ++ee) {
-                        if (*ee == e) continue;
+                    const int npatch = var.support.size(n);
+                    const int* patch = var.support.patch(n);
+                    for( int pi = 0; pi < npatch; ++pi) {
+                        const int ee_v = patch[pi];
+                        if (ee_v == e) continue;
                         // Note: some (NODES_PER_ELEM) elements will be iterated
                         // more than once (NDIMS times). These elements are direct neighbors,
                         // i.e. they share facets (3D) or edges (2D) with element e.
                         // So they are counted multiple times to reprensent a greater weight.
                         for( int i = 0; i < param.mat.nmat; i++ ) {
-                            cpdf[i] += (*(var.elemmarkers))[*ee][i];
-                            num_markers_in_nbr_elems += (*(var.elemmarkers))[*ee][i];
+                            cpdf[i] += (*(var.elemmarkers))[ee_v][i];
+                            num_markers_in_nbr_elems += (*(var.elemmarkers))[ee_v][i];
                         }
                     }
                 }
@@ -1931,8 +1937,9 @@ void advect_hydrous_markers(const Param& param, const Variables& var, double dt_
         else {
             // Marker has moved out of el. Find the new containing element.
             for(int j=0; j<NODES_PER_ELEM; j++) {
-                const int_vec& supp = (*var.support)[ conn[j] ];
-                for (std::size_t k=0; k<supp.size(); k++) {
+                const int npatch = var.support.size(conn[j]);
+                const int* supp = var.support.patch(conn[j]);
+                for (int k=0; k<npatch; k++) {
                     int ee = supp[k];
                     ConstConnAccessor conn2 = (*var.connectivity)[ee];
                     bary = get_bary_from_cache(cache, ee, *var.coord, conn2, *var.volume);

--- a/markerset.cxx
+++ b/markerset.cxx
@@ -765,7 +765,7 @@ void MarkerSet::remove_markers(const Param& param, const Variables &var, int_vec
         #pragma omp single
         #pragma acc parallel loop gang vector async
 #endif
-        for (int i = 0; i < a_out.size(); i++) {
+        for (int i = 0; i < int(a_out.size()); i++) {
             int_vec& emarkers = markers_in_elem[(*_elem)[b_out[i]]];
             auto it = std::find(emarkers.begin(), emarkers.end(), b_out[i]);
             emarkers[it - emarkers.begin()] = a_out[i];
@@ -1140,7 +1140,7 @@ namespace {
         #pragma acc parallel loop gang vector async
         for (int e = 0; e < var.nelem; e++) {
             int_vec &markers = markers_in_elem[e];
-            for (int i = 0; i < markers.size(); i++) {
+            for (int i = 0; i < int(markers.size()); i++) {
                 int m = markers[i];
                 if (ms.get_elem(m) >= 0) {
                     // This marker is not removed, so we need to update the element markers.

--- a/markerset.cxx
+++ b/markerset.cxx
@@ -49,7 +49,7 @@ MarkerSet::MarkerSet(const Param& param, Variables& var, const std::string& name
         break;
     default:
         std::cerr << "Error: unknown init_marker_option: " << param.markers.init_marker_option << ". The only valid option is '1'.\n";
-        std::exit(1);
+        die(EXIT_CONFIG_VALUE);
         break;
     }
 
@@ -61,7 +61,7 @@ MarkerSet::MarkerSet(const Param& param, Variables& var, const std::string& name
         if (num_markers_in_elem <= 0) {
             std::cerr << "Error: no marker in element #" << e
                       << ". Please increase the number of markers.\n";
-            std::exit(1);
+            die(EXIT_RUNTIME_RESOURCE);
         }
     }
 }
@@ -370,7 +370,7 @@ void MarkerSet::set_surface_marker(const Param& param,const Variables& var, cons
                 printf("  eta:");
                 for (int j=0; j<NDIMS; j++) printf(" %f", eta0[j]);
                 printf("\n");
-                std::exit(168);
+                die(EXIT_RUNTIME_LOOKUP);
             }
         }
 
@@ -690,7 +690,7 @@ int MarkerSet::initial_mattype( const Param& param, const Variables &var,
             break;
         default:
             std::cerr << "Error: unknown ic.mattype_option: " << param.ic.mattype_option << '\n';
-            std::exit(1);
+            die(EXIT_CONFIG_VALUE);
         }
     }
     return mt;
@@ -1469,8 +1469,7 @@ namespace {
         }
 
         if (is_no_nn) {
-            std::cerr << "Error: no nearest neighbor found for some new markers.\n";
-            std::exit(168);
+            die(EXIT_RUNTIME_LOOKUP, "no nearest neighbor found for some new markers.");
         }
 
         // Append new markers to the end of the marker set.
@@ -1525,9 +1524,9 @@ void MarkerSet::check_marker_elem_consistency(const Variables &var) const
 
     if (_nmarkers != ncount) {
         std::cerr << "Error: markers count mismatch: " << _nmarkers << " vs " << ncount << '\n';
-        std::exit(1);
+        die(EXIT_INTERNAL_ASSERT);
     } else if (is_error > 0) {
-        std::exit(1);
+        die(EXIT_INTERNAL_ASSERT);
     }
 
 #ifdef NPROF
@@ -1725,7 +1724,7 @@ void MarkerSet::correct_surface_marker(const Param &param, const Variables& var,
             break;
         default:
             std::cerr << "Error: unknown markers.replenishment_option: " << param.markers.replenishment_option << '\n';
-            std::exit(1);
+            die(EXIT_CONFIG_VALUE);
         }
 
         // for (int i=0; i<var.ntop_elems; i++) {
@@ -1866,7 +1865,7 @@ void remap_markers(const Param& param, Variables &var, const array_t &old_coord,
         break;
     default:
         std::cerr << "Error: unknown markers.replenishment_option: " << param.markers.replenishment_option << '\n';
-        std::exit(1);
+        die(EXIT_CONFIG_VALUE);
     }
 
 #ifdef NPROF_DETAIL

--- a/markerset.cxx
+++ b/markerset.cxx
@@ -1662,6 +1662,7 @@ void MarkerSet::correct_surface_marker(const Param &param, const Variables& var,
                             markers_in_elem_info[i].nmarker++;
                         }
                     }
+                    #pragma omp atomic update
                     --elemmarkers[e][mat];
                 }
                 int n = markers_in_elem_info[i].nmarker;

--- a/matprops.cxx
+++ b/matprops.cxx
@@ -121,6 +121,8 @@ namespace {
         int m = 0;
         #pragma acc loop seq
         for (std::size_t i=0; i<s.size(); i++) {
+            // Absent materials add 0*s[i] == 0 and 0 to m, so skipping is exact.
+            if (n[i] == 0) continue;
             result += n[i] * s[i];
             m += n[i];
         }
@@ -137,6 +139,9 @@ namespace {
         int m = 0;
         #pragma acc loop seq
         for (std::size_t i=0; i<s.size(); i++) {
+            // Absent materials add 0/s[i] == 0 and 0 to m, so skipping is exact --
+            // and it avoids the 0/0 = NaN an absent material with s[i] == 0 gave.
+            if (n[i] == 0) continue;
             result += n[i] / s[i];
             m += n[i];
         }
@@ -243,6 +248,58 @@ MatProps::MatProps(const Param& p, const Variables& var) :
             visc_nR[m] = visc_exponent[m] * gas_constant;
         }
     }
+
+    refresh_elem_cache();
+}
+
+
+/* Rebuild the per-element property means only if elemmarkers moved; they are a pure
+ * function of it. Every call site sits right after something that moves elemmarkers;
+ * a missed one is silent staleness. */
+void MatProps::refresh_elem_cache()
+{
+    const int nelem = elemmarkers.size();
+
+    // A size change means a new mesh: nothing about the old contents survives it.
+    const bool resized = int(cache_props.size()) != nelem * MP_STRIDE;
+    if (resized) {
+        cache_props.resize(std::size_t(nelem) * MP_STRIDE);
+        cache_markers.assign(std::size_t(nelem) * nmat, -1);
+    }
+
+    // Compare while copying. `changed` tracks whether the CONTENT moved: on most steps
+    // no marker moves and the whole rebuild below is skipped.
+    int changed = resized ? 1 : 0;
+#ifndef ACC
+    #pragma omp parallel for default(none) firstprivate(nelem) reduction(|:changed)
+#endif
+    // NO `async`: the host reads `changed` immediately below, and appending async would
+    // read the reduction before it lands and silently freeze the means.
+    #pragma acc parallel loop gang vector reduction(|:changed)
+    for (int e = 0; e < nelem; ++e) {
+        for (int m = 0; m < nmat; ++m) {
+            const std::size_t i = std::size_t(e) * nmat + m;
+            const int v = elemmarkers[e][m];
+            if (cache_markers[i] != v) { cache_markers[i] = v; changed = 1; }
+        }
+    }
+    if (!changed) return;
+
+#ifndef ACC
+    #pragma omp parallel for default(none) firstprivate(nelem)
+#endif
+    #pragma acc parallel loop gang vector
+    for (int e = 0; e < nelem; ++e) {
+        double* c = &cache_props[std::size_t(e) * MP_STRIDE];
+        c[MPC_BULKM]      = harmonic_mean(bulk_modulus, elemmarkers[e]);
+        c[MPC_SHEARM]     = harmonic_mean(shear_modulus, elemmarkers[e]);
+        c[MPC_PHI]        = arithmetic_mean(porosity, elemmarkers[e]);
+        c[MPC_ALPHA_BIOT] = arithmetic_mean(biot_coeff, elemmarkers[e]);
+        c[MPC_CP]         = arithmetic_mean(heat_capacity, elemmarkers[e]);
+        c[MPC_K]          = arithmetic_mean(therm_cond, elemmarkers[e]);
+        // Stored as the compressibility, so beta_fluid() is a plain load like the others.
+        c[MPC_BETA_FLUID] = 1.0 / harmonic_mean(fluid_bulk_modulus, elemmarkers[e]);
+    }
 }
 
 
@@ -263,13 +320,13 @@ MatProps::~MatProps()
 
 double MatProps::bulkm(int e) const
 {
-    return harmonic_mean(bulk_modulus, elemmarkers[e]);
+    return cache_props[std::size_t(e) * MP_STRIDE + MPC_BULKM];
 }
 
 
 double MatProps::shearm(int e) const
 {
-    return harmonic_mean(shear_modulus, elemmarkers[e]);
+    return cache_props[std::size_t(e) * MP_STRIDE + MPC_SHEARM];
 }
 
 
@@ -609,19 +666,19 @@ double MatProps::rho(int e) const
 
 double MatProps::cp(int e) const
 {
-    return arithmetic_mean(heat_capacity, elemmarkers[e]);
+    return cache_props[std::size_t(e) * MP_STRIDE + MPC_CP];
 }
 
 
 double MatProps::k(int e) const
 {
-    return arithmetic_mean(therm_cond, elemmarkers[e]);
+    return cache_props[std::size_t(e) * MP_STRIDE + MPC_K];
 }
 
 // hydraulic parameters
 double MatProps::phi(int e) const
 {
-    return arithmetic_mean(porosity, elemmarkers[e]);
+    return cache_props[std::size_t(e) * MP_STRIDE + MPC_PHI];
 }
 
 double MatProps::perm(int e) const
@@ -636,8 +693,8 @@ double MatProps::alpha_fluid(int e) const
 
 double MatProps::beta_fluid(int e) const
 {
-    // Return the inverse of harmonic mean (compressibility)
-    return 1.0 / harmonic_mean(fluid_bulk_modulus, elemmarkers[e]);
+    // Already stored as the compressibility; see refresh_elem_cache().
+    return cache_props[std::size_t(e) * MP_STRIDE + MPC_BETA_FLUID];
 }
 
 double MatProps::rho_fluid(int e) const
@@ -687,7 +744,7 @@ double MatProps::mu_fluid(int e) const
 
 double MatProps::alpha_biot(int e) const
 {
-    return arithmetic_mean(biot_coeff, elemmarkers[e]);
+    return cache_props[std::size_t(e) * MP_STRIDE + MPC_ALPHA_BIOT];
 }
 
 double MatProps::beta_mineral(int e) const

--- a/matprops.cxx
+++ b/matprops.cxx
@@ -225,6 +225,24 @@ MatProps::MatProps(const Param& p, const Variables& var) :
     characteristic_velocity = p.mat.characteristic_velocity;
     characteristic_distance = p.mat.characteristic_distance;
     // static_friction_coefficient = p.mat.static_friction_coefficient;
+
+    // Material-only terms of the creep law, in the association visc() evaluates them in
+    // so the per-element result is bit-identical at opt <= 2. Round-off-equivalent only
+    // under -ffast-math and on openacc=1 (device -> host libm).
+    {
+        // J mol^-1 K^-1, as the Chen & Morgan creep law uses it.
+        const double gas_constant = 8.3144;
+        const int nm = nmat;   // == visc_exponent.size(); nmat is the bound visc() loops to
+        visc_pow_edot.resize(nm);
+        visc_coef_term.resize(nm);
+        visc_nR.resize(nm);
+        for (int m = 0; m < nm; ++m) {
+            visc_pow_edot[m] = 1 / visc_exponent[m] - 1;
+            const double pow1 = -1 / visc_exponent[m];
+            visc_coef_term[m] = pow_safe(log_table, 0.75 * visc_coefficient[m], pow1);
+            visc_nR[m] = visc_exponent[m] * gas_constant;
+        }
+    }
 }
 
 
@@ -257,7 +275,6 @@ double MatProps::shearm(int e) const
 
 double MatProps::visc(int e) const
 {
-    const double gas_constant = 8.3144;
     const double min_strain_rate = 1e-30;
 
     // average temperature of this element
@@ -282,13 +299,16 @@ double MatProps::visc(int e) const
     int n = 0;
 
     for (int m=0; m<nmat; m++) {
-        double pow = 1 / visc_exponent[m] - 1;
-        double pow1 = -1 / visc_exponent[m];
-        double visc0 = 0.25 * pow_safe(log_table,edot, pow) * pow_safe(log_table, 0.75 * visc_coefficient[m], pow1)
+        // Absent materials add 0/visc0 == 0, so the skip is exact, and it keeps
+        // visc0 == 0 from contributing a NaN.
+        const int marker_count = elemmarkers[e][m];
+        if (marker_count == 0) continue;
+
+        double visc0 = 0.25 * pow_safe(log_table,edot, visc_pow_edot[m]) * visc_coef_term[m]
             * std::exp((visc_activation_energy[m] + visc_activation_volume[m] * s0)
-            / (visc_exponent[m] * gas_constant * T)) * 1e6;
-        result += elemmarkers[e][m] / visc0;
-        n += elemmarkers[e][m];
+            / (visc_nR[m] * T)) * 1e6;
+        result += marker_count / visc0;
+        n += marker_count;
     }
 
     double visc = n / result;

--- a/matprops.cxx
+++ b/matprops.cxx
@@ -149,9 +149,9 @@ double ref_pressure(const Param& param, double z)
 {
     // Get pressure at this depth
     double depth = -z;
-    double p;
+    double p = 0;
 
-    if (param.control.ref_pressure_option == 0)
+    if (param.control.ref_pressure_option == 0) {
         if (param.control.has_hydraulic_diffusion) {
         // Modified density considering porosity for hydraulic diffusion
             p = (param.mat.rho0[param.mat.mattype_ref] * (1 - param.mat.porosity[param.mat.mattype_ref]) + \
@@ -160,7 +160,7 @@ double ref_pressure(const Param& param, double z)
             // Standard reference pressure without hydraulic diffusion
             p = param.mat.rho0[param.mat.mattype_ref] * param.control.gravity * depth;
         }
-
+    }
     else if (param.control.ref_pressure_option == 1)
         p = get_prem_pressure(depth);
     else if (param.control.ref_pressure_option == 2)

--- a/matprops.hpp
+++ b/matprops.hpp
@@ -74,6 +74,10 @@ public:
                                  double state_variable, double& dyn_fric_coeff,
                                  int state_model) const;
 
+    // Rebuild the per-element property means if elemmarkers changed since the last call.
+    // Must be called after ANYTHING that mutates elemmarkers, before the next read.
+    void refresh_elem_cache();
+
     const bool is_plane_strain;
     const double visc_min;
     const double visc_max;
@@ -111,6 +115,18 @@ private:
     // Material-only terms of the Chen & Morgan creep law, built by the constructor.
     // Pure function of visc_exponent / visc_coefficient, never mutated.
     double_vec visc_pow_edot, visc_coef_term, visc_nR;
+
+    // The hot means, rebuilt by refresh_elem_cache(): pure functions of elemmarkers.
+    // Not exhaustive -- rho/visc CANNOT be cached (T, stress, edot). Stride 8 keeps one
+    // element's slots in a 64 B line; seven separate arrays measured 1.6x slower.
+    static const int MP_STRIDE = 8;
+    enum { MPC_BULKM = 0, MPC_SHEARM, MPC_PHI, MPC_ALPHA_BIOT,
+           MPC_CP, MPC_K, MPC_BETA_FLUID };
+    double_vec cache_props;
+
+    // Flat copy of elemmarkers, kept ONLY to detect that it moved. A version counter
+    // bumped by each mutation site would go stale the first time one is added.
+    int_vec cache_markers;
     double_vec heat_capacity, therm_cond;
     double_vec pls0, pls1;
     double_vec cohesion0, cohesion1;

--- a/matprops.hpp
+++ b/matprops.hpp
@@ -107,6 +107,10 @@ private:
     double_vec bulk_modulus, shear_modulus;
     double_vec visc_exponent, visc_coefficient, visc_activation_energy;
     double_vec visc_activation_volume;
+
+    // Material-only terms of the Chen & Morgan creep law, built by the constructor.
+    // Pure function of visc_exponent / visc_coefficient, never mutated.
+    double_vec visc_pow_edot, visc_coef_term, visc_nR;
     double_vec heat_capacity, therm_cond;
     double_vec pls0, pls1;
     double_vec cohesion0, cohesion1;

--- a/mesh.cxx
+++ b/mesh.cxx
@@ -2716,19 +2716,24 @@ void renumbering_mesh(const Param& param, array_t &coord, conn_t &connectivity,
                           param.mesh.zlength};
     size_t_vec idx(NDIMS);
     sortindex(lengths, idx);
-    int dmin, dmid, dmax;
+    int dmin, dmax;
+#ifdef THREED
+    int dmid;   // the middle axis only enters the 3D sort weight below
+#endif
 
     if (param.mesh.meshing_elem_shape == 0) {
         dmin = idx[0];
+#ifdef THREED
         dmid = idx[1];
+#endif
         dmax = idx[NDIMS-1];
     } else {
 #ifdef THREED
         dmax = 0;
+        dmid = NDIMS-2;
 #else
         dmax = NDIMS-2;
 #endif
-        dmid = NDIMS-2;
         dmin = NDIMS-1;
     }
     //

--- a/mesh.cxx
+++ b/mesh.cxx
@@ -224,7 +224,7 @@ void divide_hexahedron_to_tetrahedra_index(ConstRegularAccessor cell, int order,
             conn[3] = cell[7];
             break;
         default:
-            exit(554);
+            die(EXIT_INTERNAL_UNREACHABLE);
             break;
         }
     } else {
@@ -261,7 +261,7 @@ void divide_hexahedron_to_tetrahedra_index(ConstRegularAccessor cell, int order,
             conn[3] = cell[6];
             break;
         default:
-            exit(555);
+            die(EXIT_INTERNAL_UNREACHABLE);
             break;
         }
     }
@@ -925,25 +925,25 @@ static void mmg_refine_init_mesh_3d(
                     MMG5_ARG_end);
 
     if (MMG3D_Set_meshSize(mmgMesh, cn, ce, 0, cs, 0, 0) != 1)
-        std::exit(EXIT_FAILURE);
+        die(EXIT_MESH_MMG);
 
     // Vertices: pcoord is already AoS x0,y0,z0,... as produced by TetGen
     if (MMG3D_Set_vertices(mmgMesh, pcoord, NULL) != 1)
-        std::exit(EXIT_FAILURE);
+        die(EXIT_MESH_MMG);
 
     // Tetrahedra: MMG is 1-indexed
     int_vec conn1(ce * NODES_PER_ELEM);
     for (int i = 0; i < ce * NODES_PER_ELEM; ++i)
         conn1[i] = pconn[i] + 1;
     if (MMG3D_Set_tetrahedra(mmgMesh, conn1.data(), NULL) != 1)
-        std::exit(EXIT_FAILURE);
+        die(EXIT_MESH_MMG);
 
     // Boundary triangles: MMG is 1-indexed
     int_vec seg1(cs * NODES_PER_FACET);
     for (int i = 0; i < cs * NODES_PER_FACET; ++i)
         seg1[i] = pseg[i] + 1;
     if (MMG3D_Set_triangles(mmgMesh, seg1.data(), psegflag) != 1)
-        std::exit(EXIT_FAILURE);
+        die(EXIT_MESH_MMG);
 
     // --- Compute uniform or per-region metric ---
     // cra[e] = region index when per-region (encoded by points_to_mesh), used for connectivity-based projection.
@@ -952,9 +952,9 @@ static void mmg_refine_init_mesh_3d(
                         n_regions, regattr, max_elem_size, mesh.resolution, metric);
 
     if (MMG3D_Set_solSize(mmgMesh, mmgSol, MMG5_Vertex, cn, MMG5_Scalar) != 1)
-        std::exit(EXIT_FAILURE);
+        die(EXIT_MESH_MMG);
     if (MMG3D_Set_scalarSols(mmgSol, metric.data()) != 1)
-        std::exit(EXIT_FAILURE);
+        die(EXIT_MESH_MMG);
 
     // --- MMG parameters ---
     MMG3D_Set_iparameter(mmgMesh, mmgSol, MMG3D_IPARAM_optim,   0);
@@ -970,8 +970,7 @@ static void mmg_refine_init_mesh_3d(
     // --- Run ---
     const int ier = MMG3D_mmg3dlib(mmgMesh, mmgSol);
     if (ier == MMG5_STRONGFAILURE) {
-        std::cerr << "Error: MMG init mesh refinement failed (strong failure)\n";
-        std::exit(EXIT_FAILURE);
+        die(EXIT_MESH_MMG, "MMG init mesh refinement failed (strong failure)");
     }
 
     // --- Free old coarse arrays ---
@@ -1091,25 +1090,25 @@ static void mmg_refine_init_mesh_2d(
                     MMG5_ARG_end);
 
     if (MMG2D_Set_meshSize(mmgMesh, cn, ce, 0, cs) != 1)
-        std::exit(EXIT_FAILURE);
+        die(EXIT_MESH_MMG);
 
     // Vertices
     if (MMG2D_Set_vertices(mmgMesh, pcoord, NULL) != 1)
-        std::exit(EXIT_FAILURE);
+        die(EXIT_MESH_MMG);
 
     // Triangles
     int_vec conn1(ce * NODES_PER_ELEM);
     for (int i = 0; i < ce * NODES_PER_ELEM; ++i)
         conn1[i] = pconn[i] + 1;
     if (MMG2D_Set_triangles(mmgMesh, conn1.data(), NULL) != 1)
-        std::exit(EXIT_FAILURE);
+        die(EXIT_MESH_MMG);
 
     // Edges
     int_vec seg1(cs * NODES_PER_FACET);
     for (int i = 0; i < cs * NODES_PER_FACET; ++i)
         seg1[i] = pseg[i] + 1;
     if (MMG2D_Set_edges(mmgMesh, seg1.data(), psegflag) != 1)
-        std::exit(EXIT_FAILURE);
+        die(EXIT_MESH_MMG);
 
     // --- Compute metric ---
     // cra[e] = region index when per-region (encoded by points_to_mesh), used for connectivity-based projection.
@@ -1118,9 +1117,9 @@ static void mmg_refine_init_mesh_2d(
                         n_regions, regattr, max_elem_size, mesh.resolution, metric);
 
     if (MMG2D_Set_solSize(mmgMesh, mmgSol, MMG5_Vertex, cn, MMG5_Scalar) != 1)
-        std::exit(EXIT_FAILURE);
+        die(EXIT_MESH_MMG);
     if (MMG2D_Set_scalarSols(mmgSol, metric.data()) != 1)
-        std::exit(EXIT_FAILURE);
+        die(EXIT_MESH_MMG);
 
     // --- Run ---
     MMG2D_Set_iparameter(mmgMesh, mmgSol, MMG2D_IPARAM_optim,   0);
@@ -1135,8 +1134,7 @@ static void mmg_refine_init_mesh_2d(
 
     const int ier = MMG2D_mmg2dlib(mmgMesh, mmgSol);
     if (ier == MMG5_STRONGFAILURE) {
-        std::cerr << "Error: MMG2D init mesh refinement failed (strong failure)\n";
-        std::exit(EXIT_FAILURE);
+        die(EXIT_MESH_MMG, "MMG2D init mesh refinement failed (strong failure)");
     }
 
     // --- Free old coarse arrays ---
@@ -1857,12 +1855,12 @@ void my_fgets(char *buffer, std::size_t size, std::FILE *fp,
         if (! s) {
             std::cerr << "Error: reading line " << lineno
                       << " of '" << filename << "'\n";
-            std::exit(2);
+            die(EXIT_IO_RW);
         }
         if (std::strlen(buffer) == size-1 && buffer[size-2] != '\n') {
             std::cerr << "Error: reading line " << lineno
                       << " of '" << filename << "', line is too long.\n";
-            std::exit(2);
+            die(EXIT_IO_RW);
         }
 
         // check for blank lines and comments
@@ -1896,7 +1894,7 @@ void new_mesh_from_polyfile(const Param& param, Variables& var)
     std::FILE *fp = std::fopen(param.mesh.poly_filename.c_str(), "r");
     if (! fp) {
         std::cerr << "Error: Cannot open poly_filename '" << param.mesh.poly_filename << "'\n";
-        std::exit(2);
+        die(EXIT_IO_OPEN);
     }
 
     int lineno = 0;
@@ -1913,7 +1911,7 @@ void new_mesh_from_polyfile(const Param& param, Variables& var)
         if (n != 4) {
             std::cerr << "Error: parsing line " << lineno << " of '"
                       << param.mesh.poly_filename << "'\n";
-            std::exit(1);
+            die(EXIT_CONFIG_DATA);
         }
 
         if (dim != NDIMS ||
@@ -1921,7 +1919,7 @@ void new_mesh_from_polyfile(const Param& param, Variables& var)
             nbdrym != 0) {
             std::cerr << "Error: unsupported value in line " << lineno
                       << " of '" << param.mesh.poly_filename << "'\n";
-            std::exit(1);
+            die(EXIT_CONFIG_DATA);
         }
     }
 
@@ -1940,12 +1938,12 @@ void new_mesh_from_polyfile(const Param& param, Variables& var)
         if (n != NDIMS+1) {
             std::cerr << "Error: parsing line " << lineno << " of '"
                       << param.mesh.poly_filename << "'\n";
-            std::exit(1);
+            die(EXIT_CONFIG_DATA);
         }
         if (k != i) {
             std::cerr << "Error: node number is continuous from 0 at line " << lineno << " of '"
                       << param.mesh.poly_filename << "'\n";
-            std::exit(1);
+            die(EXIT_CONFIG_DATA);
         }
     }
 
@@ -1959,13 +1957,13 @@ void new_mesh_from_polyfile(const Param& param, Variables& var)
         if (n != 2) {
             std::cerr << "Error: parsing line " << lineno << " of '"
                       << param.mesh.poly_filename << "'\n";
-            std::exit(1);
+            die(EXIT_CONFIG_DATA);
         }
 
         if (has_bdryflag != 1) {
             std::cerr << "Error: unsupported value in line " << lineno
                       << " of '" << param.mesh.poly_filename << "'\n";
-            std::exit(1);
+            die(EXIT_CONFIG_DATA);
         }
     }
 
@@ -1982,13 +1980,13 @@ void new_mesh_from_polyfile(const Param& param, Variables& var)
         if (n != 3) {
             std::cerr << "Error: parsing line " << lineno << " of '"
                       << param.mesh.poly_filename << "'\n";
-            std::exit(1);
+            die(EXIT_CONFIG_DATA);
         }
         if (npolygons <= 0 ||
             nholes != 0) {
             std::cerr << "Error: unsupported value in line " << lineno
                       << " of '" << param.mesh.poly_filename << "'\n";
-            std::exit(1);
+            die(EXIT_CONFIG_DATA);
         }
         if (bdryflag == 0) goto flag_ok;
         for (int j=0; j<nbdrytypes; j++) {
@@ -1996,7 +1994,7 @@ void new_mesh_from_polyfile(const Param& param, Variables& var)
         }
         std::cerr << "Error: bdry_flag has multiple bits set in line " << lineno
                   << " of '" << param.mesh.poly_filename << "'\n";
-        std::exit(1);
+        die(EXIT_CONFIG_DATA);
     flag_ok:
         init_segflags[i] = bdryflag;
 
@@ -2014,7 +2012,7 @@ void new_mesh_from_polyfile(const Param& param, Variables& var)
             if (nvertex < NODES_PER_FACET || nvertex > 9999) {
                 std::cerr << "Error: unsupported number of polygon points in line " << lineno
                           << " of '" << param.mesh.poly_filename << "'\n";
-                std::exit(1);
+                die(EXIT_CONFIG_DATA);
             }
 
             f.polygonlist[j].vertexlist = new int[nvertex];
@@ -2026,7 +2024,7 @@ void new_mesh_from_polyfile(const Param& param, Variables& var)
                     std::cerr << "Error: segment contains out-of-range node # [0-" << npoints
                               <<"] in line " << lineno << " of '"
                               << param.mesh.poly_filename << "'\n";
-                    std::exit(1);
+                    die(EXIT_CONFIG_DATA);
                 }
             }
         }
@@ -2043,7 +2041,7 @@ void new_mesh_from_polyfile(const Param& param, Variables& var)
         if (n != NODES_PER_FACET+2) {
             std::cerr << "Error: parsing line " << lineno << " of '"
                       << param.mesh.poly_filename << "'\n";
-            std::exit(1);
+            die(EXIT_CONFIG_DATA);
         }
         if (bdryflag == 0) goto flag_ok;
         for (int j=0; j<nbdrytypes; j++) {
@@ -2051,7 +2049,7 @@ void new_mesh_from_polyfile(const Param& param, Variables& var)
         }
         std::cerr << "Error: bdry_flag has multiple bits set in line " << lineno
                   << " of '" << param.mesh.poly_filename << "'\n";
-        std::exit(1);
+        die(EXIT_CONFIG_DATA);
     flag_ok:
         init_segflags[i] = bdryflag;
     }
@@ -2062,7 +2060,7 @@ void new_mesh_from_polyfile(const Param& param, Variables& var)
                 std::cerr << "Error: segment contains out-of-range node # [0-" << npoints
                           <<"] in line " << lineno << " of '"
                           << param.mesh.poly_filename << "'\n";
-                std::exit(1);
+                die(EXIT_CONFIG_DATA);
             }
         }
     }
@@ -2077,13 +2075,13 @@ void new_mesh_from_polyfile(const Param& param, Variables& var)
         if (n != 1) {
             std::cerr << "Error: parsing line " << lineno << " of '"
                       << param.mesh.poly_filename << "'\n";
-            std::exit(1);
+            die(EXIT_CONFIG_DATA);
         }
 
         if (nholes != 0) {
             std::cerr << "Error: unsupported value in line " << lineno
                       << " of '" << param.mesh.poly_filename << "'\n";
-            std::exit(1);
+            die(EXIT_CONFIG_DATA);
         }
     }
 
@@ -2096,12 +2094,12 @@ void new_mesh_from_polyfile(const Param& param, Variables& var)
         if (n != 1) {
             std::cerr << "Error: parsing line " << lineno << " of '"
                       << param.mesh.poly_filename << "'\n";
-            std::exit(1);
+            die(EXIT_CONFIG_DATA);
         }
         if (nregions <= 0) {
             std::cerr << "Error: nregions <= 0, at line " << lineno << " of '"
                       << param.mesh.poly_filename << "'\n";
-            std::exit(1);
+            die(EXIT_CONFIG_DATA);
         }
     }
 
@@ -2121,13 +2119,12 @@ void new_mesh_from_polyfile(const Param& param, Variables& var)
         if (n != NDIMS+3) {
             std::cerr << "Error: parsing line " << lineno << " of '"
                       << param.mesh.poly_filename << "'. "<<NDIMS+3<<" values should be given but only "<<n<<" found.\n";
-            std::exit(1);
+            die(EXIT_CONFIG_DATA);
         }
 
         if ( x[NDIMS] < 0 || x[NDIMS] >= param.mat.nmat ) {
             std::cerr << "Error: "<<NDIMS+2<<"-th value in line "<<lineno<<" should be >=0 and < "<<param.mat.nmat<<" (=mat.num_materials) but is "<<x[NDIMS]<<"\n";
-            std::cerr << "Note that this parameter is directly used as the index of mat. prop. arrays.\n";
-            std::exit(1);
+            die(EXIT_CONFIG_DATA, "Note that this parameter is directly used as the index of mat. prop. arrays.");
         }
 
         if ( x[NDIMS+1] > 0 ) {
@@ -2258,8 +2255,7 @@ void new_mesh_from_exofile(const Param& param, Variables& var)
 {
 
 #ifndef THREED
-    std::cerr << "Error: Importing an exofile currently works in 3D only.\n";
-    std::exit(2);
+    die(EXIT_UNSUPPORTED_DIM, "Importing an exofile currently works in 3D only.");
 #endif
 
     // Open an .exo file.
@@ -2273,7 +2269,7 @@ void new_mesh_from_exofile(const Param& param, Variables& var)
                          &version); /* ExodusII library version */
     if (exoid < 0) {
         std::cerr << "Error: Cannot open exo_filename '" << param.mesh.exo_filename << "'\n";
-        std::exit(2);
+        die(EXIT_IO_OPEN);
     }
 
     // Read database parameters.
@@ -2285,7 +2281,7 @@ void new_mesh_from_exofile(const Param& param, Variables& var)
                          &num_elem_blk, &num_node_sets, &num_side_sets);
     if( error != 0 ) {
         std::cerr << "Error: Unable to read database parameters from '" << param.mesh.exo_filename << std::endl;
-        std::exit(2);
+        die(EXIT_IO_RW);
     }
     var.nnode = num_nodes;
     var.nelem = num_elem;
@@ -2297,7 +2293,7 @@ void new_mesh_from_exofile(const Param& param, Variables& var)
     if( param.mat.nmat != num_elem_blk) {
         std::cerr <<"param.mat.nmat is not equal to # of element blocks in this exo file!"<<std::endl;
         std::cerr <<"Check if your material parameters are properly set!!"<<std::endl;
-        std::exit(2);
+        die(EXIT_IO_RW);
     }
 
     // Assign node coordinates.
@@ -2308,7 +2304,7 @@ void new_mesh_from_exofile(const Param& param, Variables& var)
     error = ex_get_coord (exoid, x, y, z);
     if( error != 0 ) {
         std::cerr << "Error: Unable to read coordinates from '" << param.mesh.exo_filename << "'\n";
-        std::exit(2);
+        die(EXIT_IO_RW);
     }
 
     // assign node coordinates to var.coord.
@@ -2339,7 +2335,7 @@ void new_mesh_from_exofile(const Param& param, Variables& var)
     error = ex_get_ids (exoid, EX_ELEM_BLOCK, ids);
     if( error != 0 ) {
         std::cerr << "Error: Unable to get element block ids." << std::endl;
-        std::exit(2);
+        die(EXIT_IO_RW);
     }
     // - Read element block parameters.
     for (int i=0; i<num_elem_blk; i++) {
@@ -2350,11 +2346,11 @@ void new_mesh_from_exofile(const Param& param, Variables& var)
         if( error != 0 ) {
             std::cerr << "Error: Unable to element block " << ids[i] ;
             std::cerr << " out of " << num_elem_blk << " blocks." << std::endl;
-            std::exit(2);
+            die(EXIT_IO_RW);
         }
         if( NODES_PER_ELEM != num_nodes_per_elem[i] ) {
             std::cerr << "Error: Element has " << num_nodes_per_elem[i] << " nodes per element but should have "<<NODES_PER_ELEM<<" because element type should be uniformly tetrahedral."<< std::endl;
-            std::exit(2);
+            die(EXIT_IO_RW);
         }
     }
 
@@ -2384,7 +2380,7 @@ void new_mesh_from_exofile(const Param& param, Variables& var)
         if( error != 0 ) {
             std::cerr << "Error: Unable to connectivity for element block " << ids[i] ;
             std::cerr << " out of " << num_elem_blk << " blocks." << std::endl;
-            std::exit(2);
+            die(EXIT_IO_RW);
         }
     }
 
@@ -2422,7 +2418,7 @@ void new_mesh_from_exofile(const Param& param, Variables& var)
     error = ex_get_ids (exoid, EX_SIDE_SET, ids);
     if( error != 0 ) {
             std::cerr << "Error: Unable to get side set ids." << std::endl;
-            std::exit(2);
+            die(EXIT_IO_RW);
     }
     var.nseg = 0;
     for(int i=0; i<num_side_sets; i++) {
@@ -2430,7 +2426,7 @@ void new_mesh_from_exofile(const Param& param, Variables& var)
                                        &(num_df_in_set[i]));
         if( error != 0 ) {
             std::cerr << "Error: Unable to read "<<i<<"-th side set parameters." << std::endl;
-            std::exit(2);
+            die(EXIT_IO_RW);
         }
         var.nseg += num_sides_in_set[i];
     }
@@ -2459,14 +2455,14 @@ void new_mesh_from_exofile(const Param& param, Variables& var)
         error = ex_get_set (exoid, EX_SIDE_SET, ids[i], elem_list[i], side_list[i]);
         if( error != 0 ) {
             std::cerr << "Error: Unable to read "<< i <<"-th side set." << std::endl;
-            std::exit(2);
+            die(EXIT_IO_RW);
         }
         if (num_df_in_set != NULL) {
             error = ex_get_set_dist_fact (exoid, EX_SIDE_SET, ids[i], dist_fact[i]);
             if( error != 0 ) {
                 std::cerr << "Error: Unable to read "<< i;
                 std::cerr <<"-th side set's distribution factor list." << std::endl;
-                std::exit(2);
+                die(EXIT_IO_RW);
             }
         }
     }
@@ -2641,7 +2637,7 @@ void points_to_new_mesh(const Mesh &mesh, int npoints, const double *points,
 #else
         std::cerr << "Error: triangulation failed\n";
 #endif
-        std::exit(10);
+        die(EXIT_MESH_TETGEN);
     }
 
 }
@@ -2667,8 +2663,7 @@ void points_to_new_surface(const Mesh &mesh, int npoints, const double *points,
                         &psegment, &psegflag, &pregattr);
 
     if (nelem <= 0) {
-        std::cerr << "Error: surface triangulation failed\n";
-        std::exit(10);
+        die(EXIT_MESH_TETGEN, "surface triangulation failed");
     }
 #endif
 }
@@ -3198,7 +3193,7 @@ void create_boundary_facets(Variables& var)
                 #pragma omp critical
                 {
                     std::cerr << "Error: " << i << "-th segment is not on any element\n";
-                    std::exit(12);
+                    die(EXIT_INTERNAL_UNREACHABLE);
                 }
             }
         }
@@ -3446,7 +3441,7 @@ void create_new_mesh(const Param& param, Variables& var)
             new_mesh_regular_equilateral(param, var);
         } else {
             std::cout << "Error: unknown meshing_elem_shape: " << param.mesh.meshing_elem_shape << '\n';
-            std::exit(10);
+            die(EXIT_CONFIG_VALUE);
         }
         break;
     case 2:
@@ -3461,12 +3456,12 @@ void create_new_mesh(const Param& param, Variables& var)
         new_mesh_from_exofile(param, var);
 #else
         std::cout << "Error: Install Exodus library and rebuild with 'useexo' turned on in Makefile." << std::endl;
-        std::exit(1);
+        die(EXIT_UNSUPPORTED_LIB);
 #endif
         break;
     default:
         std::cout << "Error: unknown meshing option: " << param.mesh.meshing_option << '\n';
-        std::exit(1);
+        die(EXIT_CONFIG_VALUE);
     }
 
     if (param.mesh.is_discarding_internal_segments)

--- a/mesh.cxx
+++ b/mesh.cxx
@@ -2919,7 +2919,7 @@ void create_top_elems(Variables& var)
     var.ntop_elems = telems.size();
 
     var.top_elems = new int_vec(var.ntop_elems);
-    for (std::size_t i=0; i<var.ntop_elems; i++)
+    for (int i=0; i<var.ntop_elems; i++)
         (*var.top_elems)[i] = telems[i];
 
 #ifdef NPROF_DETAIL

--- a/mesh.cxx
+++ b/mesh.cxx
@@ -2906,9 +2906,11 @@ void create_top_elems(Variables& var)
     {
         int n = top_nodes[i];
         // grep the element connected surface
-        for (std::size_t j=0; j<(*var.support)[n].size(); j++)
+        const int npatch = var.support.size(n);
+        const int* patch = var.support.patch(n);
+        for (int j=0; j<npatch; j++)
             //use set to avoid duplicated elements.
-            elem_set.insert((*var.support)[n][j]);
+            elem_set.insert(patch[j]);
     }
     // turn set to vector
     for (auto it = elem_set.begin(); it != elem_set.end();it++)
@@ -2924,6 +2926,36 @@ void create_top_elems(Variables& var)
     nvtxRangePop();
 #endif
 }
+
+// Inverse of elem_and_nodes, which the caller must have filled. Same two passes
+// as create_support(); lidx is left empty because only facet ids are read.
+static void create_support_surf(SurfaceInfo& surfinfo, int ntop, size_t etop)
+{
+    Support& sup = surfinfo.support_surf;
+    // assign, not resize: pass 1 accumulates, so idx must start zeroed.
+    sup.idx_data.assign(ntop + 1, 0);
+
+    // Pass 1: count the facets touching each surface node.
+    for (size_t i=0; i<etop; i++)
+        for (int k=0; k<NDIMS; k++)
+            sup.idx_data[(*surfinfo.elem_and_nodes)[i][k] + 1]++;
+    // prefix-sum counts into start offsets
+    for (int n=1; n<=ntop; ++n)
+        sup.idx_data[n] += sup.idx_data[n-1];
+
+    sup.arr_data.resize(sup.idx_data[ntop]);
+
+    // Pass 2: fill, in the same facet order as pass 1, so each node's patch comes
+    // out ascending in facet id -- the order the total_dx gather sums in.
+    {
+        int_vec cursor(sup.idx_data.begin(), sup.idx_data.end() - 1);
+        for (size_t i=0; i<etop; i++)
+            for (int k=0; k<NDIMS; k++)
+                sup.arr_data[cursor[(*surfinfo.elem_and_nodes)[i][k]]++] = i;
+    }
+    sup.rebind();
+}
+
 
 void update_surface_info(const Variables& var, SurfaceInfo& surfinfo)
 {
@@ -2977,23 +3009,17 @@ void update_surface_info(const Variables& var, SurfaceInfo& surfinfo)
     surfinfo.total_slope = new double_vec(var.nnode,0.);
 
 
-    delete surfinfo.node_and_elems;
-    surfinfo.node_and_elems = new int_vec2D(ntop,int_vec(0));
     for (size_t i=0; i<etop; i++) {
-        auto j = (*(var.bfacets[iboundz1]))[i];
-        int e = j.first;
-        int f = j.second;
+        (*surfinfo.top_facet_elems)[i] = (*(var.bfacets[iboundz1]))[i].first;
 
-        (*surfinfo.top_facet_elems)[i] = e;
-
-        // the nodes of element
-        for (int k=0; k<NDIMS; k++) {
-            int n = surfinfo.arctop_nodes[(*var.connectivity)[e][NODE_OF_FACET[f][k]]];
-            (*surfinfo.elem_and_nodes)[i][k] = n;
-            // store the elements connect to node
-            (*surfinfo.node_and_elems)[n].push_back(i);
-        }
+        // Same facets in the same order, so connectivity_surface has already gathered
+        // this facet's global node ids: elem_and_nodes is just those mapped into the
+        // surface numbering -- one contiguous read, not a second random gather.
+        for (int k=0; k<NDIMS; k++)
+            (*surfinfo.elem_and_nodes)[i][k] =
+                surfinfo.arctop_nodes[(*var.connectivity_surface)[i][k]];
     }
+    create_support_surf(surfinfo, ntop, etop);
 
 }
 
@@ -3054,22 +3080,17 @@ void create_surface_info(const Param& param, const Variables& var, SurfaceInfo& 
     surfinfo.total_dx = new double_vec(var.nnode,0.);
     surfinfo.total_slope = new double_vec(var.nnode,0.);
 
-    surfinfo.node_and_elems = new int_vec2D(ntop,int_vec(0));
     for (size_t i=0; i<etop; i++) {
-        auto j = (*(var.bfacets[iboundz1]))[i];
-        int e = j.first;
-        int f = j.second;
+        (*surfinfo.top_facet_elems)[i] = (*(var.bfacets[iboundz1]))[i].first;
 
-        (*surfinfo.top_facet_elems)[i] = e;
-
-        // the nodes of element
-        for (int k=0; k<NDIMS; k++) {
-            int n = surfinfo.arctop_nodes[(*var.connectivity)[e][NODE_OF_FACET[f][k]]];
-            (*surfinfo.elem_and_nodes)[i][k] = n;
-            // store the elements connect to node
-            (*surfinfo.node_and_elems)[n].push_back(i);
-        }
+        // Same facets in the same order, so connectivity_surface has already gathered
+        // this facet's global node ids: elem_and_nodes is just those mapped into the
+        // surface numbering -- one contiguous read, not a second random gather.
+        for (int k=0; k<NDIMS; k++)
+            (*surfinfo.elem_and_nodes)[i][k] =
+                surfinfo.arctop_nodes[(*var.connectivity_surface)[i][k]];
     }
+    create_support_surf(surfinfo, ntop, etop);
 
     //***** to do *****
 //    surface_edhacc_geometry_interpolation(var,info);
@@ -3263,39 +3284,40 @@ void create_support(Variables& var)
 #ifdef NPROF_DETAIL
     nvtxRangePush(__FUNCTION__);
 #endif
-    var.support = new int_vec2D(var.nnode);
-    // CSR row-pointer format: size nnode+1, support_idx[n] = start of node n
-    var.support_idx = new int_vec(var.nnode + 1, 0);
+    // assign, not resize: pass 1 accumulates, so idx must start zeroed.
+    var.support.idx_data.assign(var.nnode + 1, 0);
 
-    // create the inverse mapping of connectivity
+    // Pass 1: count the elements supporting each node.
     for (int e=0; e<var.nelem; ++e) {
         ConstConnAccessor conn = (*var.connectivity)[e];
-        for (int i=0; i<NODES_PER_ELEM; ++i) {
-            (*var.support)[conn[i]].push_back(e);
-            (*var.support_idx)[conn[i] + 1]++;
-        }
+        for (int i=0; i<NODES_PER_ELEM; ++i)
+            var.support.idx_data[conn[i] + 1]++;
     }
     // prefix-sum counts into start offsets
     for (int n=1; n<=var.nnode; ++n)
-        (*var.support_idx)[n] += (*var.support_idx)[n-1];
+        var.support.idx_data[n] += var.support.idx_data[n-1];
 
-    int nsup = (*var.support_idx)[var.nnode];
+    int nsup = var.support.idx_data[var.nnode];
 
-    var.support_arr = new int_vec(nsup);
+    var.support.arr_data.resize(nsup);
+    var.support.lidx_data.resize(nsup);
 
-    // fill support_arr
-    for (int n=0; n<var.nnode; ++n) {
-        int start = (*var.support_idx)[n];
-        int end   = (*var.support_idx)[n+1];
-        for (int i=start; i<end; ++i) {
-            (*var.support_arr)[i] = (*var.support)[n][i-start];
+    // Pass 2: fill, in the same element order as pass 1, so each node's patch
+    // comes out ascending in element id -- the order every gather sums in.
+    {
+        int_vec cursor(var.support.idx_data.begin(), var.support.idx_data.end() - 1);
+        for (int e=0; e<var.nelem; ++e) {
+            ConstConnAccessor conn = (*var.connectivity)[e];
+            for (int i=0; i<NODES_PER_ELEM; ++i) {
+                const int n = conn[i];
+                const int slot = cursor[n]++;
+                var.support.arr_data[slot] = e;
+                var.support.lidx_data[slot] = i;   // free here: it is the loop counter
+            }
         }
     }
-    var.sup = {var.support_arr->data(), var.support_idx->data()};
+    var.support.rebind();
 
-    // std::cout << "support:\n";
-    // print(std::cout, *var.support);
-    // std::cout << "\n";
 #ifdef NPROF_DETAIL
     nvtxRangePop();
 #endif
@@ -3342,10 +3364,11 @@ void create_neighbor(Variables& var)
                 }
             }
 
-            // reference, not a copy: a copy heap-allocates per iteration.
-            const int_vec& sup = (*var.support)[n[0]];
+            // CSR row, not a copy of it: copying the patch heap-allocated per iteration.
+            const int nsup = var.support.size(n[0]);
+            const int* sup = var.support.patch(n[0]);
             bool found = false;
-            for (int j=0; j<sup.size() && !found; ++j) {
+            for (int j=0; j<nsup && !found; ++j) {
                 int neigh = sup[j];
                 if (neigh > e) {
                     ConstConnAccessor conn2 = (*var.connectivity)[neigh];

--- a/mesh.cxx
+++ b/mesh.cxx
@@ -3306,6 +3306,8 @@ void create_support(Variables& var)
 #endif
 }
 
+// Currently unused: all three call sites are commented out, so var.neighbor /
+// var.contact / var.ctmp are written and read by nobody.
 void create_neighbor(Variables& var)
 {
 #ifdef NPROF_DETAIL
@@ -3331,7 +3333,8 @@ void create_neighbor(Variables& var)
     #pragma acc parallel loop collapse(2) copy(ncontact) async
     for (int e=0; e<var.nelem; ++e) {
         for (int i=0; i<NODES_PER_ELEM; ++i) {
-            if ((*var.neighbor)[e][i] != -1) continue; // already set
+            // No "already set" early-exit: it would race the cross-row write below, and the
+            // `neigh > e` filter already registers each internal facet exactly once.
             int n[NDIMS], n2[NDIMS];
             for (int j=0; j<NDIMS; ++j)
                 n[j] = (*var.connectivity)[e][NODE_OF_FACET[i][j]];
@@ -3344,7 +3347,8 @@ void create_neighbor(Variables& var)
                 }
             }
 
-            const int_vec sup = (*var.support)[n[0]];
+            // reference, not a copy: a copy heap-allocates per iteration.
+            const int_vec& sup = (*var.support)[n[0]];
             bool found = false;
             for (int j=0; j<sup.size() && !found; ++j) {
                 int neigh = sup[j];

--- a/output.cxx
+++ b/output.cxx
@@ -78,14 +78,14 @@ void Output::write_info(const Variables& var, double dt)
 
     if (f == NULL) {
         std::cerr << "Error: cannot open file '" << filename << "' for writing\n";
-        std::exit(2);
+        die(EXIT_IO_OPEN);
     }
 
     if (std::fputs(buffer, f) == EOF) {
         std::cerr << "Error: failed writing to file '" << filename << "'\n";
         std::cerr << "\tbuffer written:\n";
         std::cerr << buffer << '\n';
-        std::exit(2);
+        die(EXIT_IO_RW);
     }
 
     std::fclose(f);

--- a/parameters.hpp
+++ b/parameters.hpp
@@ -579,6 +579,36 @@ struct Param {
 //
 // Structures for surface processes
 //
+// Node-support graph in CSR: node n owns [idx[n], idx[n+1]) of arr and lidx.
+// Owns the arrays and caches their pointers beside them, because .data() is not
+// callable from device code -- rebind() after anything that resizes them.
+struct Support {
+    int_vec arr_data;   // element ids, one per (node, element) incidence
+    int_vec idx_data;   // row-pointers, size nnode+1
+    int_vec lidx_data;  // which local node of arr[i] the gather node is; may be
+                        // left empty when only element ids are needed, and then
+                        // local() must not be called
+
+    const int* arr  = NULL;
+    const int* idx  = NULL;
+    const int* lidx = NULL;
+
+    void rebind() {
+        arr  = arr_data.data();
+        idx  = idx_data.data();
+        lidx = lidx_data.empty() ? NULL : lidx_data.data();
+    }
+
+    #pragma acc routine seq
+    int size(int inode) const { return idx[inode+1] - idx[inode]; }
+
+    #pragma acc routine seq
+    const int* patch(int inode) const { return arr + idx[inode]; }
+
+    #pragma acc routine seq
+    const int* local(int inode) const { return lidx + idx[inode]; }
+};
+
 struct SurfaceInfo {
 
 //    const double sec_year = 31556925.2;
@@ -613,7 +643,7 @@ struct SurfaceInfo {
     double_vec *dhacc;
     // variable allocate by remesh
     double_vec *edvacc_surf;
-    int_vec2D *node_and_elems;
+    Support support_surf;  // surface node -> its top facets; no lidx needed
     segment_t *elem_and_nodes;
 
     int_map arctop_facet_elems;
@@ -631,19 +661,6 @@ struct SurfaceInfo {
 
 };
 
-//
-// Non-owning view over the flattened (CSR) node-support arrays.
-// idx[n] = start of node n's entries in arr; idx[n+1]-idx[n] = count.
-struct SupportView {
-    const int* arr;  // flat element IDs
-    const int* idx;  // CSR row-pointers (size nnode+1)
-
-    #pragma acc routine seq
-    int size(int inode) const { return idx[inode+1] - idx[inode]; }
-
-    #pragma acc routine seq
-    const int* patch(int inode) const { return arr + idx[inode]; }
-};
 
 // Structures for model variables
 //
@@ -723,10 +740,7 @@ struct Variables {
     int_vec2D *markers_in_elem;
     int_vec2D *hydrous_markers_in_elem;
 
-    int_vec2D *support;
-    int_vec *support_arr;
-    int_vec *support_idx;
-    SupportView sup;
+    Support support;  // node-support graph; rebuilt by create_support()
     conn_t *neighbor; // neighboring elements for each element
     int_pair_vec *contact; // contact elements for each element
     double_vec *ctmp; // temporary array for contact elements

--- a/parameters.hpp
+++ b/parameters.hpp
@@ -706,9 +706,13 @@ struct Variables {
     double stress_bc_values[nbdrytypes];
     double vbc_val_z1_loading_period;
 
-    std::map<std::pair<int,int>, double_vec> edge_vectors;
+    // Unit vector along the edge where two boundaries meet, NDIMS doubles per pair in
+    // edge_vec. edge_slot[i*nbdrytypes + j] with i < j indexes it, and is -1 when that
+    // pair shares no edge -- the state apply_vbcs has to test before dereferencing.
+    // A dense nbdrytypes^2 table rather than a searchable list: 100 ints is smaller than
+    // any index it could carry, so the device lookup is one load and needs no pointer.
     double_vec edge_vec;
-    int_vec edge_vec_idx;
+    int edge_slot[nbdrytypes * nbdrytypes];
     double_vec vbc_vertical_div_x0;
     double_vec vbc_vertical_div_x1;
     double_vec vbc_vertical_ratio_x0;

--- a/phasechanges.cxx
+++ b/phasechanges.cxx
@@ -154,7 +154,7 @@ void phase_changes(const Param& param, Variables& var)
 
     if (is_error) {
         std::cerr << "Error: unknown phase_change_option: " << param.mat.phase_change_option << '\n';
-        std::exit(1);
+        die(EXIT_CONFIG_VALUE);
     }
 
     if (param.control.has_hydration_processes) {
@@ -188,8 +188,7 @@ void phase_changes(const Param& param, Variables& var)
                         if (hydms.get_elem(mh) == el) break;
                     }
                     if (mh >= hydms.get_nmarkers()) {
-                        std::cerr << "Error: hydrous marker phase change\n";
-                        std::exit(12);
+                        die(EXIT_RUNTIME_LOOKUP, "hydrous marker phase change");
                     }
                     #pragma omp critical(phase_change_simple_subduction)
                     {

--- a/remeshing.cxx
+++ b/remeshing.cxx
@@ -283,8 +283,7 @@ void new_bottom(const uint_vec &old_bcflag, double *qcoord,
      * near the bottom are affected as well. The code does not deal with this
      * complexity and can only work in 2D.
      */
-    std::cerr << "Error: new_bottom() does not work in 3D.\n";
-    std::exit(1);
+    die(EXIT_UNSUPPORTED_DIM, "new_bottom() does not work in 3D.");
 #endif
 
     int_vec bottom_corners;
@@ -321,7 +320,7 @@ void new_bottom(const uint_vec &old_bcflag, double *qcoord,
         std::cout << "bottom corners: ";
         print(std::cout, bottom_corners);
         std::cout << '\n';
-        std::exit(11);
+        die(EXIT_MESH_QUALITY);
     }
 
     // move the corners to the same depth
@@ -457,8 +456,7 @@ void assemble_bdry_polygons(const Variables &var, const array_t &old_coord,
             }
             else {
                 // not possible
-                std::cout << "Error: an edge is belonged to more than 2 facets. The mesh is corrupted.\n";
-                std::exit(11);
+                die(EXIT_MESH_QUALITY, "an edge is belonged to more than 2 facets. The mesh is corrupted.");
             }
         }
 
@@ -487,8 +485,7 @@ void assemble_bdry_polygons(const Variables &var, const array_t &old_coord,
         }
         // the starting point and end point must be the same
         if (polygon.front() != polygon.back()) {
-            std::cout << "Error: boundary polygon is not closed. The mesh is corrupted.\n";
-            std::exit(11);
+            die(EXIT_MESH_QUALITY, "boundary polygon is not closed. The mesh is corrupted.");
         }
         polygon.pop_back();  // removed the duplicating end point
 
@@ -622,7 +619,7 @@ void delete_facets(int &nseg, int *segment, int *segflag)
                 ) {
                 std::cerr << "Error: segment array is corrupted before delete_facets()!\n";
                 print(std::cerr, segment, nseg*NODES_PER_FACET);
-                std::exit(11);
+                die(EXIT_MESH_QUALITY);
             }
 
             // replace deleted segment with the last segment
@@ -650,8 +647,7 @@ void delete_points_and_merge_segments(const int_vec &points_to_delete, int &npoi
                                       uint_vec &bcflag, double min_length)
 {
 #ifdef THREED
-    std::cerr << "delete_points_and_merge_segments() doesn't work in 3D!\n";
-    std::exit(12);
+    die(EXIT_INTERNAL_ASSERT, "delete_points_and_merge_segments() doesn't work in 3D!");
 #endif
 
     int *endsegment = segment + nseg * NODES_PER_FACET;
@@ -672,8 +668,7 @@ void delete_points_and_merge_segments(const int_vec &points_to_delete, int &npoi
             int *a = std::find(segment, endsegment, *i);
             int *b = std::find(a+1, endsegment, *i);
             if (b == endsegment) {
-                std::cerr << "Error: segment array is corrupted when merging segment!\n";
-                std::exit(11);
+                die(EXIT_MESH_QUALITY, "segment array is corrupted when merging segment!");
             }
 
             // a could be the either first or second node of the segment,
@@ -753,8 +748,7 @@ void delete_points_and_merge_facets(const int_vec &points_to_delete,
                                     uint_vec &bcflag, double min_length)
 {
 #ifndef THREED
-    std::cerr << "delete_points_and_merge_facets() doesn't work in 2D!\n";
-    std::exit(12);
+    die(EXIT_INTERNAL_ASSERT, "delete_points_and_merge_facets() doesn't work in 2D!");
 #else
 
     int_vec inverse[nbdrytypes], nfacets;
@@ -889,11 +883,10 @@ void delete_points_and_merge_facets(const int_vec &points_to_delete,
                 std::cout << "new conn: ";
                 print(std::cout, pconnectivity, new_nelem*3);
                 std::cout << '\n';
-                std::exit(12);
+                die(EXIT_INTERNAL_ASSERT);
             }
             if (new_nseg != new_polygon_size) {
-                std::cerr << "Error: points_to_new_surface is adding new segments!\n";
-                std::exit(12);
+                die(EXIT_INTERNAL_ASSERT, "points_to_new_surface is adding new segments!");
             }
 
             delete [] pcoord;
@@ -919,8 +912,7 @@ void delete_points_and_merge_facets(const int_vec &points_to_delete,
 
     int nseg2 = std::accumulate(nfacets.begin(), nfacets.end(), 0);
     if (nseg2 > nseg) {
-        std::cerr << "Error: ponits_to_new_surface too many segments!\n";
-        std::exit(12);
+        die(EXIT_INTERNAL_ASSERT, "ponits_to_new_surface too many segments!");
     }
 
     // appending facets of all boundaries into segment array
@@ -1171,7 +1163,7 @@ void new_mesh(const Param &param, Variables &var, int bad_quality,
         break;
     default:
         std::cerr << "Error: unknown remeshing_option: " << param.mesh.remeshing_option << '\n';
-        std::exit(1);
+        die(EXIT_CONFIG_VALUE);
     }
 
     /* choosing which way to remesh the boundary */
@@ -2280,7 +2272,7 @@ void optimize_mesh(const Param &param, Variables &var, int bad_quality,
         break;
     default:
         std::cerr << "Error: unknown remeshing_option: " << param.mesh.remeshing_option << '\n';
-        std::exit(1);
+        die(EXIT_CONFIG_VALUE);
     }
 
     // --- STEP I: Initialization
@@ -2303,20 +2295,20 @@ void optimize_mesh(const Param &param, Variables &var, int bad_quality,
     //  a) give the size of the mesh: vertices, tetra, prisms, triangles, quads, edges
     if ( MMG3D_Set_meshSize(mmgMesh, old_nnode, old_nelem,
                             0,old_nseg,0,0) != 1 )
-        exit(EXIT_FAILURE);
+        die(EXIT_MESH_MMG);
     //   b) give the vertex coordinates. References are NULL but can be an integer array for boundary flag etc.
     if( MMG3D_Set_vertices(mmgMesh, qcoord, NULL) != 1)
-        exit(EXIT_FAILURE);
+        die(EXIT_MESH_MMG);
     //   c) give the connectivity. References are NULL but can be an integer array for boundary flag etc.
     for (int i = 0; i < old_nelem*NODES_PER_ELEM; ++i)
         ++qconn_from_1[i];
     if( MMG3D_Set_tetrahedra(mmgMesh, qconn_from_1, NULL) != 1 )
-        exit(EXIT_FAILURE);
+        die(EXIT_MESH_MMG);
     //   d) give the segments (i.e., boundary facet)
     for (int i = 0; i < old_nseg*NODES_PER_FACET; ++i)
         ++qsegment_from_1[i];
     if( MMG3D_Set_triangles(mmgMesh, qsegment_from_1, qsegflag) != 1 )
-        exit(EXIT_FAILURE);
+        die(EXIT_MESH_MMG);
 
     // 3) Build sol in MMG5 format
     //      Here a 'solution' is a nodal field that becomes
@@ -2325,65 +2317,65 @@ void optimize_mesh(const Param &param, Variables &var, int bad_quality,
     //
     //   a) give info for the sol structure
     if( MMG3D_Set_solSize(mmgMesh, mmgSol, MMG5_Vertex, old_nnode, MMG5_Scalar) != 1 )
-        exit(EXIT_FAILURE);
+        die(EXIT_MESH_MMG);
     //   b) give solutions values and positions
     compute_metric_field(var, *var.ntmp, *var.etmp);
     //      i) If sol array is available:
     if( MMG3D_Set_scalarSols(mmgSol, (*var.ntmp).data()) != 1 )
-        exit(EXIT_FAILURE);
+        die(EXIT_MESH_MMG);
 
     /*save init mesh*/
     //      ii) Otherwise, set a value node by node:
     // for (int i = 0; i < var.nnode; ++i) {
     //     if( MMG3D_Set_scalarSol(mmgSol, 100.0, i+1) != 1 )
-    //         exit(EXIT_FAILURE);
+    //         exit(10);
     // }
     //      iii) If a metric field ('solution') is given, 
     //           optimization mode should be off.
     if ( MMG3D_Set_iparameter(mmgMesh,mmgSol,MMG3D_IPARAM_optim, 0) != 1 ) 
-        exit(EXIT_FAILURE);
+        die(EXIT_MESH_MMG);
 
     // 4) (not mandatory): check if the number of given entities match with mesh size
-    if( MMG3D_Chk_meshData(mmgMesh, mmgSol) != 1 ) exit(EXIT_FAILURE);
+    if( MMG3D_Chk_meshData(mmgMesh, mmgSol) != 1 ) die(EXIT_MESH_MMG);
 
     //--- STEP  II: Remesh function
     /* debug mode ON (default value = OFF) */
     if ( MMG3D_Set_iparameter(mmgMesh,mmgSol,MMG3D_IPARAM_debug, param.mesh.mmg_debug) != 1 )
-        exit(EXIT_FAILURE);
+        die(EXIT_MESH_MMG);
     if ( MMG3D_Set_iparameter(mmgMesh,mmgSol,MMG3D_IPARAM_verbose, param.mesh.mmg_verbose) != 1 )
-        exit(EXIT_FAILURE);
+        die(EXIT_MESH_MMG);
  
     /* maximal memory size (default value = 50/100*ram) */
     //if ( MMG3D_Set_iparameter(mmgMesh,mmgSol,MMG3D_IPARAM_mem, 600) != 1 )
-    //exit(EXIT_FAILURE);
+    //exit(10);
 
     // /* Maximal mesh size (default FLT_MAX)*/
     if ( MMG3D_Set_dparameter(mmgMesh,mmgSol,MMG3D_DPARAM_hmax, param.mesh.mmg_hmax_factor*param.mesh.resolution) != 1 )
-    exit(EXIT_FAILURE);
+    die(EXIT_MESH_MMG);
 
     /* Minimal mesh size (default 0)*/
     if ( MMG3D_Set_dparameter(mmgMesh,mmgSol,MMG3D_DPARAM_hmin, param.mesh.mmg_hmin_factor*param.mesh.resolution) != 1 )
-    exit(EXIT_FAILURE);
+    die(EXIT_MESH_MMG);
 
     /* Global hausdorff value (default value = 0.01) applied on the whole boundary */
     if ( MMG3D_Set_dparameter(mmgMesh,mmgSol,MMG3D_DPARAM_hausd, param.mesh.mmg_hausd_factor*param.mesh.resolution) != 1 )
-    exit(EXIT_FAILURE);
+    die(EXIT_MESH_MMG);
 
     // /* Gradation control*/
     // if ( MMG3D_Set_dparameter(mmgMesh,mmgSol,MMG3D_DPARAM_hgrad, 3.0) != 1 )
-    // exit(EXIT_FAILURE);
+    // exit(10);
 
     // /* Gradation requirement */
     // if ( MMG3D_Set_dparameter(mmgMesh,mmgSol,MMG3D_DPARAM_hgradreq, -1.0) != 1 )
-    // exit(EXIT_FAILURE);
+    // exit(10);
 
     const int ier = MMG3D_mmg3dlib(mmgMesh, mmgSol);
     if ( ier == MMG5_STRONGFAILURE ) {
         fprintf(stdout,"BAD ENDING OF MMG3DLIB: UNABLE TO SAVE MESH\n");
-        exit(EXIT_FAILURE);
+        die(EXIT_MESH_MMG);
     } else if ( ier == MMG5_LOWFAILURE ) {
         fprintf(stdout,"BAD ENDING OF MMG3DLIB\n");
-        exit(EXIT_FAILURE);
+        die(EXIT_MESH_MMG);
     }
 
     //--- STEP III: Get results
@@ -2391,7 +2383,7 @@ void optimize_mesh(const Param &param, Variables &var, int bad_quality,
     //   a) get the size of the mesh: vertices, tetra, triangles, edges */
     int na;
     if ( MMG3D_Get_meshSize(mmgMesh, &(var.nnode), &(var.nelem), NULL, &(var.nseg), NULL, &na) !=1 )
-        exit(EXIT_FAILURE);
+        die(EXIT_MESH_MMG);
     std::cerr << "Updated mesh size\n";
     std::cerr << "New number of vertices:" << var.nnode << std::endl;
     std::cerr << "New number of elements:" << var.nelem << std::endl;
@@ -2413,14 +2405,14 @@ void optimize_mesh(const Param &param, Variables &var, int bad_quality,
     //   a) Vertex recovering
     for (int i = 0; i < var.nnode; ++i) {
         if ( MMG3D_Get_vertex(mmgMesh, &(new_coord[i][0]), &(new_coord[i][1]), &(new_coord[i][2]), NULL, NULL, NULL) != 1 )
-            exit(EXIT_FAILURE);
+            die(EXIT_MESH_MMG);
     }
     std::cerr << "New coordinates populated\n";
 
     //   b) Tetra recovering
     for (int i = 0; i < var.nelem; ++i) {
         if ( MMG3D_Get_tetrahedron(mmgMesh, &(new_connectivity[i][0]), &(new_connectivity[i][1]), &(new_connectivity[i][2]), &(new_connectivity[i][3]), NULL, NULL) != 1 )  
-            exit(EXIT_FAILURE);
+            die(EXIT_MESH_MMG);
         for(std::size_t j = 0; j < NODES_PER_ELEM; ++j)
             new_connectivity[i][j] -= 1;
     }
@@ -2429,7 +2421,7 @@ void optimize_mesh(const Param &param, Variables &var, int bad_quality,
     //   c) segments recovering
     for (int i = 0; i < var.nseg; ++i) {
         if ( MMG3D_Get_triangle(mmgMesh, &(new_segment[i][0]), &(new_segment[i][1]), &(new_segment[i][2]),&(new_segflag.data()[i]), NULL) != 1 )
-            exit(EXIT_FAILURE);
+            die(EXIT_MESH_MMG);
         for(int j = 0; j < NODES_PER_FACET; ++j)
             new_segment[i][j] -= 1;
     }     
@@ -2531,7 +2523,7 @@ void optimize_mesh_2d(const Param &param, Variables &var, int bad_quality,
         break;
     default:
         std::cerr << "Error: unknown remeshing_option: " << param.mesh.remeshing_option << '\n';
-        std::exit(1);
+        die(EXIT_CONFIG_VALUE);
     }
 
     // --- STEP I: Initialization
@@ -2553,24 +2545,24 @@ void optimize_mesh_2d(const Param &param, Variables &var, int bad_quality,
     // Manually set of the mesh 
     //  a) give the size of the mesh: vertices, triangles, quads(=0), edges
     if ( MMG2D_Set_meshSize(mmgMesh, old_nnode, old_nelem, 0, old_nseg) != 1 )
-        exit(EXIT_FAILURE);
+        die(EXIT_MESH_MMG);
     //   b) give the vertex coordinates. References are NULL but can be an integer array for boundary flag etc.
     if( MMG2D_Set_vertices(mmgMesh, qcoord, NULL) != 1)
-        exit(EXIT_FAILURE);
+        die(EXIT_MESH_MMG);
     //   c) give the connectivity. References are NULL but can be an integer array for boundary flag etc.
     for (int i = 0; i < old_nelem*NODES_PER_ELEM; ++i)
         ++qconn_from_1[i];
     if( MMG2D_Set_triangles(mmgMesh, qconn_from_1, NULL) != 1 )
-        exit(EXIT_FAILURE);
+        die(EXIT_MESH_MMG);
     //   d) give the segments (i.e., boundary edges)
     for (int i = 0; i < old_nseg*NODES_PER_FACET; ++i)
         ++qsegment_from_1[i];
     for (int i = 0; i < old_nseg; ++i)        
         if( MMG2D_Set_edge(mmgMesh, qsegment_from_1[i*NODES_PER_FACET], 
                 qsegment_from_1[i*NODES_PER_FACET+1], qsegflag[i], i+1) != 1)
-            exit(EXIT_FAILURE);
+            die(EXIT_MESH_MMG);
     // if( MMG2D_Set_edges(mmgMesh, qsegment_from_1, qsegflag) != 1 )
-    //     exit(EXIT_FAILURE);
+    //     exit(10);
 
     // 3) Build sol in MMG5 format
     //      Here a 'solution' is a nodal field that becomes
@@ -2579,72 +2571,72 @@ void optimize_mesh_2d(const Param &param, Variables &var, int bad_quality,
     //
     //   a) give info for the sol structure
     if( MMG2D_Set_solSize(mmgMesh, mmgSol, MMG5_Vertex, old_nnode, MMG5_Scalar) != 1 )
-        exit(EXIT_FAILURE);
+        die(EXIT_MESH_MMG);
     //   b) give solutions values and positions
     compute_metric_field(var, *var.ntmp, *var.etmp);
     //      i) If sol array is available:
     if( MMG2D_Set_scalarSols(mmgSol, (*var.ntmp).data()) != 1 )
-        exit(EXIT_FAILURE);
+        die(EXIT_MESH_MMG);
     //      ii) Otherwise, set a value node by node:
     // for (int i = 0; i < var.nnode; ++i) {
     //     if( MMG2D_Set_scalarSol(mmgSol, 0.5, i+1) != 1 )
-    //         exit(EXIT_FAILURE);
+    //         exit(10);
     // }
     if ( MMG2D_Set_iparameter(mmgMesh,mmgSol,MMG2D_IPARAM_optim, 0) != 1 )
-    exit(EXIT_FAILURE);
+    die(EXIT_MESH_MMG);
 
     // 4) (not mandatory): check if the number of given entities match with mesh size
-    if( MMG2D_Chk_meshData(mmgMesh, mmgSol) != 1 ) exit(EXIT_FAILURE);
+    if( MMG2D_Chk_meshData(mmgMesh, mmgSol) != 1 ) die(EXIT_MESH_MMG);
 
     //--- STEP  II: Remesh function
     /* debug mode ON (default value = OFF) */
     if ( MMG2D_Set_iparameter(mmgMesh,mmgSol,MMG2D_IPARAM_debug, param.mesh.mmg_debug) != 1 )
-    exit(EXIT_FAILURE);
+    die(EXIT_MESH_MMG);
 
     if ( MMG2D_Set_iparameter(mmgMesh,mmgSol,MMG2D_IPARAM_verbose, param.mesh.mmg_verbose) != 1 )
-    exit(EXIT_FAILURE);
+    die(EXIT_MESH_MMG);
 
     // if ( MMG2D_Set_iparameter(mmgMesh,mmgSol,MMG2D_IPARAM_iso, 1) != 1 )
-    // exit(EXIT_FAILURE);
+    // exit(10);
  
     /* maximal memory size (default value = 50/100*ram) */
     //if ( MMG2D_Set_iparameter(mmgMesh,mmgSol,MMG2D_IPARAM_mem, 600) != 1 )
-    //exit(EXIT_FAILURE);
+    //exit(10);
 
     /* Maximal mesh size (default FLT_MAX)*/
     if ( MMG2D_Set_dparameter(mmgMesh,mmgSol,MMG2D_DPARAM_hmax, param.mesh.mmg_hmax_factor*param.mesh.resolution) != 1 )
-    exit(EXIT_FAILURE);
+    die(EXIT_MESH_MMG);
 
     /* Minimal mesh size (default 0)*/
     if ( MMG2D_Set_dparameter(mmgMesh,mmgSol,MMG2D_DPARAM_hmin, param.mesh.mmg_hmin_factor*param.mesh.resolution) != 1 )
-    exit(EXIT_FAILURE);
+    die(EXIT_MESH_MMG);
 
     /* Global hausdorff value (default value = 0.01) applied on the whole boundary */
     if ( MMG2D_Set_dparameter(mmgMesh,mmgSol,MMG2D_DPARAM_hausd, param.mesh.mmg_hausd_factor*param.mesh.resolution) != 1 )
-    exit(EXIT_FAILURE);
+    die(EXIT_MESH_MMG);
 
     // /* Gradation control*/
     // if ( MMG2D_Set_dparameter(mmgMesh,mmgSol,MMG2D_DPARAM_hgrad, 3.0) != 1 )
-    // exit(EXIT_FAILURE);
+    // exit(10);
 
     // /* Gradation requirement */
     // if ( MMG2D_Set_dparameter(mmgMesh,mmgSol,MMG2D_DPARAM_hgradreq, 3.0) != 1 )
-    // exit(EXIT_FAILURE);
+    // exit(10);
 
     const int ier = MMG2D_mmg2dlib(mmgMesh, mmgSol);
     if ( ier == MMG5_STRONGFAILURE ) {
         fprintf(stdout,"BAD ENDING OF MMG3DLIB: UNABLE TO SAVE MESH\n");
-        exit(EXIT_FAILURE);
+        die(EXIT_MESH_MMG);
     } else if ( ier == MMG5_LOWFAILURE ) {
         fprintf(stdout,"BAD ENDING OF MMG3DLIB\n");
-        exit(EXIT_FAILURE);
+        die(EXIT_MESH_MMG);
     }    
 
     //--- STEP III: Get results
     // 1) Preparations
     //   a) get the size of the mesh: vertices, tetra, triangles, edges */
     if ( MMG2D_Get_meshSize(mmgMesh, &(var.nnode), &(var.nelem), NULL, &(var.nseg)) !=1 )
-        exit(EXIT_FAILURE);
+        die(EXIT_MESH_MMG);
     std::cerr << "Updated mesh size\n";
     std::cerr << "New number of vertices:" << var.nnode << std::endl;
     std::cerr << "New number of elements:" << var.nelem << std::endl;
@@ -2661,14 +2653,14 @@ void optimize_mesh_2d(const Param &param, Variables &var, int bad_quality,
     //   a) Vertexes recovering
     for (int i = 0; i < var.nnode; ++i) {
         if ( MMG2D_Get_vertex(mmgMesh, &(new_coord[i][0]), &(new_coord[i][1]), NULL, NULL, NULL) != 1 )
-            exit(EXIT_FAILURE);
+            die(EXIT_MESH_MMG);
     }
     std::cerr << "New coordinates populated\n";
 
     //   b) Triangles recovering
     for (int i = 0; i < var.nelem; ++i) {
         if ( MMG2D_Get_triangle(mmgMesh, &(new_connectivity[i][0]), &(new_connectivity[i][1]), &(new_connectivity[i][2]), NULL, NULL) != 1 )  
-            exit(EXIT_FAILURE);
+            die(EXIT_MESH_MMG);
         for(std::size_t j = 0; j < NODES_PER_ELEM; ++j)
             new_connectivity[i][j] -= 1;
     }
@@ -2677,7 +2669,7 @@ void optimize_mesh_2d(const Param &param, Variables &var, int bad_quality,
     //   c) segments recovering
     for (int i = 0; i < var.nseg; ++i) {
         if ( MMG2D_Get_edge(mmgMesh, &(new_segment[i][0]), &(new_segment[i][1]), &(new_segflag.data()[i]), NULL, NULL) != 1 )
-            exit(EXIT_FAILURE);
+            die(EXIT_MESH_MMG);
         for(std::size_t j = 0; j < NODES_PER_FACET; ++j)
             new_segment[i][j] -= 1;
     }
@@ -2972,7 +2964,7 @@ void remesh(const Param &param, Variables &var, int bad_quality)
                     old_segment, old_segflag);
         } else {
             std::cerr << "Error: unknown meshing_elem_shape: " << param.mesh.meshing_elem_shape << '\n';
-            std::exit(1);
+            die(EXIT_CONFIG_VALUE);
         }
 #else  // if 2d
         if (param.mesh.meshing_elem_shape == 0) {
@@ -2991,7 +2983,7 @@ void remesh(const Param &param, Variables &var, int bad_quality)
                 old_segment, old_segflag);
         } else {
             std::cerr << "Error: unknown meshing_elem_shape: " << param.mesh.meshing_elem_shape << '\n';
-            std::exit(1);
+            die(EXIT_CONFIG_VALUE);
         }        
 #endif
         // Drain all async GPU work before freeing/reallocating temporary arrays.

--- a/remeshing.cxx
+++ b/remeshing.cxx
@@ -2181,8 +2181,10 @@ void compute_metric_field(const Variables &var, double_vec &metric, double_vec &
 
     #pragma omp parallel for default(none) shared(var, metric, etmp)
     for (int n = 0; n < var.nnode; n++) {
-        for (auto e = (*var.support)[n].begin(); e < (*var.support)[n].end(); ++e)
-            metric[n] += etmp[*e];
+        const int npatch = var.support.size(n);
+        const int* patch = var.support.patch(n);
+        for (int i=0; i<npatch; ++i)
+            metric[n] += etmp[patch[i]];
         metric[n] *= (*var.init_elem_size_n)[n] / (*var.volume_n)[n];
     }
 }
@@ -2738,8 +2740,10 @@ void initialize_elem_size_n(const Variables &var, double_vec &init_elem_size_n)
 #endif
     #pragma acc parallel loop gang vector async
     for (int n = 0; n < var.nnode; n++) {
-        for (auto e = (*var.support)[n].begin(); e < (*var.support)[n].end(); ++e)
-            init_elem_size_n[n] += (*var.etmp)[*e];
+        const int npatch = var.support.size(n);
+        const int* patch = var.support.patch(n);
+        for (int i=0; i<npatch; ++i)
+            init_elem_size_n[n] += (*var.etmp)[patch[i]];
         init_elem_size_n[n] /= (*var.volume_n)[n];
     }
 }
@@ -3030,9 +3034,6 @@ void remesh(const Param &param, Variables &var, int bad_quality)
             barycentric_node_interpolation(param, var, bary, old_coord, old_connectivity);
         }
 
-        delete var.support;
-        delete var.support_arr;
-        delete var.support_idx;
         create_support(var);
         // delete var.neighbor;
         // delete var.contact;
@@ -3070,11 +3071,6 @@ void remesh(const Param &param, Variables &var, int bad_quality)
     create_top_elems(var);
 
     update_surface_info(var, var.surfinfo);
-
-    /* // moved before remap_markers()
-     * delete var.support;
-     * create_support(var);
-     */
 
     {
         SurfaceTopo topo_new;

--- a/remeshing.cxx
+++ b/remeshing.cxx
@@ -1955,7 +1955,11 @@ void new_uniformed_regular_mesh(const Param &param, Variables &var,
                             break;
                         }
 
-                        int ind_x0=-1, ind_x1, ind_x2, ind_y0=-1, ind_y1, ind_y2;
+                        // Grid indices of the 3-point stencil bracketing p0 and p1. All -1
+                        // until a search below finds the first grid coordinate above its
+                        // target; a target at or above the top of the grid never matches,
+                        // and the stencil is then the last three points.
+                        int ind_x0=-1, ind_x1=-1, ind_x2=-1, ind_y0=-1, ind_y1=-1, ind_y2=-1;
                         double p0 = (*var.coord)[ind][n0];
                         double p1 = (*var.coord)[ind][n1];
 
@@ -1968,7 +1972,9 @@ void new_uniformed_regular_mesh(const Param &param, Variables &var,
                                 break;
                             }
                         }
-                        if (ind_x2 > nxyz[n0] - 1) {
+                        // ind_x2 < 0 is the no-match case; it takes the same last-three
+                        // stencil as a match whose upper point ran off the end.
+                        if (ind_x2 < 0 || ind_x2 > nxyz[n0] - 1) {
                             ind_x2 = nxyz[n0] - 1;
                             ind_x1 = nxyz[n0] - 2;
                             ind_x0 = nxyz[n0] - 3;
@@ -1992,7 +1998,7 @@ void new_uniformed_regular_mesh(const Param &param, Variables &var,
                                 break;
                             }
                         }
-                        if (ind_y2 > nxyz[n1] - 1) {
+                        if (ind_y2 < 0 || ind_y2 > nxyz[n1] - 1) {
                             ind_y2 = nxyz[n1] - 1;
                             ind_y1 = nxyz[n1] - 2;
                             ind_y0 = nxyz[n1] - 3;

--- a/rheology.cxx
+++ b/rheology.cxx
@@ -684,34 +684,53 @@ void update_stress(const Param& param, Variables& var, tensor_t& stress,
     nvtxRangePush(__FUNCTION__);
 #endif
 
+    // Loop-invariant, so the per-element gathers they gate are decided once.
+    const bool has_hydraulic_diffusion = param.control.has_hydraulic_diffusion;
+    // Only the two rate-and-state branches call compute_slip_rate*, which is the
+    // sole consumer of the centroid velocity.
+    const bool needs_slip_rate = (param.mat.rheol_type == MatProps::rh_ep_rsf)
+                              || (param.mat.rheol_type == MatProps::rh_evp_rsf);
+
 #ifndef ACC
-    #pragma omp parallel for default(none) shared(param, var, ppressure, dppressure, \
+    #pragma omp parallel for default(none) shared(param, var, dppressure, \
         vel, stress, stressyy, dpressure, viscosity, strain, plstrain, delta_plstrain, \
-        strain_rate, dyn_fric_coeff, state_variable)
+        strain_rate, dyn_fric_coeff, state_variable) \
+        firstprivate(has_hydraulic_diffusion, needs_slip_rate)
 #endif
     #pragma acc parallel loop gang vector async // TODO: ACC: CPU and GPU results are differet because of using 3x3 in elasto_plastic
     for (int e = 0; e < var.nelem; e++) {
         ConstConnAccessor conn = (*var.connectivity)[e];
-        double pp_element = 0.0;
-        double dpp_element = 0.0;
 
-        const array_t& vel = *var.vel;
-        double vx_element = 0.0, vy_element = 0.0, vz_element = 0.0;
+        // Centroid interpolations, each gated on the branch that reads it: ungated they cost
+        // 2 + NDIMS nodal gathers per element per step in every run. The `ppressure` LEVEL
+        // is not interpolated at all; restore it here if a rheology comes to need it.
+        double dpp = 0.0;
+        if (has_hydraulic_diffusion) {
+            #pragma acc loop seq
+            for (int j = 0; j < NODES_PER_ELEM; ++j)
+                dpp += dppressure[conn[j]] / double(NODES_PER_ELEM);
+            // Biot-weighted pore-pressure INCREMENT, not a rate: update_pore_pressure()
+            // folded dt in, and stores dppressure with the sign OPPOSITE to its change
+            // to ppressure. elastic_effective() adds this to the diagonal components.
+            dpp *= var.mat->alpha_biot(e);
+        }
 
-        #pragma acc loop seq
-        for (int j = 0; j < NODES_PER_ELEM; ++j) {
+        // No vz in 2D: compute_slip_rate2 takes the vertical component as its second
+        // argument, so vy carries it and a vz here would only ever be written.
+        double vx = 0.0, vy = 0.0;
 #ifdef THREED
-            pp_element += ppressure[conn[j]] / 4.0; // the centroid shape functions are 1/4 for each node in 3D
-            dpp_element += dppressure[conn[j]] / 4.0; // the centroid shape functions are 1/4 for each node in 3D
-            vx_element += vel[conn[j]][0] / 4.0; // the centroid shape functions are 1/4 for each node in 3D
-            vy_element += vel[conn[j]][1] / 4.0; // the centroid shape functions are 1/4 for each node in 3D
-            vz_element += vel[conn[j]][2] / 4.0; // the centroid shape functions are 1/4 for each node in 3D
-#else
-            pp_element += ppressure[conn[j]] / 3.0; // the centroid shape functions are 1/3 for each node in 2D
-            dpp_element += dppressure[conn[j]] / 3.0; // the centroid shape functions are 1/3 for each node in 2D
-            vx_element += vel[conn[j]][0] / 3.0; // the centroid shape functions are 1/3 for each node in 2D
-            vy_element += vel[conn[j]][1] / 3.0; // the centroid shape functions are 1/3 for each node in 2D
+        double vz = 0.0;
 #endif
+        if (needs_slip_rate) {
+            const array_t& vel = *var.vel;
+            #pragma acc loop seq
+            for (int j = 0; j < NODES_PER_ELEM; ++j) {
+                vx += vel[conn[j]][0] / double(NODES_PER_ELEM);
+                vy += vel[conn[j]][1] / double(NODES_PER_ELEM);
+#ifdef THREED
+                vz += vel[conn[j]][2] / double(NODES_PER_ELEM);
+#endif
+            }
         }
 
         // stress, strain and strain_rate of this element
@@ -720,17 +739,6 @@ void update_stress(const Param& param, Variables& var, tensor_t& stress,
         TensorAccessor es = strain[e];
         TensorAccessor edot = strain_rate[e];
         double old_s = trace(s);
-
-        // Calculate effective pore pressure using Biot's coefficient
-        double alpha_b = var.mat->alpha_biot(e); // Biot coefficient
-        double pp = pp_element;        // Use element-level interpolated pore pressure
-        double dpp = dpp_element;        // Use element-level interpolated pore pressure rate
-
-        double vx = vx_element;        // Use element-level interpolated velocity in x direction
-        double vy = vy_element;        // Use element-level interpolated velocity in y direction
-#ifdef THREED
-        double vz = vz_element;        // Use element-level interpolated velocity in z direction
-#endif
 
         // // Calculate the center of the element
         // const int *conn = (*var.connectivity)[e];
@@ -747,11 +755,6 @@ void update_stress(const Param& param, Variables& var, tensor_t& stress,
         // int_vec &a = (*var.elemmarkers)[e];
         // int material = std::distance(a.begin(), std::max_element(a.begin(), a.end()));
         
-        if (param.control.has_hydraulic_diffusion) {
-            pp = alpha_b * pp; // Apply Biot coefficient to pore pressure
-            dpp = alpha_b * dpp; // Apply Biot coefficient to pore pressure rate
-        }
-
         // anti-mesh locking correction on strain rate
         if(1){
             double div = trace(edot);
@@ -789,7 +792,7 @@ void update_stress(const Param& param, Variables& var, tensor_t& stress,
             {
                 double bulkm = var.mat->bulkm(e);
                 double shearm = var.mat->shearm(e);
-                if (param.control.has_hydraulic_diffusion)
+                if (has_hydraulic_diffusion)
                 {
                     elastic_effective(bulkm, shearm, de, s, dpp);
                 }
@@ -828,12 +831,12 @@ void update_stress(const Param& param, Variables& var, tensor_t& stress,
                 if (var.mat->is_plane_strain) {
                     elasto_plastic2d(bulkm, shearm, amc, anphi, anpsi, hardn, ten_max,
                                      de, depls, s, syy, failure_mode, 
-                                     param.control.has_hydraulic_diffusion, dpp);
+                                     has_hydraulic_diffusion, dpp);
                 }
                 else {
                     elasto_plastic(bulkm, shearm, amc, anphi, anpsi, hardn, ten_max,
                                    de, depls, s, failure_mode, 
-                                   param.control.has_hydraulic_diffusion, dpp);
+                                   has_hydraulic_diffusion, dpp);
                 }
                 plstrain[e] += depls;
                 delta_plstrain[e] = depls;
@@ -865,12 +868,12 @@ void update_stress(const Param& param, Variables& var, tensor_t& stress,
                     spyy = syy;
                     elasto_plastic2d(bulkm, shearm, amc, anphi, anpsi, hardn, ten_max,
                                      de, depls, sp, spyy, failure_mode, 
-                                     param.control.has_hydraulic_diffusion, dpp);
+                                     has_hydraulic_diffusion, dpp);
                 }
                 else {
                     elasto_plastic(bulkm, shearm, amc, anphi, anpsi, hardn, ten_max,
                                    de, depls, sp, failure_mode, 
-                                   param.control.has_hydraulic_diffusion, dpp);
+                                   has_hydraulic_diffusion, dpp);
                 }
                 double spII = second_invariant2(sp);
 
@@ -912,12 +915,12 @@ void update_stress(const Param& param, Variables& var, tensor_t& stress,
                 if (var.mat->is_plane_strain) {
                     elasto_plastic2d(bulkm, shearm, amc, anphi, anpsi, hardn, ten_max,
                                      de, depls, s, syy, failure_mode, 
-                                     param.control.has_hydraulic_diffusion, dpp);
+                                     has_hydraulic_diffusion, dpp);
                 }
                 else {
                     elasto_plastic(bulkm, shearm, amc, anphi, anpsi, hardn, ten_max,
                                    de, depls, s, failure_mode, 
-                                   param.control.has_hydraulic_diffusion, dpp);
+                                   has_hydraulic_diffusion, dpp);
                 }
                 plstrain[e] += depls;
                 delta_plstrain[e] = depls;
@@ -960,12 +963,12 @@ void update_stress(const Param& param, Variables& var, tensor_t& stress,
                     spyy = syy;
                     elasto_plastic2d(bulkm, shearm, amc, anphi, anpsi, hardn, ten_max,
                                      de, depls, sp, spyy, failure_mode, 
-                                     param.control.has_hydraulic_diffusion, dpp);
+                                     has_hydraulic_diffusion, dpp);
                 }
                 else {
                     elasto_plastic(bulkm, shearm, amc, anphi, anpsi, hardn, ten_max,
                                    de, depls, sp, failure_mode, 
-                                   param.control.has_hydraulic_diffusion, dpp);
+                                   has_hydraulic_diffusion, dpp);
                 }
                 double spII = second_invariant2(sp);
 

--- a/rheology.cxx
+++ b/rheology.cxx
@@ -1,6 +1,7 @@
 #include <cmath>
 #include <iostream>
 
+#include "3x3-C/dsyevc3.h"
 #include "3x3-C/dsyevh3.h"
 
 #include "constants.hpp"
@@ -9,64 +10,77 @@
 #include "rheology.hpp"
 #include "utils.hpp"
 
+#ifdef THREED
+// Half-width of the undecided band around the yield surface, relative to
+// (|p0| + anphi*|p2| + |amc|). Covers dsyevc3's 6.6e-4 error relative to max|lambda|:
+// anphi >= 1, so band >= 1e-2*max|lambda|; worst measured error/band 4e-2 over 2.6e7 tensors.
+// Only the 3D yield test pre-filters, so 2D has no use for it.
+const double YIELD_PREFILTER_MARGIN = 1e-2;
+#endif
+
+// Order p ascending, applying the same permutation to the columns of v when given.
+// One ordering rule for both entry points; v == nullptr is the values-only case.
+#pragma acc routine seq
+static void sort_principal3(double p[3], double v[3][3])
+{
+    // Three compare-swaps: the (0,1),(1,2),(0,1) network sorts three elements.
+    const int pairs[3][2] = {{0,1},{1,2},{0,1}};
+    #pragma acc loop seq
+    for (int k=0; k<3; ++k) {
+        const int i = pairs[k][0], j = pairs[k][1];
+        if (p[i] > p[j]) {
+            const double tmp = p[i];
+            p[i] = p[j];
+            p[j] = tmp;
+            if (v) {
+                #pragma acc loop seq
+                for (int r=0; r<3; ++r) {
+                    const double b = v[r][i];
+                    v[r][i] = v[r][j];
+                    v[r][j] = b;
+                }
+            }
+        }
+    }
+}
+
+// Unflatten {XX, YY, ZZ, XY, XZ, YZ} into the upper triangle of a 3x3.
 #pragma acc routine seq
 template <typename T>
-static void principal_stresses3(T s, double p[3], double v[3][3])
+static void unflatten_stress3(T s, double a[3][3])
 {
-    /* s is a flattened stress vector, with the components {XX, YY, ZZ, XY, XZ, YZ}.
-     * Returns the eigenvalues p and eignvectors v.
-     * The eigenvalues are ordered such that p[0] <= p[1] <= p[2].
-     *  - Maximum shear stress direction 'shear_dir'.
-     */
-
-    // unflatten s to a 3x3 tensor, only the upper part is needed.
-    double a[3][3];
     a[0][0] = s[0];
     a[1][1] = s[1];
     a[2][2] = s[2];
     a[0][1] = s[3];
     a[0][2] = s[4];
     a[1][2] = s[5];
+}
 
+/* Eigenvalues ONLY, ascending, for the yield test in elasto_plastic(). dsyevc3 (Cardano)
+ * is 4.8x cheaper (25.1 vs 121.1 ns/call) but inaccurate near degeneracy, so a decision
+ * near the surface is undecided -- see YIELD_PREFILTER_MARGIN. */
+#pragma acc routine seq
+template <typename T>
+static void principal_values3(T s, double p[3])
+{
+    double a[3][3];
+    unflatten_stress3(s, a);
+    dsyevc3(a, p);
+    sort_principal3(p, nullptr);
+}
+
+/* Eigenvalues AND eigenvectors, p ascending, v holding eigenvectors as columns.
+ * Vendored dsyevh3, reached only on the branch that needs vectors.
+ */
+#pragma acc routine seq
+template <typename T>
+static void principal_stresses3(T s, double p[3], double v[3][3])
+{
+    double a[3][3];
+    unflatten_stress3(s, a);
     dsyevh3(a, v, p);
-
-    // reorder p and v
-    if (p[0] > p[1]) {
-        double tmp, b[3];
-        tmp = p[0];
-        p[0] = p[1];
-        p[1] = tmp;
-        for (int i=0; i<3; ++i)
-            b[i] = v[i][0];
-        for (int i=0; i<3; ++i)
-            v[i][0] = v[i][1];
-        for (int i=0; i<3; ++i)
-            v[i][1] = b[i];
-    }
-    if (p[1] > p[2]) {
-        double tmp, b[3];
-        tmp = p[1];
-        p[1] = p[2];
-        p[2] = tmp;
-        for (int i=0; i<3; ++i)
-            b[i] = v[i][1];
-        for (int i=0; i<3; ++i)
-            v[i][1] = v[i][2];
-        for (int i=0; i<3; ++i)
-            v[i][2] = b[i];
-    }
-    if (p[0] > p[1]) {
-        double tmp, b[3];
-        tmp = p[0];
-        p[0] = p[1];
-        p[1] = tmp;
-        for (int i=0; i<3; ++i)
-            b[i] = v[i][0];
-        for (int i=0; i<3; ++i)
-            v[i][0] = v[i][1];
-        for (int i=0; i<3; ++i)
-            v[i][1] = b[i];
-    }
+    sort_principal3(p, v);
 }
 
 #pragma acc routine seq
@@ -333,6 +347,19 @@ static void elasto_plastic(double bulkm, double shearm,
 #ifdef THREED
     // eigenvectors
     double v[3][3];
+
+    // Eigenvalue-only PRE-FILTER: v is needed only to rotate a CORRECTED stress back, and
+    // only 0.170% of elements yield, so the eigenvectors are almost never needed.
+    // One-sided -- anything within the band falls through to the accurate solver.
+    {
+        double pf[3];
+        principal_values3(s, pf);
+        const double band = YIELD_PREFILTER_MARGIN
+            * (std::fabs(pf[0]) + anphi * std::fabs(pf[2]) + std::fabs(amc));
+        if (pf[0] - pf[2] * anphi + amc > band && pf[2] - ten_max < -band)
+            return;   // no failure, and not close enough to it to need checking
+    }
+
     principal_stresses3(s, p, v);
 #else
     // In 2D, we only construct the eigenvectors from

--- a/runtime_info.cxx
+++ b/runtime_info.cxx
@@ -14,6 +14,10 @@
 #ifdef _OPENMP
 #include <omp.h>
 #endif
+#ifdef __APPLE__
+#include <sys/sysctl.h>
+#include <sys/types.h>
+#endif
 
 namespace {
 
@@ -54,6 +58,18 @@ bool env_forces_device(const char* env, acc_device_t& device)
 
 std::string read_cpu_model()
 {
+#ifdef __APPLE__
+    // No /proc on macOS; the brand string lives in sysctl.
+    std::size_t len = 0;
+    if (sysctlbyname("machdep.cpu.brand_string", NULL, &len, NULL, 0) != 0 || len == 0)
+        return "unknown";
+    std::string model(len, '\0');
+    if (sysctlbyname("machdep.cpu.brand_string", &model[0], &len, NULL, 0) != 0)
+        return "unknown";
+    // len counts the trailing NUL, which does not belong in a std::string.
+    model.resize(len > 0 ? len - 1 : 0);
+    return model.empty() ? "unknown" : model;
+#else
     std::ifstream cpuinfo("/proc/cpuinfo");
     if (!cpuinfo) return "unknown";
 
@@ -69,6 +85,7 @@ std::string read_cpu_model()
         if (!model.empty()) return model;
     }
     return "unknown";
+#endif
 }
 
 } // namespace

--- a/runtime_info.cxx
+++ b/runtime_info.cxx
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <cctype>
+#include <cstdio>
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
@@ -54,6 +55,18 @@ bool env_forces_device(const char* env, acc_device_t& device)
     device = parse_openacc_device_env(env);
     return (device != acc_device_default);
 }
+
+bool using_offload_device()
+{
+    return (acc_get_device_type() == acc_device_nvidia &&
+            acc_get_num_devices(acc_device_nvidia) > 0);
+}
+
+const char* env_or_unset(const char* name)
+{
+    const char* v = std::getenv(name);
+    return v ? v : "(unset)";
+}
 #endif
 
 std::string read_cpu_model()
@@ -90,11 +103,11 @@ std::string read_cpu_model()
 
 } // namespace
 
-void report_cpu_runtime_status()
+void report_host_runtime_status()
 {
     const std::string cpu_model = read_cpu_model();
     const unsigned int hw_threads = std::thread::hardware_concurrency();
-    std::cout << "[Runtime][CPU] model=" << cpu_model
+    std::cout << "[Runtime][Host] name=" << cpu_model
               << ", hw_threads="
               << (hw_threads ? std::to_string(hw_threads) : "unknown");
 #ifdef _OPENMP
@@ -107,23 +120,19 @@ void report_cpu_runtime_status()
     std::cout << '\n';
 }
 
-void report_openacc_runtime_status()
+void init_offload_device()
 {
 #ifdef ACC
-    const char* env_acc_device_type = std::getenv("ACC_DEVICE_TYPE");
-    const char* env_nv_acc_device_type = std::getenv("NVCOMPILER_ACC_DEVICE_TYPE");
-    const int n_nvidia = acc_get_num_devices(acc_device_nvidia);
-    const int n_host = acc_get_num_devices(acc_device_host);
-
     acc_device_t forced = acc_device_default;
-    const bool forced_by_env = env_forces_device(env_acc_device_type, forced) ||
-                               env_forces_device(env_nv_acc_device_type, forced);
+    const bool forced_by_env =
+        env_forces_device(std::getenv("ACC_DEVICE_TYPE"), forced) ||
+        env_forces_device(std::getenv("NVCOMPILER_ACC_DEVICE_TYPE"), forced);
 
     if (forced_by_env) {
         acc_set_device_type(forced);
         acc_init(forced);
     }
-    else if (n_nvidia > 0) {
+    else if (acc_get_num_devices(acc_device_nvidia) > 0) {
         acc_set_device_type(acc_device_nvidia);
         acc_init(acc_device_nvidia);
     }
@@ -131,55 +140,63 @@ void report_openacc_runtime_status()
         acc_set_device_type(acc_device_host);
         acc_init(acc_device_host);
     }
+#endif
+}
 
+void report_device_runtime_status()
+{
+#ifndef ACC
+    std::cout << "[Runtime][Device] build=non-ACC, kernel=CPU\n";
+#else
     const acc_device_t active_type = acc_get_device_type();
     const int active_dev = acc_get_device_num(active_type);
-    const bool using_gpu = (active_type == acc_device_nvidia && n_nvidia > 0);
+    const bool using_device = using_offload_device();
 
-    std::cout << "[Runtime][OpenACC] build=ACC"
-              << ", env.ACC_DEVICE_TYPE="
-              << (env_acc_device_type ? env_acc_device_type : "(unset)")
+    // The selection picture: the steering environment (these two can force the
+    // device type), what was visible, and what was chosen.
+    std::cout << "[Runtime][Device] build=ACC"
+              << ", env.ACC_DEVICE_TYPE=" << env_or_unset("ACC_DEVICE_TYPE")
               << ", env.NVCOMPILER_ACC_DEVICE_TYPE="
-              << (env_nv_acc_device_type ? env_nv_acc_device_type : "(unset)")
-              << ", num_nvidia=" << n_nvidia
-              << ", num_host=" << n_host
+              << env_or_unset("NVCOMPILER_ACC_DEVICE_TYPE");
+    // When set it renumbers devices from 0, so num_nvidia and active_dev below
+    // count within the remapped set, not the physical machine.
+    const char* visible = std::getenv("CUDA_VISIBLE_DEVICES");
+    if (visible)
+        std::cout << ", env.CUDA_VISIBLE_DEVICES=" << visible;
+    std::cout << ", num_nvidia=" << acc_get_num_devices(acc_device_nvidia)
+              << ", num_host=" << acc_get_num_devices(acc_device_host)
               << ", active_type=" << openacc_device_name(active_type)
               << ", active_dev=" << active_dev
               << '\n';
 
-    const char* dev_name =
-        acc_get_property_string(active_dev, active_type, acc_property_name);
-    const char* dev_vendor =
-        acc_get_property_string(active_dev, active_type, acc_property_vendor);
-    const char* dev_driver =
-        acc_get_property_string(active_dev, active_type, acc_property_driver);
-    const size_t mem_total =
-        acc_get_property(active_dev, active_type, acc_property_memory);
-    const size_t mem_free =
-        acc_get_property(active_dev, active_type, acc_property_free_memory);
+    const char* name = acc_get_property_string(active_dev, active_type, acc_property_name);
+    const char* vendor = acc_get_property_string(active_dev, active_type, acc_property_vendor);
+    const char* driver = acc_get_property_string(active_dev, active_type, acc_property_driver);
+    const size_t mem_total = acc_get_property(active_dev, active_type, acc_property_memory);
+    // A snapshot, not a device property: whatever other processes hold on the device
+    // right now, before DES allocates anything. Not comparable across runs.
+    const size_t mem_free = acc_get_property(active_dev, active_type, acc_property_free_memory);
 
-    if (dev_name || dev_vendor || dev_driver || mem_total || mem_free) {
-        std::cout << "[Runtime][OpenACC] device"
-                  << " name=" << (dev_name ? dev_name : "(unknown)")
-                  << ", vendor=" << (dev_vendor ? dev_vendor : "(unknown)")
-                  << ", driver=" << (dev_driver ? dev_driver : "(unknown)");
+    if (name || vendor || driver || mem_total || mem_free) {
+        std::cout << "[Runtime][Device] name=" << (name ? name : "(unknown)")
+                  << ", vendor=" << (vendor ? vendor : "(unknown)")
+                  << ", driver=" << (driver ? driver : "(unknown)");
+        char mem[32];
         if (mem_total) {
-            const double gb = static_cast<double>(mem_total) /
-                              (1024.0 * 1024.0 * 1024.0);
-            std::cout << ", mem_total_gb=" << gb;
+            std::snprintf(mem, sizeof(mem), "%.1f",
+                          static_cast<double>(mem_total) / (1024.0 * 1024.0 * 1024.0));
+            std::cout << ", mem_total_gb=" << mem;
         }
         if (mem_free) {
-            const double gb = static_cast<double>(mem_free) /
-                              (1024.0 * 1024.0 * 1024.0);
-            std::cout << ", mem_free_gb=" << gb;
+            std::snprintf(mem, sizeof(mem), "%.1f",
+                          static_cast<double>(mem_free) / (1024.0 * 1024.0 * 1024.0));
+            std::cout << ", mem_free_at_start_gb=" << mem;
         }
         std::cout << '\n';
     }
 
-    std::cout << "[Runtime][OpenACC] status="
-              << (using_gpu ? "gpu-offload" : "cpu-fallback") << '\n';
-#else
-    std::cout << "[Runtime][OpenACC] build=non-ACC\n";
+    std::cout << "[Runtime][Device] kernel=" << (using_device ? "GPU" : "CPU")
+              << ", status=" << (using_device ? "gpu-offload" : "cpu-fallback") << '\n';
 #endif
 }
 

--- a/runtime_info.hpp
+++ b/runtime_info.hpp
@@ -3,8 +3,14 @@
 
 #include "parameters.hpp"
 
-void report_cpu_runtime_status();
-void report_openacc_runtime_status();
+// Selects and initializes the OpenACC device; a non-ACC build does nothing. Call it
+// exactly once and before any compute.
+void init_offload_device();
+void report_host_runtime_status();
+// Describes the device this run actually got -- not a property of the build: an
+// openacc=1 binary falls back to the host when no NVIDIA device is visible. Queries
+// the OpenACC runtime only, never selects, so it can be skipped or repeated freely.
+void report_device_runtime_status();
 void report_mesh_info(const Variables& var, const char* tag);
 
 #endif

--- a/tests.cxx
+++ b/tests.cxx
@@ -13,6 +13,9 @@ void test_barycentric_transformation(Variables &var)
 {
     Barycentric_transformation bary(*var.coord, *var.connectivity, *var.volume);
 
+    // drain bary's async ctor kernel before the host-side transform below
+    #pragma acc wait
+
     double p[NDIMS];
 
     // p is the mid point of element 1

--- a/utils.cxx
+++ b/utils.cxx
@@ -1,0 +1,35 @@
+#include <cstdlib>
+#include <iostream>
+
+#include "utils.hpp"
+
+namespace {
+
+const char* exit_category(int code)
+{
+    switch (code / 10) {
+    case 0: return "normal exit";
+    case 1: return "user input";
+    case 2: return "I/O";
+    case 3: return "unsupported in this build";
+    case 4: return "mesh generation";
+    case 5: return "runtime";
+    case 6: return "internal error";
+    default: return "unknown";
+    }
+}
+
+} // namespace
+
+void die(ExitCode code)
+{
+    std::cerr << "[DES exit " << int(code) << "] " << exit_category(code) << '\n';
+    std::exit(code);
+}
+
+void die(ExitCode code, const char* msg)
+{
+    std::cerr << "[DES exit " << int(code) << "] " << exit_category(code)
+              << ": " << msg << '\n';
+    std::exit(code);
+}

--- a/utils.hpp
+++ b/utils.hpp
@@ -14,6 +14,46 @@
 #include <time.h>
 #endif
 
+// Process exit codes: first digit the category, second the cause, so a bare status
+// says where to look -- 1x the user to fix, 2x the environment, 3x-6x ours. Keep in
+// step with DEVELOPING.md. Nothing above 99; the shell reserves 126+.
+enum ExitCode {
+    EXIT_OK                   =  0,
+
+    EXIT_CONFIG               = 10,  // generic config error
+    EXIT_CONFIG_VALUE         = 11,  // value out of range / unknown option
+    EXIT_CONFIG_DATA          = 12,  // malformed input data file (.poly, .exo)
+
+    EXIT_IO_OPEN              = 20,  // cannot open file
+    EXIT_IO_RW                = 21,  // read/write failed (incl. HDF5)
+    EXIT_IO_RESTART           = 22,  // restart/checkpoint mismatch
+
+    EXIT_UNSUPPORTED_DIM      = 30,  // not implemented for this NDIMS
+    EXIT_UNSUPPORTED_LIB      = 31,  // optional library not compiled in
+
+    EXIT_MESH_TETGEN          = 40,  // Triangle / TetGen
+    EXIT_MESH_MMG             = 41,  // MMG
+    EXIT_MESH_QUALITY         = 42,  // mesh quality / topology
+
+    EXIT_RUNTIME_NAN          = 50,  // NaN or non-finite state
+    EXIT_RUNTIME_LOOKUP       = 51,  // marker/geometry lookup failed
+    EXIT_RUNTIME_RESOURCE     = 52,  // resource exhausted
+
+    EXIT_INTERNAL_ASSERT      = 60,  // assertion / invariant violated
+    EXIT_INTERNAL_UNREACHABLE = 61   // unreachable branch
+};
+
+// Terminate with `code`, naming the category so the number never has to be looked up.
+// One-argument form where the site already printed its diagnostic. [[noreturn]] is what
+// keeps -Wreturn-type and -Wsometimes-uninitialized alive across the call sites.
+//
+// Defined in utils.cxx, not inline: this header also carries binary_search_index() with an
+// `acc routine seq`, and where device code calls that routine nvc++ walks the header's
+// statics and gives die() a device version too, which its std::cerr cannot support
+// (NVC++-W-1053). A declaration alone leaves nothing to promote.
+[[noreturn]] void die(ExitCode code);
+[[noreturn]] void die(ExitCode code, const char* msg);
+
 static void print(std::ostream& os, const double& x)
 {
   os << x;
@@ -346,7 +386,7 @@ static void check_nan(const Variables& var, const char* func_name = nullptr) {
         } else {
             std::cerr << "Error: " << is_nan << " NaN values found in the variables." << std::endl;
         }
-        std::exit(1);
+        die(EXIT_RUNTIME_NAN);
     }
 #ifdef NPROF
     nvtxRangePop();

--- a/utils.hpp
+++ b/utils.hpp
@@ -285,7 +285,7 @@ static void check_nan(const Variables& var, const char* func_name = nullptr) {
     nvtxRangePush(__FUNCTION__);
 #endif
 
-    #pragma acc serial
+    // Host scalar: the two loops below reduce into it and the host reads it.
     int is_nan = 0;
 
 #ifndef ACC


### PR DESCRIPTION
### Update 2026-08-19

- **OpenACC**: the barycentric constructor kernels stay `async`; the three constructor-internal waits move to the consumers (one wait in brc `prepare_interpolation` ahead of its host reads, one in the test helper). All nine construction sites audited — every host read, non-async device consumer, and destruction is behind a wait; the contract is documented on the class.
- **OpenMP**: two more `SurfaceTopo::build` pragmas move const scalars from `shared()` to `firstprivate()` — gcc 8 rejects predetermined-shared consts in `shared()`, gcc 9+ requires them under `default(none)`; `firstprivate` satisfies both.
- **New CI**: `omp-gcc-matrix.yml` — a g++ 8–15 compile matrix (in `gcc:N` containers) that hard-errors on version-dependent `default(none)` violations (it caught the fix above), plus a 1-thread vs 4-thread run of `2d-ep-irregular.cfg` compared with `compare.py` to flag race-sized divergence. Also runs locally under `act`.
- **Makefile**: `GPP1X` (the listing pragma variants) now defined from g++ 9, not 11 -- gcc 9/10 enforce the new `default(none)` const rule but were getting the gcc-8 pragma form; the matrix caught it on its first run.
- **CI hardening**: every workflow token scoped to least privilege (top-level `contents: read`); nvc-build additionally gets `pull-requests: read` (gh pr list, paths-filter) and `packages: read` (GHCR image pull -- its absence broke nvc build #227); the image-push job keeps its per-job `packages: write`.

### Update 2026-08-15

- **Dropped**: the commit writing `<modelname>.runtime` — run provenance moves to an issue.
- **Added** (commits 31–34): GPU parallelization of `update_pore_pressure`; `firstprivate` for gcc 8's OpenMP; a test-config restart tweak; and the console half of the provenance work as two commits — the CPU model read via sysctl on macOS (was `model=unknown`), and device selection separated from reporting: `init_offload_device()` selects exactly once, `report_device_runtime_status()` only queries, and the report adds `kernel=CPU|GPU`, `mem_free_at_start_gb`, and `env.CUDA_VISIBLE_DEVICES` when set. Log tags change: `[Runtime][CPU]` → `[Runtime][Host]`, `[Runtime][OpenACC]` → `[Runtime][Device]`.
- **Added** (commit 35): a no-op make is now fully silent — any output on a quiet tree means something happened.

The periodic catch-all for 2026-08:
build correctness, a set of OpenMP/OpenACC defects, four uninitialized-read fixes, run provenance, categorized exit codes, and a rheology/matprops performance series worth **1.55x in 2D and 2.17x in 3D**.

Every commit is behaviour-neutral. Bit-exact against master on every case run, including a 400 kyr production run of `examples/rifting-2d.cfg`.

## Contents — the original 30 commits, five groups (31–35 above)

**Build (1–5)**
- `INCS` listed only some headers, so editing a `.hpp` left the other objects on the old struct layout — plausible wrong numbers, not a link error.
- clang `opt=0` warns on unknown pragmas, which is what catches a `#pragma wait` typo.
- make accepts any `NAME=VALUE`, so `ndim=2` built 3D and reported success. Both Makefiles now reject a name they do not define.
- Submodule fetch shows progress on a non-tty and stops cloning full history (mmg 33 MB → 8.8 MB).
- `GPU_CC` names the compute capability instead of letting nvc++ infer it from the build host, and both GPU archives hang off a flag stamp — neither was rebuilt when its flags changed.

**Correctness (6–14)**
- Race on the pore-pressure diffusivity maximum: `std::max` on a shared scalar → `reduction(max:)`.
- Four OpenACC async kernels read by the host with no wait; one `#pragma wait` missing its `acc` prefix, so it never waited.
- Four loops with no `default(none)`; a `private()` clause spliced into a comment by a trailing backslash; an `acc serial` applied to a declaration.
- nvc++ drops `default(none)` for a whole region when a loop reaches a class member through the implicit `this`, so `SurfaceTopo::build` had no data-sharing checking on that toolchain.
- `correct_surface_marker`'s `elemmarkers` decrement was not atomic while the matching increment was.
- `apply_vbcs` dereferenced an uninitialized `edge` pointer, twice, in the code that sets every boundary velocity every step — and the table replacing it was still being filled *after* its first reader ran.
- Startup warning when a boundary pair meets on a node but shares no edge, which the kernel can only skip in silence.
- `new_uniformed_regular_mesh` read two stencil indices uninitialized, so stack contents chose which end of the grid to interpolate from.
- The hydraulic-diffusivity guard passed a material index to accessors taking an element index, so it described element 0.

**Validation and diagnostics (15–18)**
- `ref_pressure()` returned an uninitialized local for any option outside 0–2 — silently wrong stress. Rejected at startup instead.
- Categorized exit codes: two digits, 1x the user's to fix, 2x the environment, 3x–6x ours, printed with the category.
- `quality_check_step_interval` or `checkpoint_frame_interval` of 0 was an integer division by zero — SIGFPE, exit 136, no message naming the parameter.
- (dropped) Each run writes `<modelname>.runtime` with the build, host, thread count and, for an ACC build, the device actually selected. HDF5 frames carry the same as root-group attributes.

**Refactor and performance (19–23)**
- Both node-support graphs flattened to CSR; the gathers stop rediscovering each element's local node by linear search (~100 probes per node in 3D), and the surface graph stops leaking.
- Creep-law material terms hoisted out of `visc()`; per-element property means memoized against `elemmarkers`; centroid gathers gated on the branch that reads them; eigenvalue-only pre-filter ahead of the 3D yield test.

**Warning sweep (24–30)**
Sign compares, `//` line continuations, a 3D-only barycentric branch compiled into 2D builds (a real `-Warray-bounds` index), 3D-only assignments in 2D, a dead line counter, and a note that `initial_stress_state_1d_load` is unfinished. `-Wall` then moves into every build, ordered last so it lands on an already-clean tree.

## Performance

macOS arm64 (M3 Max), clang 21, `OMP_NUM_THREADS=3`, one run at a time with a cooldown and arm order rotated per rep. Metric is DES's own `Compute` timer, so remesh and I/O do not dilute it. Separate `make clean` build per arm; medians of 2 clean reps, spreads under 2%.

**2D — `examples/rifting-2d.cfg`, 2 materials**

| commit | Compute | vs prev |
|---|---|---|
| 01 first | 34.72 s | — |
| 19 flatten support graphs to CSR | 34.04 s | 1.014x |
| 20 hoist creep-law terms out of `visc()` | 30.24 s | **1.126x** |
| 21 memoize per-element property means | 22.46 s | **1.346x** |
| 22 gate the centroid gathers | 22.01 s | 1.021x |
| 23 eigenvalue-only yield pre-filter | 21.56 s | 1.021x |
| **30 tip** | **22.38 s** | **1.55x end to end** |

**3D — EVP, 7 materials**

| commit | Compute | vs prev |
|---|---|---|
| 01 first | 52.56 s | — |
| 19 flatten support graphs to CSR | 52.12 s | 1.009x |
| 20 hoist creep-law terms out of `visc()` | 39.68 s | **1.314x** |
| 21 memoize per-element property means | 34.99 s | **1.134x** |
| 22 gate the centroid gathers | 34.45 s | 1.016x |
| 23 eigenvalue-only yield pre-filter | 24.07 s | **1.431x** |
| **30 tip** | **24.19 s** | **2.17x end to end** |

The pre-filter is `#ifdef THREED`, so its ~1.0x in 2D is the expected result. Commits 19 and 22 are inside the noise band described below; 19 is labelled `refactor:` and neither claims an end-to-end number.

Two cautions for anyone repeating this:

- **The config needs more than one material.** On a single-material EVP case the whole branch measures 1.03x, because commits 20 and 21 both loop over `nmat` — with one material there is nothing to hoist and nothing to skip.
- **Below ~5%, code layout dominates.** Relinking one commit's identical object files in four permuted orders — same program, different placement — spans 3.4%. A 3% "regression" at the tip reproduced across two experiments and was false; only a permuted-link control broke it.

## Verification

Bit-exact against master, `OMP_NUM_THREADS=1`, at the last frame:

| case | | result |
|---|---|---|
| `test-3d-equ-tiny.cfg` | 3D, 400 steps, 2 remeshes | **BIT-EXACT** |
| `test-tiny-long.cfg` | 2D, 4000 steps | **BIT-EXACT** |
| `test-rect-tiny-long.cfg` | 2D, 1000 steps, 100 frames | **BIT-EXACT** |
| `test-model.cfg` | 2D, 1869 steps, remeshing | **BIT-EXACT** |
| `examples/rifting-2d.cfg` | 2D, **400 kyr**, 1,675,000 steps, 12 remeshes | **BIT-EXACT** at frames 0/10/20/30/40 |
| restart determinism | 3D, fresh 400 vs restart-from-2 | **BIT-EXACT** |

**All 30 commits build individually** (2D, `make clean` each), and the tip builds 2D, 3D and `opt=0` with zero first-party warnings beyond the four master already had.

Mechanism-level evidence where a passing run would not have been evidence: `[[noreturn]]` added/removed flips the `markerset.cxx` uninitialized warning; touching `3x3-C/dsyevc3.c` gave 0 rebuild steps before the `lib3x3` fix and 2 after; the flag stamp recompiles 4 of 4 objects on a flip and 0 when unchanged; the atomic fix emits 15 `ldadd` against 14.

The GPU half was verified separately on cotopaxi (nvc++ 25.7, A100 cc80): `openacc=1` builds in 2D/3D/hdf5 and `nprof=1`; branch-vs-master bit-exact on GPU; `compute-sanitizer memcheck` clean through both remeshes; the pre-existing CPU↔GPU divergence unchanged to every printed digit.

## Action required

1. **Exit status values changed.** Scripts testing for exit 1 need review — I/O → 21/22, NaN → 50, `.poly` parse → 12. `DEVELOPING.md` carries the table and a note that 10/11/12 previously meant something else.
2. **Unknown make variables now fail the build.** CI jobs, module files and scripts passing a renamed knob will error instead of being ignored silently.
3. `3x3-C/Makefile` is vendored and carries local changes here (+30/−5) for the flag stamp and the `GPU_CC` hook. Deliberate — it was the fix for a stale-archive defect — but worth a look.







