### PR TITLE
fix: GPU build failures from #89 (allocator interposition, nvc++ 26.5 STL miscompile)

### DIFF
--- a/3x3-C/Makefile
+++ b/3x3-C/Makefile
@@ -60,14 +60,17 @@ HEADER = dsytrd3.h dsyevc3.h dsyevq3.h dsyevh3.h
 # process than the build -- hence the re-entry in `all`.
 STAMP = .build-flags-3x3$(suffix)
 
+CC_ID = command -v $(firstword $(CC)); v=`$(CC) --version 2>/dev/null | head -1`; \
+        test -n "$$v" || v=`$(CC) -V 2>&1 | grep -m1 .`; echo "$$v"
+
 .PHONY: all clean FORCE
 all: $(STAMP)
 	@$(MAKE) -q --no-print-directory $(BIN) || $(MAKE) --no-print-directory $(BIN)
 
 $(STAMP): FORCE
-	@echo '$(CC)|$(CFLAGS)|$(INCFLAGS)' > $@.tmp
+	@{ echo '$(CC)|$(CFLAGS)|$(INCFLAGS)'; $(CC_ID); } > $@.tmp
 	@if cmp -s $@.tmp $@; then rm -f $@.tmp; else \
-		test -f $@ && echo "   3x3-C flags changed since the last build -- rebuilding"; \
+		test -f $@ && echo "   3x3-C compiler or flags changed since the last build -- rebuilding"; \
 		mv $@.tmp $@; rm -f $(OBJ) $(BIN); \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -884,10 +884,13 @@ GLOBAL_CXXFLAGS = $(filter-out $(FEATURE_FLAGS),$(CXXFLAGS) $(BOOST_CXXFLAGS))
 ## which the outer make finishes before `all` runs `$(MAKE) build`. The map's
 ## dependency edges stay too: they cover a stamp that does not exist yet.
 FLAG_STAMPS = $(BUILD_STAMP) $(LINK_STAMP) $(FEATURE_STAMPS)
+CXX_ID = command -v $(firstword $(CXX)); v=`$(CXX) --version 2>/dev/null | head -1`; \
+         test -n "$$v" || v=`$(CXX) -V 2>&1 | grep -m1 .`; echo "$$v"
+
 $(BUILD_STAMP): FORCE
-	@echo '$(CXX)|$(GLOBAL_CXXFLAGS)' > $@.tmp
+	@{ echo '$(CXX)|$(GLOBAL_CXXFLAGS)'; $(CXX_ID); } > $@.tmp
 	@if cmp -s $@.tmp $@; then rm -f $@.tmp; else \
-		test -f $@ && echo "   compile flags changed since the last build -- rebuilding"; \
+		test -f $@ && echo "   compiler or compile flags changed since the last build -- rebuilding"; \
 		mv $@.tmp $@; rm -f $(OBJS) $(M_OBJS); \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -624,6 +624,9 @@ else ifneq (, $(findstring nvc++, $(CXX)))
 		LDFLAGS += -acc=gpu -gpu=cc$(GPU_CC),mem:managed -cuda
 		# CXXFLAGS += -acc=gpu -Mcuda -DACC
 		# LDFLAGS += -acc=gpu -gpu=managed -Mcuda
+
+		## Keep our symbols out of .dynsym
+		LDFLAGS += -Wl,--version-script=local-symbols.map
 		ifeq ($(nofma), 1)
 			CXXFLAGS += -gpu=cc$(GPU_CC),mem:managed,nofma
 			# CXXFLAGS += -gpu=managed,nofma

--- a/local-symbols.map
+++ b/local-symbols.map
@@ -1,0 +1,28 @@
+/* Linker version script for the openacc=1 executable: keep every symbol it
+ * defines out of the dynamic symbol table.
+ *
+ * nvc++ -gpu=mem:managed does not replace malloc/free process-wide: it rewrites
+ * the new/delete call sites inside each unit it compiles, so input.2d.gpu.o
+ * references __pgi_managed_new and no _Znwm at all. Those units also emit their
+ * own copies of the libstdc++ templates they use -- _M_realloc_insert,
+ * _Rb_tree, basic_string, the stream machinery. Those copies are weak, they
+ * reach .dynsym, and an executable outranks every shared library for the whole
+ * process: 33 of them here, all called through libboost's and libstdc++'s PLT.
+ *
+ * Boost then allocates from the managed pool through our copy and releases
+ * through a path it inlined locally -- glibc free() on a pool pointer, which
+ * aborts with "free(): invalid size" or similar. The reverse direction is
+ * harmless; NVHPC's managed delete forwards a foreign pointer to free().
+ *
+ * It aborts early and silently. The first operator new in a DES unit is inside
+ * declare_parameters(), and NVHPC brings the OpenACC device up from inside that
+ * allocation, so the process can die before "Checking consistency of input
+ * parameters..." reaches the terminal.
+ *
+ * Keeping the symbols local leaves each side one consistent allocator. DES's
+ * own allocations stay managed -- the managed-new count is unchanged, the heap
+ * is still device-accessible, and numerical output is bit-identical.
+ */
+{
+    local: *;
+};

