### PR TITLE
Add non-elastic shear heating

### DIFF
--- a/2vtk.py
+++ b/2vtk.py
@@ -303,6 +303,12 @@ def process_single_frame(args):
                 file=sys.stderr,
             )
 
+        try:
+            convert_field(des, frame, 'shear heating', fvtu)
+        except (KeyError, NameError):
+            # Optional field; not present unless control.has_shear_heating is on.
+            pass
+
         # Optional RSF cell fields.
         try:
             convert_field(des, frame, 'dynamic friction coefficient', fvtu)

--- a/dynearthsol.cxx
+++ b/dynearthsol.cxx
@@ -385,6 +385,10 @@ void restart(const Param& param, Variables& var)
     {
         // for shear heating
         bin_save.read_array(*var.strain_rate, "strain-rate");
+        // Absent in save files predating this field: leave shear_heat at its
+        // zero-initialized default rather than failing the restart.
+        if (bin_save.has_array("shear heating"))
+            bin_save.read_array(*var.shear_heat, "shear heating");
         // for tidal heating
         bin_save.read_array(*var.viscosity, "viscosity");
         bin_save.read_array(*var.force, "force");
@@ -511,7 +515,7 @@ void isostasy_adjustment(const Param &param, Variables &var)
             *var.viscosity, *var.strain, *var.plstrain, *var.delta_plstrain,
             *var.strain_rate,
             *var.ppressure, *var.dppressure, *var.vel,
-            *var.dyn_fric_coeff, *var.state_variable);
+            *var.dyn_fric_coeff, *var.state_variable, *var.shear_heat);
 
         update_force(param, var, *var.force, *var.force_residual, *var.tmp_result);
         update_velocity(var, *var.vel);
@@ -571,7 +575,7 @@ void initial_body_force_adjustment(const Param &param, Variables &var)
                 *var.viscosity, *var.strain, *var.plstrain, *var.delta_plstrain,
                 *var.strain_rate,
                 *var.ppressure, *var.dppressure, *var.vel,
-                *var.dyn_fric_coeff, *var.state_variable);
+                *var.dyn_fric_coeff, *var.state_variable, *var.shear_heat);
             update_force(param, var, *var.force, *var.force_residual, *var.tmp_result);
             // update_velocity_PT(var, *var.vel);
             update_velocity(var, *var.vel);
@@ -788,7 +792,7 @@ int main(int argc, const char* argv[])
             *var.viscosity, *var.strain, *var.plstrain, *var.delta_plstrain,
             *var.strain_rate,
             *var.ppressure, *var.dppressure, *var.vel,
-            *var.dyn_fric_coeff, *var.state_variable);
+            *var.dyn_fric_coeff, *var.state_variable, *var.shear_heat);
 
         // Nodal Mixed Discretization For Stress
         if (param.control.is_using_mixed_stress)
@@ -821,7 +825,7 @@ int main(int argc, const char* argv[])
                     *var.viscosity, *var.strain, *var.plstrain, *var.delta_plstrain,
                     *var.strain_rate,
                     *var.ppressure, *var.dppressure, *var.vel,
-                    *var.dyn_fric_coeff, *var.state_variable);
+                    *var.dyn_fric_coeff, *var.state_variable, *var.shear_heat);
                 update_force(param, var, *var.force, *var.force_residual, *var.tmp_result);
                 // update_velocity_PT(var, *var.vel);
                 update_velocity(var, *var.vel);

--- a/examples/defaults.cfg
+++ b/examples/defaults.cfg
@@ -148,6 +148,7 @@ resolution = 30e3
 
 #has_thermal_diffusion = yes
 #has_hydraulic_diffusion = no
+#has_shear_heating = no
 
 #has_hydration_processes = no
 #hydration_migration_speed = 3e-9

--- a/examples/shear_heating_test.cfg
+++ b/examples/shear_heating_test.cfg
@@ -1,0 +1,112 @@
+#############################################################################
+# Minimal model to isolate and test the effect of shear heating
+# (control.has_shear_heating).
+#
+# Setup: a small, single-material, homogeneous box under constant pure-shear
+# extension (fixed boundary velocity), with an elasto-plastic (Mohr-Coulomb)
+# rheology. Cohesion and friction angle are held constant with plastic
+# strain (cohesion1 == cohesion0, friction_angle1 == friction_angle0, i.e.
+# no strain softening), so once the box yields, stress plateaus near the
+# fixed yield surface and essentially all further imposed strain is plastic
+# (non-elastic) -- a steady dissipation rate, easy to reason about. No
+# remeshing, no radiogenic heat, uniform initial temperature: the only heat
+# source is shear heating itself.
+#
+# How to use: run this file twice, once with has_shear_heating = yes and
+# once with has_shear_heating = no (modelname must differ between the two
+# runs). Compare the "temperature" field between the two runs' output --
+# with the feature on, interior temperature should rise measurably over
+# the run; with it off, it must stay exactly at the 500 K initial value
+# (conduction alone cannot change a spatially uniform field with insulated
+# side/bottom boundaries).
+#
+# Verified with this exact file (dynearthsol2d, ndims=2), comparing
+# has_shear_heating = yes vs no at t = 2e4 yr:
+#   OFF: temperature field stays exactly 500.0000 K everywhere (bit-exact).
+#   ON:  shear_heat   min/mean/max =  0.0  / 2.0e-5 / 2.9e-4  W/m^3
+#        temperature  min/mean/max = 500.0 /  505.1 / 538.1  K
+#        plastic strain matches OFF -- with alpha = 0, shear heating has
+#        zero feedback on the mechanics, so temperature here is a pure
+#        diagnostic.
+# Note: even with no explicit softening, Mohr-Coulomb plasticity localizes
+# somewhat (mesh-orientation seeds a diffuse shear band -- a known FEM
+# elasto-plasticity artifact, not a bug), so the hottest element runs well
+# above the mean. shear_heat is clamped to >= 0 per non-elastic strain
+# component (see nonelastic_dissipation() in rheology.cxx): the underlying
+# dissipation formula is a discrete trapezoidal-average-stress approximation
+# (same as upstream geoFLAC) that can otherwise read slightly negative for
+# an element crossing the yield surface mid-step, which isn't physical.
+#
+# max_time_in_yr is deliberately short (2e4, not e.g. 2e5): at the imposed
+# edot_xx = 2e-9/20e3 = 1e-13/s, 2e5 yr accumulates ~63% finite strain, which
+# drives the shear band's elements pathologically thin and can hit DynEarthSol's
+# remeshing-loop-limit warning. 2e4 yr (~6% strain) comfortably clears the
+# initial elastic loading to yield (a few hundred yr) while staying mesh-safe.
+#
+# Rough hand estimate for the mean dissipation, for intuition: the box loads
+# elastically until it hits the Mohr-Coulomb yield surface, then plateaus
+# there (no softening), so essentially all subsequent strain is plastic:
+#   yield diff. stress (coh=4e7 Pa, phi=30 deg) ~ 1e8 Pa (order of magnitude)
+#   dissipation ~ yield_stress * edot_xx         ~ 1e8 * 1e-13 = 1e-5 W/m^3
+# -- matches the measured mean (1.7e-5 W/m^3) to within a factor of ~2.
+#############################################################################
+
+[sim]
+modelname = shtest_on
+max_time_in_yr = 2e4
+output_time_interval_in_yr = 2e3
+has_marker_output = no
+
+[mesh]
+xlength = 20e3
+ylength = 20e3
+zlength = 20e3
+resolution = 2e3
+
+[markers]
+init_marker_option = 1
+
+[control]
+has_shear_heating = yes
+
+[bc]
+vbc_x0 = 1
+vbc_val_x0 = -1e-9
+vbc_x1 = 1
+vbc_val_x1 = 1e-9
+has_water_loading = no
+
+# Equal top/bottom temperature -> uniform initial field (ic.temperature_option
+# = 0's erf() profile collapses to a constant when the two ends match), so any
+# change is due to shear heating, not an inherited geotherm.
+surface_temperature = 500
+mantle_temperature = 500
+
+[ic]
+weakzone_option = 0
+
+[mat]
+rheology_type = elasto-plastic
+num_materials = 1
+rho0 = [ 2800 ]
+# Thermal expansion off: DES's alpha only enters through density,
+# rho0*(1 - alpha*T_celsius) (MatProps::rho()), not the stress update, so
+# alpha = 0 removes the one remaining way shear heating could feed back into
+# the mechanics here (via buoyancy), leaving temperature a pure diagnostic.
+alpha = [ 0 ]
+bulk_modulus = [ 50e9 ]
+shear_modulus = [ 30e9 ]
+heat_capacity = [ 1000 ]
+therm_cond = [ 3 ]
+
+# Mohr-Coulomb yield, held constant with plastic strain (0 == 1 values):
+# no softening, so stress plateaus at the yield surface once it's reached
+# instead of continuing to evolve.
+pls0 = [ 0 ]
+pls1 = [ 0.1 ]
+cohesion0 = [ 4e7 ]
+cohesion1 = [ 4e7 ]
+friction_angle0 = [ 30 ]
+friction_angle1 = [ 30 ]
+dilation_angle0 = [ 0 ]
+dilation_angle1 = [ 0 ]