--- a/markerset.cxx
+++ b/markerset.cxx
@@ -1499,7 +1499,6 @@ void MarkerSet::check_marker_elem_consistency(const Variables &var) const
 #ifdef NPROF
     nvtxRangePush(__FUNCTION__);
 #endif
-    #pragma acc serial
     int ncount = 0, is_error = 0;
 #ifndef ACC
     #pragma omp parallel for reduction(+:ncount,is_error) default(none) shared(var,std::cerr)

--- a/markerset.cxx
+++ b/markerset.cxx
@@ -767,8 +767,9 @@ void MarkerSet::remove_markers(const Param& param, const Variables &var, int_vec
 #endif
         for (int i = 0; i < int(a_out.size()); i++) {
             int_vec& emarkers = markers_in_elem[(*_elem)[b_out[i]]];
-            auto it = std::find(emarkers.begin(), emarkers.end(), b_out[i]);
-            emarkers[it - emarkers.begin()] = a_out[i];
+            std::size_t pos = 0;
+            while (pos < emarkers.size() && emarkers[pos] != b_out[i]) ++pos;
+            emarkers[pos] = a_out[i];
             remove_marker_data(a_out[i],b_out[i]);
         }
     }
@@ -1505,7 +1506,10 @@ void MarkerSet::check_marker_elem_consistency(const Variables &var) const
 #endif
     #pragma acc parallel loop gang vector reduction(+:ncount,is_error)
     for (int e=0; e<var.nelem; ++e) {
-        int nmarker_mat = std::accumulate((*var.elemmarkers)[e].begin(), (*var.elemmarkers)[e].end(), 0);
+        const int_vec &em = (*var.elemmarkers)[e];
+        int nmarker_mat = 0;
+        for (std::size_t k=0; k<em.size(); ++k)
+            nmarker_mat += em[k];
         int elenmarkers = (*var.markers_in_elem)[e].size();
 
         if (elenmarkers != nmarker_mat) {


### PR DESCRIPTION
Fixes both failures reported in #89 (RTX 4000 Ada / WSL2 / NVHPC 26.5), plus the
build gap that made them hard to diagnose. Both reproduced on tierra4 before and
after the fix.

## 1. `free(): invalid size` before any output

`-gpu=mem:managed` rewrites `new`/`delete` call sites per translation unit
instead of interposing process-wide, and those units export their own copies of
the libstdc++ templates they use. An executable outranks every shared library,
so libboost and libstdc++ allocated from NVHPC's managed pool and released with
glibc `free()` — 33 exported vague-linkage symbols, 13 shared with libboost and
20 with libstdc++, all reached through their PLT.

`local-symbols.map` (`{ local: *; };`) keeps them local, giving each side one
allocator: shared symbols 33 → 0, cross-allocator frees 4515 → 731, DES's own
managed allocations unchanged at 1979 so its heap stays device-accessible.
Config-file errors also stop aborting with heap corruption and now exit
`10`/`11` with a message.

## 2. `markers count mismatch: 4 vs <garbage>`

nvc++ 26.5 miscompiles iterator-based STL algorithms inside `acc` compute
regions: they return pointer values while `.size()` stays correct, hence
`4 vs 83954434`, where the second number is a heap address. Reduced to ~25 lines
with no DES code:

```
             accumulate  max_element   find   index loop
nvc++ 25.7:           0            0      0            0    (wrong results, of 111)
nvc++ 26.5:         111          111    111            0
```

Both sites become index loops — `markerset.cxx:1508` `std::accumulate`, the
reported abort, and `markerset.cxx:770` `std::find`, which is worse: a garbage
iterator makes `emarkers[it - emarkers.begin()]` an out-of-bounds write,
unreached by `aniso_test.cfg` so it never surfaced. A whole-program audit found
no others. Also drops a `#pragma acc serial` sitting on a declaration, which on
25.7 swallowed the element loop into a serial kernel and discarded
`reduction(+:ncount,is_error)`.

## 3. Build blind to a compiler change

`$(CXX)` and `$(CC)` are bare words identical across every version, so switching
toolchains on `PATH` reused objects from the previous compiler — surfacing as
`nvlink fatal: ABI version '8' is incompatible with target ABI version '7'`
blaming a DES object. Stamps now key on the resolved compiler path and version
banner: DES (`CXX_ID`), 3x3-C (`CC_ID`) and knn-bvh.

## Verification

CPU `ndims=2`/`3`/`opt=0` and GPU `ndims=2`/`3` build clean. `aniso_test`
and `2d-ep-irregular` pass under both 25.7 and 26.5ㄡ. Restart is BIT-EXACT in
2D and 3D across all 17 fields including markers.