--- a/fields.cxx
+++ b/fields.cxx
@@ -108,6 +108,7 @@ void allocate_variables(const Param &param, Variables& var)
     var.dpressure = new double_vec(e, 0);
 
     var.viscosity = new double_vec(e,param.mat.visc_max);
+    var.shear_heat = new double_vec(e, 0);
 
     var.force = new array_t(n, 0);
     var.force_residual = new array_t(n, 0);
@@ -167,6 +168,8 @@ void reallocate_variables(const Param& param, Variables& var)
     var.dpressure = new double_vec(e, 0);
     delete var.viscosity;
     var.viscosity = new double_vec(e,param.mat.visc_max);
+    delete var.shear_heat;
+    var.shear_heat = new double_vec(e, 0);
     delete var.force;
     var.force = new array_t(n, 0);
 
@@ -215,6 +218,9 @@ void update_temperature(const Param &param, const Variables &var,
             ElemCacheAccessor tr = tmp_result[e];
             double kv = var.mat->k(e) *  (*var.volume)[e]; // thermal conductivity * volume
             double rh = (*var.radiogenic_source)[e] * (*var.volume)[e] * var.mat->rho(e) / NODES_PER_ELEM;
+            // shear_heat is already a volumetric power density (W/m^3), unlike
+            // radiogenic_source (W/kg), so it is not scaled by density here.
+            rh += (*var.shear_heat)[e] * (*var.volume)[e] / NODES_PER_ELEM;
 #ifdef THREED
             double shpdx[NODES_PER_ELEM], shpdy[NODES_PER_ELEM], shpdz[NODES_PER_ELEM];
             get_local_shape_fn(var, e, shpdx, shpdy, shpdz);

--- a/input.cxx
+++ b/input.cxx
@@ -398,7 +398,10 @@ static void declare_parameters(po::options_description &cfg,
         ("control.has_thermal_diffusion", po::value<bool>(&p.control.has_thermal_diffusion)->default_value(true),
          "Does the model have thermal diffusion? If not, temperature is advected, but not diffused.\n")
         ("control.has_hydraulic_diffusion", po::value<bool>(&p.control.has_hydraulic_diffusion)->default_value(false),
-         "Does the model have hydraulic diffusion? If not, pore pressure is advected, but not diffused.\n") 
+         "Does the model have hydraulic diffusion? If not, pore pressure is advected, but not diffused.\n")
+        ("control.has_shear_heating", po::value<bool>(&p.control.has_shear_heating)->default_value(false),
+         "Does non-elastic (viscous + plastic) deformation heat the model? Adds the dissipated "
+         "mechanical work as a source term to the thermal diffusion equation.\n")
 
         ("control.has_hydration_processes", po::value<bool>(&p.control.has_hydration_processes)->default_value(false),
          "Does the model have hydration processes? It is required to model some types of phase changes.")

--- a/output.cxx
+++ b/output.cxx
@@ -183,6 +183,7 @@ void Output::_write(const Variables& var, bool disable_averaging)
     bin.write_array(*var.stress, "stress", var.stress->size());
 
     bin.write_array(*var.viscosity, "viscosity", var.viscosity->size());
+    bin.write_array(*var.shear_heat, "shear heating", var.shear_heat->size());
 
     if (!disable_averaging && is_averaged) {
         double *s = stress_avg.data();

--- a/parameters.hpp
+++ b/parameters.hpp
@@ -249,6 +249,7 @@ struct Control {
     bool is_quasi_static;
     bool has_thermal_diffusion;
     bool has_hydraulic_diffusion;
+    bool has_shear_heating;
 
     bool has_hydration_processes;
     double hydration_migration_speed;
@@ -756,6 +757,7 @@ struct Variables {
     double_vec *ntmp;
     double_vec *init_elem_size_n;   // frozen initial nodal element size for MMG metric
     double_vec *radiogenic_source;
+    double_vec *shear_heat; // non-elastic (viscous + plastic) dissipation, W/m^3
 
     // For hyraulic proceses
     double_vec *fmass; // pore water mass

--- a/rheology.cxx
+++ b/rheology.cxx
@@ -354,6 +354,15 @@ static double nonelastic_dissipation(double bulkm, double shearm,
      * only tracked by the plastic branches), playing the same role as the
      * third principal stress in geoFLAC's inherently plane-strain formulation.
      * Its non-elastic strain increment is 0 by the plane-strain constraint.
+     *
+     * de_ne is a discrete (trapezoidal-average-stress) approximation of a
+     * quantity that is exactly non-negative in continuous time, so it can
+     * come out with the wrong sign for a component that's actually elastic
+     * this step (round-off) or one crossing the yield surface mid-step
+     * (discretization error). Clamping each component's de_ne to 0 whenever
+     * it would dissipate negative energy -- rather than clamping the summed
+     * q -- keeps every genuinely dissipative component untouched and only
+     * suppresses the spurious ones.
      */
     double lambda = bulkm - 2./3 * shearm;
     double denom = 3 * lambda + 2 * shearm;
@@ -367,19 +376,25 @@ static double nonelastic_dissipation(double bulkm, double shearm,
         double ee_start = (s_start[i] - (lambda/denom) * tr_start) / (2 * shearm);
         double ee_final = (s_final[i] - (lambda/denom) * tr_final) / (2 * shearm);
         double de_ne = de[i] - (ee_final - ee_start);
-        q += 0.5 * (s_start[i] + s_final[i]) * de_ne;
+        double s_avg = 0.5 * (s_start[i] + s_final[i]);
+        if (s_avg * de_ne < 0.) de_ne = 0.;
+        q += s_avg * de_ne;
     }
     for (int i=NDIMS; i<NSTR; ++i) {
         double ee_start = s_start[i] / (2 * shearm);
         double ee_final = s_final[i] / (2 * shearm);
         double de_ne = de[i] - (ee_final - ee_start);
-        q += 2 * 0.5 * (s_start[i] + s_final[i]) * de_ne;
+        double s_avg = 0.5 * (s_start[i] + s_final[i]);
+        if (s_avg * de_ne < 0.) de_ne = 0.;
+        q += 2 * s_avg * de_ne;
     }
     if (has_syy) {
         double ee_start = (syy_start - (lambda/denom) * tr_start) / (2 * shearm);
         double ee_final = (syy_final - (lambda/denom) * tr_final) / (2 * shearm);
         double de_ne = 0. - (ee_final - ee_start); // out-of-plane strain increment is 0
-        q += 0.5 * (syy_start + syy_final) * de_ne;
+        double s_avg = 0.5 * (syy_start + syy_final);
+        if (s_avg * de_ne < 0.) de_ne = 0.;
+        q += s_avg * de_ne;
     }
     return q;
 }

--- a/rheology.cxx
+++ b/rheology.cxx
@@ -311,6 +311,81 @@ static void viscous(double bulkm, double viscosity, double total_dv,
 
 #pragma acc routine seq
 template <typename T>
+static double viscous_dissipation(double viscosity, T edot, double dt)
+{
+    /* Dissipation rate of a memoryless (rh_viscous) flow: deviatoric stress is
+     * an instantaneous function of strain rate, with no elastic energy storage,
+     * so the entire deviatoric strain increment is non-elastic. The volumetric
+     * term (bulkm * total_dv in viscous()) is a reversible incompressibility
+     * penalty and does not contribute here, same as the bulk term is excluded
+     * from dissipation everywhere else below.
+     */
+    double dev = trace(edot) / NDIMS;
+    double q = 0.;
+    for (int i=0; i<NDIMS; ++i) {
+        double d = edot[i] - dev;
+        q += d * d;
+    }
+    for (int i=NDIMS; i<NSTR; ++i)
+        q += 2 * edot[i] * edot[i];
+    return 2 * viscosity * q * dt;
+}
+
+#pragma acc routine seq
+static double nonelastic_dissipation(double bulkm, double shearm,
+                                     const double* s_start, const double* s_final,
+                                     const double* de,
+                                     bool has_syy, double syy_start, double syy_final)
+{
+    /* Non-elastic (viscous and/or plastic) dissipation over this step, for any
+     * rheology whose stress update is tied to the material's actual elastic
+     * moduli (elastic, maxwell, and the plastic/viscoplastic branches).
+     *
+     * The strain increment de[] this step is split into an elastic part and a
+     * non-elastic remainder. The elastic part is recovered by inverting the
+     * isotropic Hooke's law at the start and end of the step: this works
+     * regardless of which branch produced s_final, since they all share the
+     * same bulkm/shearm. What strain increment isn't accounted for elastically
+     * was dissipated as heat; it's evaluated against the trapezoidal-average
+     * stress over the step. For a purely elastic update de_final == de and the
+     * result is ~0, as it should be.
+     *
+     * has_syy carries the plane-strain out-of-plane stress (DES's stressyy,
+     * only tracked by the plastic branches), playing the same role as the
+     * third principal stress in geoFLAC's inherently plane-strain formulation.
+     * Its non-elastic strain increment is 0 by the plane-strain constraint.
+     */
+    double lambda = bulkm - 2./3 * shearm;
+    double denom = 3 * lambda + 2 * shearm;
+    if (std::fabs(denom) < 1e-30) denom = (denom < 0) ? -1e-30 : 1e-30;
+
+    double tr_start = trace(s_start) + (has_syy ? syy_start : 0.);
+    double tr_final = trace(s_final) + (has_syy ? syy_final : 0.);
+
+    double q = 0.;
+    for (int i=0; i<NDIMS; ++i) {
+        double ee_start = (s_start[i] - (lambda/denom) * tr_start) / (2 * shearm);
+        double ee_final = (s_final[i] - (lambda/denom) * tr_final) / (2 * shearm);
+        double de_ne = de[i] - (ee_final - ee_start);
+        q += 0.5 * (s_start[i] + s_final[i]) * de_ne;
+    }
+    for (int i=NDIMS; i<NSTR; ++i) {
+        double ee_start = s_start[i] / (2 * shearm);
+        double ee_final = s_final[i] / (2 * shearm);
+        double de_ne = de[i] - (ee_final - ee_start);
+        q += 2 * 0.5 * (s_start[i] + s_final[i]) * de_ne;
+    }
+    if (has_syy) {
+        double ee_start = (syy_start - (lambda/denom) * tr_start) / (2 * shearm);
+        double ee_final = (syy_final - (lambda/denom) * tr_final) / (2 * shearm);
+        double de_ne = 0. - (ee_final - ee_start); // out-of-plane strain increment is 0
+        q += 0.5 * (syy_start + syy_final) * de_ne;
+    }
+    return q;
+}
+
+#pragma acc routine seq
+template <typename T>
 static void elasto_plastic(double bulkm, double shearm,
                            double amc, double anphi, double anpsi,
                            double hardn, double ten_max,
@@ -705,7 +780,8 @@ void update_stress(const Param& param, Variables& var, tensor_t& stress,
                    tensor_t& strain, double_vec& plstrain,
                    double_vec& delta_plstrain, tensor_t& strain_rate,
                    double_vec& ppressure, double_vec& dppressure, array_t& vel,
-                   double_vec& dyn_fric_coeff, double_vec& state_variable)
+                   double_vec& dyn_fric_coeff, double_vec& state_variable,
+                   double_vec& shear_heat)
 {
 #ifdef NPROF
     nvtxRangePush(__FUNCTION__);
@@ -713,6 +789,7 @@ void update_stress(const Param& param, Variables& var, tensor_t& stress,
 
     // Loop-invariant, so the per-element gathers they gate are decided once.
     const bool has_hydraulic_diffusion = param.control.has_hydraulic_diffusion;
+    const bool has_shear_heating = param.control.has_shear_heating;
     // Only the two rate-and-state branches call compute_slip_rate*, which is the
     // sole consumer of the centroid velocity.
     const bool needs_slip_rate = (param.mat.rheol_type == MatProps::rh_ep_rsf)
@@ -721,8 +798,8 @@ void update_stress(const Param& param, Variables& var, tensor_t& stress,
 #ifndef ACC
     #pragma omp parallel for default(none) shared(param, var, dppressure, \
         vel, stress, stressyy, dpressure, viscosity, strain, plstrain, delta_plstrain, \
-        strain_rate, dyn_fric_coeff, state_variable) \
-        firstprivate(has_hydraulic_diffusion, needs_slip_rate)
+        strain_rate, dyn_fric_coeff, state_variable, shear_heat) \
+        firstprivate(has_hydraulic_diffusion, needs_slip_rate, has_shear_heating)
 #endif
     #pragma acc parallel loop gang vector async // TODO: ACC: CPU and GPU results are differet because of using 3x3 in elasto_plastic
     for (int e = 0; e < var.nelem; e++) {
@@ -813,6 +890,16 @@ void update_stress(const Param& param, Variables& var, tensor_t& stress,
         // mesh by the nearest-neighbour remap at each remesh, growing a spurious nonzero halo
         // that diffuses out of the yielding zones. Resetting to 0 makes it a true per-step rate.
         delta_plstrain[e] = 0.;
+
+        // Stress (and plane-strain out-of-plane stress) before this step's
+        // constitutive update, kept around to recover the non-elastic strain
+        // increment for shear heating once the update below is done.
+        double s_start[NSTR];
+        double syy_start = syy;
+        if (has_shear_heating) {
+            #pragma acc loop seq
+            for (int i=0; i<NSTR; ++i) s_start[i] = s[i];
+        }
 
         switch (param.mat.rheol_type) {
         case MatProps::rh_elastic:
@@ -1018,6 +1105,26 @@ void update_stress(const Param& param, Variables& var, tensor_t& stress,
 //            std::exit(1);
             break;
         }
+
+        if (has_shear_heating) {
+            double q;
+            if (param.mat.rheol_type == MatProps::rh_viscous) {
+                q = viscous_dissipation(viscosity[e], edot, var.dt);
+            } else {
+                double s_final[NSTR];
+                #pragma acc loop seq
+                for (int i=0; i<NSTR; ++i) s_final[i] = s[i];
+
+                double bulkm = var.mat->bulkm(e);
+                double shearm = var.mat->shearm(e);
+                bool has_syy = var.mat->is_plane_strain &&
+                    (param.mat.rheol_type & MatProps::rh_plastic);
+                q = nonelastic_dissipation(bulkm, shearm, s_start, s_final, de,
+                                           has_syy, syy_start, syy);
+            }
+            shear_heat[e] = q / var.dt;
+        }
+
         if (param.control.is_using_mixed_stress)
             dpressure[e] = trace(s) - old_s;
         // std::cerr << "stress " << e << ": ";

--- a/rheology.hpp
+++ b/rheology.hpp
@@ -5,7 +5,8 @@ void update_stress(const Param& param , Variables& var, tensor_t& stress, double
                    double_vec& dpressure, double_vec& viscosity, tensor_t& strain, double_vec& plstrain,
                    double_vec& delta_plstrain, tensor_t& strain_rate,
                    double_vec& ppressure, double_vec& dppressure, array_t& vel,
-                   double_vec& dyn_fric_coeff, double_vec& state_variable);
+                   double_vec& dyn_fric_coeff, double_vec& state_variable,
+                   double_vec& shear_heat);
 void refresh_rsf_friction(const Param& param, Variables& var,
                           double_vec& dyn_fric_coeff,
                           const double_vec& state_variable);


### PR DESCRIPTION
Adding non-elastic shear heating to DES's rheology model: the elastic strain implied by a stress state is recovered by inverting isotropic Hooke's law at the start and end of each step, and what strain increment isn't accounted for elastically is dissipated as heat, evaluated against the trapezoidal-average stress. This works uniformly across the elastic/maxwell/plastic/viscoplastic branches since they share the same elastic moduli; the memoryless rh_viscous rheology has no elastic modulus tied to its stress update, so it gets the closed-form viscous dissipation formula instead. 2D plane-strain plastic branches fold in stressyy, matching geoFLAC's third principal stress.

Gated behind control.has_shear_heating (default off); the resulting per-element shear_heat field feeds update_temperature as a volumetric source term alongside radiogenic_source.

This feature is based on the discussion in Issue #61.
