### PR TITLE
Add strain-invariant RSF slip rates and paper benchmarks

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -72,6 +72,9 @@ jobs:
     - name: test 2d RSF ATS benchmark subset
       run: bash 2d-rsf-ats.sh
 
+    - name: test 2d homogeneous initial stress
+      run: python3 initial_stress/check_initial_stress.py --exe ../../dynearthsol2d
+
     - name: make 3d hdf5 opt=-1
       working-directory: .
       run: make cleanall && make -j ndims=3 opt=-1 openmp=1 hdf5=1

--- a/benchmarks/simple_shear_rsf/README.md
+++ b/benchmarks/simple_shear_rsf/README.md
@@ -1,43 +1,87 @@
-# Simple-Shear RSF Benchmark
+# Local EP/RSF Benchmark
+
+This directory reproduces the constitutive verification described in the DES
+v2.0 paper revision. The main benchmark has nine two-element simple-shear
+cases:
+
+- static-friction elastoplasticity at 10, 20, and 30 degrees
+- steady-state RSF at \(V_0=10^{-6},10^{-5},10^{-4}\) m/s
+- aging-law RSF at \(D_c=10^{-3},3\times10^{-3},10^{-2}\) m
+
+Each case uses a fixed 0.01 s step for 200,000 steps. The top boundary moves at
+\(10^{-5}\) m/s, giving a final time of 2000 s and an engineering shear strain
+of 0.02. The RSF cases explicitly select the total-strain-invariant rate
+measure. In this deforming cell,
+
+\[
+V(t)=\frac{v_x}{\sqrt{(1-v_x t/H)^2+1}}.
+\]
+
+The runner can also reproduce the paper's separate zero-velocity healing test:
+1546 fixed steps of three days with \(D_c=10^{-2}\) m and
+\(V_0=4\times10^{-9}\) m/s.
 
 ## Files
 
-- `simple_shear_base.cfg`: base CFG template
-- `run_simple_shear_benchmark.py`: generate and run benchmark cases
-- `plot_simple_shear_benchmark.py`: create a figure or run a numerical check
-- `check_simple_shear_benchmark.py`: run the small CI subset without plotting
+- simple_shear_base.cfg: shared CFG template
+- run_simple_shear_benchmark.py: case generation and execution
+- benchmark_reference.py: paper reference solutions and monitor readers
+- plot_simple_shear_benchmark.py: paper-layout figure and metrics CSV
+- check_simple_shear_benchmark.py: non-plotting regression check
 
-## Full Run
+## Full Paper Run
 
-```bash
+~~~bash
 cd benchmarks/simple_shear_rsf
-python3 run_simple_shear_benchmark.py --clean --output-step-interval 40
-python3 plot_simple_shear_benchmark.py -o simple_shear_benchmark.png
-```
+python3 run_simple_shear_benchmark.py --clean --aging-transient --healing
+python3 plot_simple_shear_benchmark.py -o simple_shear_benchmark.pdf
+~~~
 
-Generated outputs:
+This creates nine main case directories, three higher-frequency aging-law
+monitor directories for the state inset, and one healing directory under
+runs/. The plotting command creates the requested figure and
+simple_shear_benchmark_metrics.csv.
 
-- case directories under `runs/`
-- figure file `simple_shear_benchmark.png`
+The stress comparison is the two-element mean absolute shear stress. At every
+sample after \(t=0\), the reported error is
 
-## Check Only
+\[
+\frac{|\overline{\sigma}_{xy}^{DES}
+      -\overline{\sigma}_{xy}^{ref}|}
+     {\overline{\sigma}_{xy}^{ref}}.
+\]
 
-Run the small RSF subset used for functional testing:
+## Regression Check
 
-```bash
+The default check runs one steady-state case, one aging-law case, and the
+zero-velocity healing test:
+
+~~~bash
 cd benchmarks/simple_shear_rsf
 python3 check_simple_shear_benchmark.py
-```
+~~~
 
-Default check settings:
+Run all nine simple-shear cases plus healing with:
 
-- cases: `steady_ab_pos_v0_1e-6`, `aging_ab_neg_dc_1e-6`
-- relative error tolerance: `5e-2`
-- output directory: temporary and auto-removed
+~~~bash
+python3 check_simple_shear_benchmark.py --all
+~~~
 
-## Manual Check Without PNG
+The checker verifies pointwise stress error, recovers the rate used by the RSF
+law from the monitored friction and state outputs, and iterates the discrete
+zero-velocity healing update independently. Temporary results are removed
+unless --keep-output is supplied.
 
-```bash
-cd benchmarks/simple_shear_rsf
-python3 plot_simple_shear_benchmark.py --check --no-save --max-relative-error 5e-2
-```
+The default maximum pointwise stress-error tolerance is \(2\times10^{-5}\) as
+a fraction. The paper reports a largest pointwise error of
+\(1.16\times10^{-3}\) percent.
+
+## Check Existing Results
+
+~~~bash
+python3 plot_simple_shear_benchmark.py \
+  --check --no-save --max-relative-error 2e-5
+~~~
+
+NumPy and Matplotlib are required only for plotting; the runner and regression
+checker use the Python standard library.

--- a/benchmarks/simple_shear_rsf/benchmark_reference.py
+++ b/benchmarks/simple_shear_rsf/benchmark_reference.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Reference solutions and monitor readers for the local EP/RSF benchmarks."""
+
+from __future__ import annotations
+
+import csv
+import math
+from dataclasses import dataclass
+from pathlib import Path
+
+from run_simple_shear_benchmark import BenchmarkCase
+
+
+VX_TOP_M_S = 1.0e-5
+HEIGHT_M = 1.0
+SHEAR_MODULUS_PA = 200.0e6
+COHESION_PA = 1.0e6
+SHEAR_DT_S = 0.01
+VELOCITY_FLOOR_M_S = 1.0e-16
+
+
+@dataclass(frozen=True)
+class MonitorData:
+    time_s: list[float]
+    stress_by_element: list[list[float]]
+    friction_by_element: list[list[float] | None]
+    state_by_element: list[list[float] | None]
+
+    @property
+    def mean_abs_stress(self) -> list[float]:
+        return [
+            sum(values) / len(values)
+            for values in zip(*self.stress_by_element)
+        ]
+
+
+@dataclass(frozen=True)
+class ErrorMetrics:
+    samples: int
+    mean_fraction: float
+    max_fraction: float
+    final_fraction: float
+
+
+def slip_rate(time_s: float) -> float:
+    """Return 2 w strain_rate_II for the deforming two-triangle cell."""
+    gamma = VX_TOP_M_S * time_s / HEIGHT_M
+    return VX_TOP_M_S / math.sqrt((1.0 - gamma) ** 2 + 1.0)
+
+
+def _integrating_factor(time_s: float, dc_m: float) -> float:
+    gamma = VX_TOP_M_S * time_s / HEIGHT_M
+    return (HEIGHT_M / dc_m) * (
+        math.asinh(1.0) - math.asinh(1.0 - gamma)
+    )
+
+
+def aging_state(
+    time_s: list[float],
+    dc_m: float,
+    v0_m_s: float,
+) -> list[float]:
+    """Solve the aging law by the paper's integrating-factor quadrature."""
+    if not time_s:
+        return []
+    if any(right < left for left, right in zip(time_s, time_s[1:])):
+        raise ValueError("Reference times must be nondecreasing.")
+
+    max_time_s = time_s[-1]
+    grid_steps = int(math.ceil(max_time_s / SHEAR_DT_S - 1.0e-12))
+    integrals = [0.0] * (grid_steps + 1)
+    previous_exp = 1.0
+    for step in range(1, grid_steps + 1):
+        grid_time_s = step * SHEAR_DT_S
+        current_exp = math.exp(_integrating_factor(grid_time_s, dc_m))
+        integrals[step] = (
+            integrals[step - 1]
+            + 0.5 * (previous_exp + current_exp) * SHEAR_DT_S
+        )
+        previous_exp = current_exp
+
+    theta0_s = dc_m / v0_m_s
+    result: list[float] = []
+    for sample_time_s in time_s:
+        position = sample_time_s / SHEAR_DT_S
+        lower = min(int(math.floor(position)), grid_steps)
+        upper = min(lower + 1, grid_steps)
+        if upper == lower:
+            integral = integrals[lower]
+        else:
+            fraction = position - lower
+            integral = integrals[lower] + fraction * (
+                integrals[upper] - integrals[lower]
+            )
+        phi = _integrating_factor(sample_time_s, dc_m)
+        result.append(math.exp(-phi) * (theta0_s + integral))
+    return result
+
+
+def yield_stress_from_mu(mu: float) -> float:
+    """Return the zero-pressure Mohr-Coulomb shear strength."""
+    phi = math.atan(max(mu, 1.0e-6))
+    sin_phi = math.sin(phi)
+    n_phi = (1.0 + sin_phi) / (1.0 - sin_phi)
+    return 2.0 * COHESION_PA * math.sqrt(n_phi) / (1.0 + n_phi)
+
+
+def analytical_stress(
+    case: BenchmarkCase,
+    time_s: list[float],
+) -> list[float]:
+    """Return the paper's small-strain reference stress."""
+    elastic = [
+        SHEAR_MODULUS_PA * VX_TOP_M_S * value / HEIGHT_M
+        for value in time_s
+    ]
+    mu0 = math.tan(math.radians(case.friction_angle_deg))
+
+    if case.group == "ep":
+        strength = yield_stress_from_mu(mu0)
+        return [min(value, strength) for value in elastic]
+
+    velocities = [slip_rate(value) for value in time_s]
+    if case.state_var_model == 0:
+        friction = [
+            mu0
+            + (case.direct_a - case.evolution_b)
+            * math.log(velocity / case.characteristic_velocity)
+            for velocity in velocities
+        ]
+    else:
+        states = aging_state(
+            time_s,
+            case.characteristic_distance,
+            case.characteristic_velocity,
+        )
+        friction = [
+            mu0
+            + case.direct_a
+            * math.log(velocity / case.characteristic_velocity)
+            + case.evolution_b
+            * math.log(
+                case.characteristic_velocity
+                * state
+                / case.characteristic_distance
+            )
+            for velocity, state in zip(velocities, states)
+        ]
+
+    return [
+        min(value, yield_stress_from_mu(mu))
+        for value, mu in zip(elastic, friction)
+    ]
+
+
+def analytical_state_ratio(
+    case: BenchmarkCase,
+    time_s: list[float],
+) -> list[float]:
+    states = aging_state(
+        time_s,
+        case.characteristic_distance,
+        case.characteristic_velocity,
+    )
+    return [
+        state / (case.characteristic_distance / slip_rate(value))
+        for value, state in zip(time_s, states)
+    ]
+
+
+def load_monitor_case(case_dir: Path) -> MonitorData:
+    paths = sorted(case_dir.glob("monitor_point_*.csv"))
+    if len(paths) != 2:
+        raise FileNotFoundError(f"Expected two monitor CSVs in {case_dir}")
+
+    times: list[list[float]] = []
+    stresses: list[list[float]] = []
+    frictions: list[list[float] | None] = []
+    states: list[list[float] | None] = []
+    for path in paths:
+        with path.open("r", encoding="utf-8", newline="") as handle:
+            rows = sorted(
+                csv.DictReader(handle),
+                key=lambda row: float(row["time_s"]),
+            )
+        if not rows:
+            raise ValueError(f"No monitor rows found in {path}")
+        header = rows[0].keys()
+        times.append([float(row["time_s"]) for row in rows])
+        stresses.append([abs(float(row["stress_2"])) for row in rows])
+        frictions.append(
+            [float(row["dynamic_friction"]) for row in rows]
+            if "dynamic_friction" in header
+            else None
+        )
+        states.append(
+            [float(row["state_variable"]) for row in rows]
+            if "state_variable" in header
+            else None
+        )
+
+    reference_time = times[0]
+    if len(times[1]) != len(reference_time):
+        raise ValueError(f"Monitor time-axis length mismatch in {case_dir}")
+    for left, right in zip(reference_time, times[1]):
+        if abs(left - right) > 1.0e-10:
+            raise ValueError(f"Monitor time-axis mismatch in {case_dir}")
+
+    return MonitorData(reference_time, stresses, frictions, states)
+
+
+def pointwise_error_metrics(
+    numerical: list[float],
+    reference: list[float],
+) -> ErrorMetrics:
+    if len(numerical) != len(reference):
+        raise ValueError("Numerical and reference series have different lengths.")
+    errors = [
+        abs(num - ref) / abs(ref)
+        for num, ref in zip(numerical[1:], reference[1:])
+    ]
+    if not errors:
+        raise ValueError("The t=0 sample is the only available sample.")
+    return ErrorMetrics(
+        len(errors),
+        sum(errors) / len(errors),
+        max(errors),
+        errors[-1],
+    )
+
+
+def recovered_rate_errors(
+    case: BenchmarkCase,
+    data: MonitorData,
+) -> list[float]:
+    """Recover the constitutive rate from monitored friction and state."""
+    if case.group == "ep":
+        return []
+    mu0 = math.tan(math.radians(case.friction_angle_deg))
+    errors: list[float] = []
+    for friction, state in zip(
+        data.friction_by_element,
+        data.state_by_element,
+    ):
+        if friction is None:
+            raise ValueError("Dynamic friction is required to recover slip rate.")
+        element_errors: list[float] = []
+        for index in range(1, len(data.time_s)):
+            if case.state_var_model == 0:
+                velocity = case.characteristic_velocity * math.exp(
+                    (friction[index] - mu0)
+                    / (case.direct_a - case.evolution_b)
+                )
+            else:
+                if state is None:
+                    raise ValueError("State variable is required to recover slip rate.")
+                evolution = case.evolution_b * math.log(
+                    case.characteristic_velocity
+                    * state[index]
+                    / case.characteristic_distance
+                )
+                velocity = case.characteristic_velocity * math.exp(
+                    (friction[index] - mu0 - evolution) / case.direct_a
+                )
+            reference = slip_rate(data.time_s[index])
+            element_errors.append(abs(velocity - reference) / reference)
+        errors.append(max(element_errors))
+    return errors
+
+
+def healing_reference(max_step: int) -> list[float]:
+    dc_m = 1.0e-2
+    theta_s = dc_m / 4.0e-9
+    result = [theta_s]
+    for _ in range(max_step):
+        theta_s += (
+            1.0 - VELOCITY_FLOOR_M_S * theta_s / dc_m
+        ) * 259_200.0
+        theta_s = min(max(theta_s, 1.0e-12), 1.0e12)
+        result.append(theta_s)
+    return result

--- a/benchmarks/simple_shear_rsf/check_simple_shear_benchmark.py
+++ b/benchmarks/simple_shear_rsf/check_simple_shear_benchmark.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
-"""Run a small simple-shear RSF subset, verify against analytics, and clean up outputs."""
+"""Run paper benchmark cases, check their references, and clean the outputs."""
 
 from __future__ import annotations
 
 import argparse
 import csv
-import math
 import shutil
 import subprocess
 import sys
@@ -14,13 +13,25 @@ from pathlib import Path
 
 sys.dont_write_bytecode = True
 
-from run_simple_shear_benchmark import BENCHMARK_CASES, BenchmarkCase
+from benchmark_reference import (
+    analytical_stress,
+    healing_reference,
+    load_monitor_case,
+    pointwise_error_metrics,
+    recovered_rate_errors,
+)
+from run_simple_shear_benchmark import (
+    BENCHMARK_CASES,
+    HEALING_CASE,
+    BenchmarkCase,
+)
 
 
-VX_TOP = 1e-5
-SHEAR_MODULUS = 200.0e6
-COHESION = 1.0e6
-DT = 1.0
+DEFAULT_CASES = (
+    "steady_ab_neg_v0_1e-6",
+    "aging_ab_neg_dc_1e-3",
+)
+HEALING_RELATIVE_TOLERANCE = 1.0e-12
 
 
 def cleanup_pycache(root_dir: Path) -> None:
@@ -29,212 +40,9 @@ def cleanup_pycache(root_dir: Path) -> None:
             shutil.rmtree(path, ignore_errors=True)
 
 
-def effective_velocity() -> float:
-    v1 = VX_TOP / 3.0
-    v2 = 2.0 * VX_TOP / 3.0
-    return math.sqrt(v1 * v2)
-
-
-def analytical_ep(phi_deg: float, total_time: float) -> tuple[list[float], list[float]]:
-    phi = math.radians(phi_deg)
-    sf = math.sin(phi)
-    nphi = (1.0 + sf) / (1.0 - sf)
-    npsi = 1.0
-
-    nstep = int(total_time / DT) + 1
-    time_s = [DT * i for i in range(nstep)]
-    stress_xy = [0.0] * nstep
-
-    for i in range(1, nstep):
-        d_exy = 0.5 * VX_TOP * DT
-        d_stress_el = 2.0 * SHEAR_MODULUS * d_exy
-        stress_el = stress_xy[i - 1] + d_stress_el
-
-        s1_el = -stress_el
-        s3_el = stress_el
-        yield_fn = s1_el - s3_el * nphi + 2.0 * COHESION * math.sqrt(nphi)
-
-        if yield_fn > 0.0:
-            stress_xy[i] = stress_el
-        else:
-            d_beta = yield_fn / (2.0 * SHEAR_MODULUS * (1.0 + nphi * npsi))
-            s3_bar = s3_el + 2.0 * SHEAR_MODULUS * d_beta * npsi
-            stress_xy[i] = s3_bar
-
-    return time_s, stress_xy
-
-
-def analytical_rsf_steady(
-    phi_deg: float,
-    a: float,
-    b: float,
-    v0: float,
-    total_time: float,
-) -> tuple[list[float], list[float]]:
-    phi0 = math.radians(phi_deg)
-    mu0 = math.tan(phi0)
-    velocity = effective_velocity()
-
-    nstep = int(total_time / DT) + 1
-    time_s = [DT * i for i in range(nstep)]
-    stress_xy = [0.0] * nstep
-
-    mu_ss = max(mu0 + (a - b) * math.log(velocity / v0), 1.0e-6)
-    phi_eff = math.atan(mu_ss)
-    sf_eff = math.sin(phi_eff)
-    nphi_eff = (1.0 + sf_eff) / (1.0 - sf_eff)
-    npsi = 1.0
-
-    for i in range(1, nstep):
-        d_exy = 0.5 * VX_TOP * DT
-        d_stress_el = 2.0 * SHEAR_MODULUS * d_exy
-        stress_el = stress_xy[i - 1] + d_stress_el
-
-        s1_el = -stress_el
-        s3_el = stress_el
-        yield_fn = s1_el - nphi_eff * s3_el + 2.0 * COHESION * math.sqrt(nphi_eff)
-
-        if yield_fn > 0.0:
-            stress_xy[i] = stress_el
-        else:
-            d_beta = yield_fn / (2.0 * SHEAR_MODULUS * (1.0 + nphi_eff * npsi))
-            s3_bar = s3_el + 2.0 * SHEAR_MODULUS * d_beta * npsi
-            stress_xy[i] = s3_bar
-
-    return time_s, stress_xy
-
-
-def analytical_rsf_aging(
-    phi_deg: float,
-    a: float,
-    b: float,
-    dc: float,
-    v0: float,
-    total_time: float,
-) -> tuple[list[float], list[float]]:
-    phi0 = math.radians(phi_deg)
-    mu0 = math.tan(phi0)
-    velocity = max(effective_velocity(), 1.0e-12)
-    theta = dc / v0
-
-    nstep = int(total_time / DT) + 1
-    time_s = [DT * i for i in range(nstep)]
-    stress_xy = [0.0] * nstep
-    npsi = 1.0
-
-    for i in range(1, nstep):
-        d_exy = 0.5 * VX_TOP * DT
-        d_stress_el = 2.0 * SHEAR_MODULUS * d_exy
-        stress_el = stress_xy[i - 1] + d_stress_el
-
-        theta = theta + DT * (1.0 - velocity * theta / dc)
-        theta = max(theta, 1.0e-30)
-        mu = max(mu0 + a * math.log(velocity / v0) + b * math.log((theta * v0) / dc), 1.0e-6)
-        phi_eff = math.atan(mu)
-        sf_eff = math.sin(phi_eff)
-        nphi_eff = (1.0 + sf_eff) / (1.0 - sf_eff)
-
-        s1_el = -stress_el
-        s3_el = stress_el
-        yield_fn = s1_el - nphi_eff * s3_el + 2.0 * COHESION * math.sqrt(nphi_eff)
-
-        if yield_fn > 0.0:
-            stress_xy[i] = stress_el
-        else:
-            d_beta = yield_fn / (2.0 * SHEAR_MODULUS * (1.0 + nphi_eff * npsi))
-            s3_bar = s3_el + 2.0 * SHEAR_MODULUS * d_beta * npsi
-            stress_xy[i] = s3_bar
-
-    return time_s, stress_xy
-
-
-def analytical_series(case: BenchmarkCase, total_time: float) -> tuple[list[float], list[float]]:
-    if case.group == "ep":
-        return analytical_ep(case.friction_angle_deg, total_time)
-    if case.group in ("steady_ab_pos", "steady_ab_neg"):
-        return analytical_rsf_steady(
-            phi_deg=case.friction_angle_deg,
-            a=case.direct_a,
-            b=case.evolution_b,
-            v0=case.characteristic_velocity,
-            total_time=total_time,
-        )
-    if case.group == "aging_ab_neg":
-        return analytical_rsf_aging(
-            phi_deg=case.friction_angle_deg,
-            a=case.direct_a,
-            b=case.evolution_b,
-            dc=case.characteristic_distance,
-            v0=case.characteristic_velocity,
-            total_time=total_time,
-        )
-    raise ValueError(f"Unsupported group: {case.group}")
-
-
-def load_monitor_stress(case_dir: Path) -> tuple[list[float], list[float]]:
-    csv_paths = sorted(case_dir.glob("monitor_point_*.csv"))
-    if not csv_paths:
-        raise FileNotFoundError(f"No monitor CSV found in {case_dir}")
-
-    series: list[tuple[list[float], list[float]]] = []
-    for csv_path in csv_paths:
-        with csv_path.open("r", encoding="utf-8", newline="") as handle:
-            reader = csv.DictReader(handle)
-            rows = sorted(reader, key=lambda row: float(row["time_s"]))
-        time_s = [float(row["time_s"]) for row in rows]
-        stress_xy = [abs(float(row["stress_2"])) for row in rows]
-        if not time_s:
-            raise ValueError(f"No monitor rows found in {csv_path}")
-        series.append((time_s, stress_xy))
-
-    ref_time = series[0][0]
-    for idx, (time_s, _) in enumerate(series[1:], start=1):
-        if len(time_s) != len(ref_time):
-            raise ValueError(f"Monitor time axis length mismatch between point 0 and point {idx} in {case_dir}")
-        for t0, t1 in zip(ref_time, time_s):
-            if abs(t0 - t1) > 1.0e-12:
-                raise ValueError(f"Monitor time axis mismatch between point 0 and point {idx} in {case_dir}")
-
-    mean_abs_stress: list[float] = []
-    for sample_index in range(len(ref_time)):
-        mean_abs_stress.append(
-            sum(stress_series[sample_index] for _, stress_series in series) / float(len(series))
-        )
-
-    return ref_time, mean_abs_stress
-
-
-def interpolate_linear(x_values: list[float], y_values: list[float], x: float) -> float:
-    if x <= x_values[0]:
-        return y_values[0]
-    if x >= x_values[-1]:
-        return y_values[-1]
-
-    hi = 1
-    while x_values[hi] < x:
-        hi += 1
-    lo = hi - 1
-    x0 = x_values[lo]
-    x1 = x_values[hi]
-    y0 = y_values[lo]
-    y1 = y_values[hi]
-    if x1 == x0:
-        return y0
-    return y0 + (y1 - y0) * (x - x0) / (x1 - x0)
-
-
-def compare_series(
-    num_time: list[float],
-    num_stress: list[float],
-    ana_time: list[float],
-    ana_stress: list[float],
-) -> float:
-    ana_on_num = [interpolate_linear(ana_time, ana_stress, x) for x in num_time]
-    scale = max(max(abs(value) for value in ana_on_num), 1.0)
-    return max(abs(num - ana) for num, ana in zip(num_stress, ana_on_num)) / scale
-
-
-def selected_cases(case_names: list[str]) -> list[BenchmarkCase]:
+def selected_cases(case_names: list[str], use_all: bool) -> list[BenchmarkCase]:
+    if use_all:
+        return list(BENCHMARK_CASES)
     cases_by_name = {case.name: case for case in BENCHMARK_CASES}
     missing = [name for name in case_names if name not in cases_by_name]
     if missing:
@@ -242,23 +50,83 @@ def selected_cases(case_names: list[str]) -> list[BenchmarkCase]:
     return [cases_by_name[name] for name in case_names]
 
 
+def check_healing(case_dir: Path) -> tuple[float, float]:
+    paths = sorted(case_dir.glob("monitor_point_*.csv"))
+    if len(paths) != 2:
+        raise FileNotFoundError(f"Expected two monitor CSVs in {case_dir}")
+
+    series: list[list[tuple[int, float, float]]] = []
+    for path in paths:
+        with path.open("r", encoding="utf-8", newline="") as handle:
+            rows = [
+                (
+                    int(row["step"]),
+                    float(row["time_s"]),
+                    float(row["state_variable"]),
+                )
+                for row in csv.DictReader(handle)
+            ]
+        rows.sort(key=lambda item: item[0])
+        if not rows:
+            raise ValueError(f"No monitor rows found in {path}")
+        series.append(rows)
+
+    final_step = min(rows[-1][0] for rows in series)
+    if final_step != 1_546:
+        raise ValueError(f"Unexpected healing final step: {final_step}")
+    reference = healing_reference(final_step)
+
+    errors: list[float] = []
+    final_states: list[float] = []
+    for rows in series:
+        for step, time_s, state_s in rows:
+            if abs(time_s - step * 259_200.0) > 1.0e-6:
+                raise ValueError(f"Healing time does not match step {step}.")
+            errors.append(
+                abs(state_s - reference[step])
+                / max(abs(reference[step]), 1.0e-300)
+            )
+        final_states.append(rows[-1][2])
+
+    mean_final_state = sum(final_states) / len(final_states)
+    theta0_s = HEALING_CASE.characteristic_distance / HEALING_CASE.characteristic_velocity
+    final_time_s = final_step * 259_200.0
+    linear_deficit = (
+        theta0_s + final_time_s - mean_final_state
+    ) / final_time_s
+    return max(errors), linear_deficit
+
+
 def main() -> None:
     script_dir = Path(__file__).resolve().parent
     runner = script_dir / "run_simple_shear_benchmark.py"
 
-    parser = argparse.ArgumentParser(description="Check a small RSF simple-shear subset and clean outputs.")
+    parser = argparse.ArgumentParser(
+        description="Check the paper's local EP/RSF benchmark references."
+    )
     parser.add_argument("--exe", default=None, help="Path to dynearthsol2d. If omitted, auto-detect.")
     parser.add_argument(
         "--cases",
         nargs="+",
-        default=["steady_ab_pos_v0_1e-6", "aging_ab_neg_dc_1e-6"],
-        help="Representative cases to run and verify.",
+        default=list(DEFAULT_CASES),
+        help="Representative simple-shear cases to run and verify.",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Run all nine simple-shear cases instead of the representative subset.",
     )
     parser.add_argument(
         "--max-relative-error",
         type=float,
-        default=5e-2,
-        help="Relative error tolerance for CI-style checks.",
+        default=2.0e-5,
+        help="Maximum allowed pointwise stress error as a fraction.",
+    )
+    parser.add_argument(
+        "--max-rate-relative-error",
+        type=float,
+        default=5.0e-4,
+        help="Maximum allowed error in the rate recovered from friction outputs.",
     )
     parser.add_argument(
         "--keep-output",
@@ -267,7 +135,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    cases = selected_cases(args.cases)
+    cases = selected_cases(args.cases, args.all)
     temp_ctx: tempfile.TemporaryDirectory[str] | None = None
     if args.keep_output:
         output_root = Path(tempfile.mkdtemp(prefix="simple_shear_rsf_check_"))
@@ -280,30 +148,56 @@ def main() -> None:
             "python3",
             str(runner),
             "--clean",
-            "--output-step-interval",
-            "40",
+            "--healing",
             "--output-root",
             str(output_root),
             "--cases",
-            *args.cases,
+            *[case.name for case in cases],
         ]
         if args.exe:
-            run_cmd.extend(["--exe", args.exe])
+            run_cmd.extend(["--exe", str(Path(args.exe).expanduser().resolve())])
         subprocess.run(run_cmd, cwd=script_dir, check=True)
 
-        failures: list[tuple[str, float]] = []
+        failures: list[str] = []
         for case in cases:
-            case_dir = output_root / case.name
-            num_time, num_stress = load_monitor_stress(case_dir)
-            ana_time, ana_stress = analytical_series(case, total_time=num_time[-1])
-            rel_error = compare_series(num_time, num_stress, ana_time, ana_stress)
-            print(f"[ok] {case.name}: max relative error = {rel_error:.3e}")
-            if rel_error > args.max_relative_error:
-                failures.append((case.name, rel_error))
+            data = load_monitor_case(output_root / case.name)
+            reference = analytical_stress(case, data.time_s)
+            metrics = pointwise_error_metrics(data.mean_abs_stress, reference)
+            print(
+                f"[stress] {case.name}: "
+                f"mean={100.0 * metrics.mean_fraction:.3e}%, "
+                f"max={100.0 * metrics.max_fraction:.3e}%"
+            )
+            if metrics.max_fraction > args.max_relative_error:
+                failures.append(
+                    f"{case.name} stress={metrics.max_fraction:.3e}"
+                )
+
+            rate_errors = recovered_rate_errors(case, data)
+            if rate_errors:
+                max_rate_error = max(rate_errors)
+                print(
+                    f"[rate]   {case.name}: "
+                    f"max relative error={max_rate_error:.3e}"
+                )
+                if max_rate_error > args.max_rate_relative_error:
+                    failures.append(
+                        f"{case.name} rate={max_rate_error:.3e}"
+                    )
+
+        healing_error, linear_deficit = check_healing(
+            output_root / HEALING_CASE.name
+        )
+        print(
+            "[healing] "
+            f"max relative error={healing_error:.3e}, "
+            f"linear-growth deficit={linear_deficit:.3e}"
+        )
+        if healing_error > HEALING_RELATIVE_TOLERANCE:
+            failures.append(f"healing={healing_error:.3e}")
 
         if failures:
-            details = ", ".join(f"{name}={err:.3e}" for name, err in failures)
-            raise SystemExit(f"Benchmark check failed: {details}")
+            raise SystemExit("Benchmark check failed: " + ", ".join(failures))
     finally:
         if args.keep_output:
             print(f"[kept] {output_root}")

--- a/benchmarks/simple_shear_rsf/plot_simple_shear_benchmark.py
+++ b/benchmarks/simple_shear_rsf/plot_simple_shear_benchmark.py
@@ -1,296 +1,127 @@
 #!/usr/bin/env python3
-"""Plot monitor-based simple-shear benchmark results against analytical curves."""
+"""Plot the paper's local EP/RSF benchmark and its pointwise errors."""
 
 from __future__ import annotations
 
 import argparse
+import csv
+import math
 import os
+import shutil
 import sys
-from math import pi, sqrt
 from pathlib import Path
 from typing import Iterable
 
 sys.dont_write_bytecode = True
 
 import matplotlib
+
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
+import matplotlib.tri as mtri
 import numpy as np
+from matplotlib.ticker import LogLocator, NullFormatter
 
-from run_simple_shear_benchmark import BENCHMARK_CASES, GROUP_ORDER, BenchmarkCase
+from benchmark_reference import (
+    analytical_state_ratio,
+    analytical_stress,
+    load_monitor_case,
+    pointwise_error_metrics,
+    slip_rate,
+)
+from run_simple_shear_benchmark import (
+    BENCHMARK_CASES,
+    GROUP_ORDER,
+    BenchmarkCase,
+)
 
 
-VX_TOP = 1e-5
-SHEAR_MODULUS = 200.0e6
-COHESION = 1.0e6
-DT = 1.0
-STRESS_SCALE = 1e-6
-LINE_W = 2.2
-MARKER_SIZE = 6.5
-MARKER_EDGE_W = 1.5
+STRESS_SCALE = 1.0e-6
+GROUP_TITLE = {
+    "ep": "Elastoplastic",
+    "steady_ab_neg": r"Steady-state RSF ($a-b<0$)",
+    "aging_ab_neg": r"Aging-law RSF ($a-b<0$)",
+}
 
 
 def set_plot_style() -> None:
     try:
         from matplotlib import font_manager
 
-        nimbus_paths = [
+        for font_path in (
             "/usr/share/fonts/opentype/urw-base35/NimbusSans-Regular.otf",
             "/usr/share/fonts/opentype/urw-base35/NimbusSans-Bold.otf",
             "/usr/share/fonts/opentype/urw-base35/NimbusSans-Italic.otf",
-        ]
-        for path in nimbus_paths:
-            if os.path.isfile(path):
-                font_manager.fontManager.addfont(path)
+        ):
+            if os.path.isfile(font_path):
+                font_manager.fontManager.addfont(font_path)
     except Exception:
-        # Font configuration is optional; ignore any errors so plotting still works
-        print("Warning: failed to configure Nimbus Sans fonts; using default matplotlib fonts.", file=sys.stderr)
+        print(
+            "Warning: failed to configure Nimbus Sans fonts; using defaults.",
+            file=sys.stderr,
+        )
 
     plt.rcParams.update(
         {
             "font.family": "sans-serif",
-            "font.sans-serif": ["Nimbus Sans", "Arial", "Liberation Sans", "DejaVu Sans"],
-            "font.size": 15,
-            "axes.labelsize": 18,
-            "axes.titlesize": 16,
-            "legend.fontsize": 11,
-            "xtick.labelsize": 13,
-            "ytick.labelsize": 13,
-            "axes.linewidth": 2.4,
-            "lines.linewidth": LINE_W,
+            "font.sans-serif": [
+                "Nimbus Sans",
+                "Arial",
+                "Liberation Sans",
+                "DejaVu Sans",
+            ],
+            "font.size": 9.0,
+            "axes.labelsize": 10.0,
+            "axes.titlesize": 10.5,
+            "legend.fontsize": 7.6,
+            "xtick.labelsize": 8.0,
+            "ytick.labelsize": 8.0,
+            "axes.linewidth": 1.0,
+            "lines.linewidth": 1.7,
+            "pdf.fonttype": 42,
+            "ps.fonttype": 42,
         }
     )
 
 
-def style_axis(ax: plt.Axes, panel_tag: str, title: str) -> None:
-    ax.set_title(title, fontweight="bold")
-    ax.set_xlabel("Time (s)", fontweight="bold")
-    ax.set_ylabel(r"$|\sigma_{xy}|$ (MPa)", fontweight="bold")
-    ax.text(
-        0.02,
-        0.97,
-        panel_tag,
-        transform=ax.transAxes,
-        va="top",
-        ha="left",
-        fontsize=14,
-        fontweight="bold",
-    )
-    ax.tick_params(axis="both", which="both", width=2.4, length=6.5)
-    for label in ax.get_xticklabels() + ax.get_yticklabels():
-        label.set_fontweight("bold")
-    for spine in ax.spines.values():
-        spine.set_linewidth(2.4)
-    ax.grid(False)
+def case_color(index: int) -> str:
+    return ("#0072B2", "#D55E00", "#009E73")[index]
 
 
-def style_legend(legend: plt.Legend | None) -> None:
-    if legend is None:
-        return
-    legend.set_frame_on(False)
-    for text in legend.get_texts():
-        text.set_fontweight("bold")
+def case_linestyle(index: int) -> str:
+    return ("-", "--", ":")[index]
 
 
-def pow10_label(x: float) -> str:
-    if x == 0:
-        return "0"
-    exp = int(np.round(np.log10(x)))
-    return rf"10^{{{exp}}}"
+def case_marker(index: int) -> str:
+    return ("o", "s", "^")[index]
 
 
-def analytical_ep(phi_deg: float, total_time: float) -> tuple[np.ndarray, np.ndarray]:
-    phi = phi_deg * np.pi / 180.0
-    sf = np.sin(phi)
-    nphi = (1.0 + sf) / (1.0 - sf)
-    npsi = 1.0
-
-    nstep = int(total_time / DT) + 1
-    time_s = DT * np.arange(nstep, dtype=float)
-    stress_xy = np.zeros(nstep, dtype=float)
-
-    for i in range(1, nstep):
-        d_exy = 0.5 * VX_TOP * DT
-        d_stress_el = 2.0 * SHEAR_MODULUS * d_exy
-        stress_el = stress_xy[i - 1] + d_stress_el
-
-        s1_el = -stress_el
-        s3_el = stress_el
-        yield_fn = s1_el - s3_el * nphi + 2.0 * COHESION * sqrt(nphi)
-
-        if yield_fn > 0.0:
-            stress_xy[i] = stress_el
-        else:
-            d_beta = yield_fn / (2.0 * SHEAR_MODULUS * (1.0 + nphi * npsi))
-            s3_bar = s3_el + 2.0 * SHEAR_MODULUS * d_beta * npsi
-            stress_xy[i] = s3_bar
-
-    return time_s, stress_xy
-
-
-def effective_velocity() -> float:
-    v1 = VX_TOP / 3.0
-    v2 = 2.0 * VX_TOP / 3.0
-    return float(np.sqrt(v1 * v2))
-
-
-def analytical_rsf_steady(phi_deg: float, a: float, b: float, v0: float, total_time: float) -> tuple[np.ndarray, np.ndarray]:
-    phi0 = phi_deg * pi / 180.0
-    mu0 = np.tan(phi0)
-    velocity = effective_velocity()
-
-    nstep = int(total_time / DT) + 1
-    time_s = DT * np.arange(nstep, dtype=float)
-    stress_xy = np.zeros(nstep, dtype=float)
-
-    mu_ss = max(mu0 + (a - b) * np.log(velocity / v0), 1.0e-6)
-    phi_eff = np.arctan(mu_ss)
-    sf_eff = np.sin(phi_eff)
-    nphi_eff = (1.0 + sf_eff) / (1.0 - sf_eff)
-    npsi = 1.0
-
-    for i in range(1, nstep):
-        d_exy = 0.5 * VX_TOP * DT
-        d_stress_el = 2.0 * SHEAR_MODULUS * d_exy
-        stress_el = stress_xy[i - 1] + d_stress_el
-
-        s1_el = -stress_el
-        s3_el = stress_el
-        yield_fn = s1_el - nphi_eff * s3_el + 2.0 * COHESION * np.sqrt(nphi_eff)
-
-        if yield_fn > 0.0:
-            stress_xy[i] = stress_el
-        else:
-            d_beta = yield_fn / (2.0 * SHEAR_MODULUS * (1.0 + nphi_eff * npsi))
-            s3_bar = s3_el + 2.0 * SHEAR_MODULUS * d_beta * npsi
-            stress_xy[i] = s3_bar
-
-    return time_s, stress_xy
-
-
-def analytical_rsf_aging(phi_deg: float, a: float, b: float, dc: float, v0: float, total_time: float) -> tuple[np.ndarray, np.ndarray]:
-    phi0 = phi_deg * pi / 180.0
-    mu0 = np.tan(phi0)
-    velocity = max(effective_velocity(), 1.0e-12)
-    theta = dc / v0
-
-    nstep = int(total_time / DT) + 1
-    time_s = DT * np.arange(nstep, dtype=float)
-    stress_xy = np.zeros(nstep, dtype=float)
-    npsi = 1.0
-
-    for i in range(1, nstep):
-        d_exy = 0.5 * VX_TOP * DT
-        d_stress_el = 2.0 * SHEAR_MODULUS * d_exy
-        stress_el = stress_xy[i - 1] + d_stress_el
-
-        theta = theta + DT * (1.0 - velocity * theta / dc)
-        theta = max(theta, 1.0e-30)
-        mu = max(mu0 + a * np.log(velocity / v0) + b * np.log((theta * v0) / dc), 1.0e-6)
-        phi_eff = np.arctan(mu)
-        sf_eff = np.sin(phi_eff)
-        nphi_eff = (1.0 + sf_eff) / (1.0 - sf_eff)
-
-        s1_el = -stress_el
-        s3_el = stress_el
-        yield_fn = s1_el - nphi_eff * s3_el + 2.0 * COHESION * np.sqrt(nphi_eff)
-
-        if yield_fn > 0.0:
-            stress_xy[i] = stress_el
-        else:
-            d_beta = yield_fn / (2.0 * SHEAR_MODULUS * (1.0 + nphi_eff * npsi))
-            s3_bar = s3_el + 2.0 * SHEAR_MODULUS * d_beta * npsi
-            stress_xy[i] = s3_bar
-
-    return time_s, stress_xy
-
-
-def analytical_series(case: BenchmarkCase, total_time: float) -> tuple[np.ndarray, np.ndarray]:
+def parameter_text(case: BenchmarkCase) -> str:
     if case.group == "ep":
-        return analytical_ep(case.friction_angle_deg, total_time)
-    if case.group in ("steady_ab_pos", "steady_ab_neg"):
-        return analytical_rsf_steady(
-            phi_deg=case.friction_angle_deg,
-            a=case.direct_a,
-            b=case.evolution_b,
-            v0=case.characteristic_velocity,
-            total_time=total_time,
-        )
-    if case.group == "aging_ab_neg":
-        return analytical_rsf_aging(
-            phi_deg=case.friction_angle_deg,
-            a=case.direct_a,
-            b=case.evolution_b,
-            dc=case.characteristic_distance,
-            v0=case.characteristic_velocity,
-            total_time=total_time,
-        )
-    raise ValueError(f"Unsupported group: {case.group}")
+        return rf"$\phi={case.friction_angle_deg:.0f}^\circ$"
+    if case.group == "steady_ab_neg":
+        exponent = int(round(math.log10(case.characteristic_velocity)))
+        return rf"$V_0=10^{{{exponent}}}$ m s$^{{-1}}$"
+    exponent = int(math.floor(math.log10(case.characteristic_distance)))
+    coefficient = case.characteristic_distance / 10.0**exponent
+    if abs(coefficient - 1.0) < 1.0e-9:
+        return rf"$D_c=10^{{{exponent}}}$ m"
+    return rf"$D_c={coefficient:g}\times10^{{{exponent}}}$ m"
 
 
-def load_monitor_stress(case_dir: Path) -> tuple[np.ndarray, np.ndarray]:
-    csv_paths = sorted(case_dir.glob("monitor_point_*.csv"))
-    if not csv_paths:
-        raise FileNotFoundError(f"No monitor CSV found in {case_dir}")
-
-    series: list[tuple[np.ndarray, np.ndarray]] = []
-    for csv_path in csv_paths:
-        arr = np.genfromtxt(csv_path, delimiter=",", names=True, dtype=None, encoding="utf-8")
-        arr = np.atleast_1d(arr)
-        names = arr.dtype.names or ()
-        if "time_s" not in names or "stress_2" not in names:
-            raise ValueError(f"Missing required columns in {csv_path}")
-
-        time_s = np.asarray(arr["time_s"], dtype=float)
-        stress_xy = np.abs(np.asarray(arr["stress_2"], dtype=float))
-        order = np.argsort(time_s)
-        series.append((time_s[order], stress_xy[order]))
-
-    ref_time = series[0][0]
-    stacked = [series[0][1]]
-    for idx, (time_s, stress_xy) in enumerate(series[1:], start=1):
-        if time_s.shape != ref_time.shape or not np.allclose(time_s, ref_time):
-            raise ValueError(
-                f"Monitor time axis mismatch between point 0 and point {idx} in {case_dir}"
-            )
-        stacked.append(stress_xy)
-
-    mean_abs_stress = np.mean(np.vstack(stacked), axis=0)
-    return ref_time, mean_abs_stress
-
-
-def case_label(case: BenchmarkCase) -> str:
-    if case.group == "ep":
-        return rf"$\phi = {case.friction_angle_deg:.0f}^\circ$"
-    if case.group in ("steady_ab_pos", "steady_ab_neg"):
-        return rf"$V_0 = {pow10_label(case.characteristic_velocity)}$"
-    return rf"$D_c = {pow10_label(case.characteristic_distance)}$"
-
-
-def case_color(case: BenchmarkCase) -> str:
-    palette = {
-        "ep_phi30": "#1f77b4",
-        "ep_phi20": "#ff7f0e",
-        "ep_phi10": "#2ca02c",
-        "steady_ab_pos_v0_1e-6": "#1f77b4",
-        "steady_ab_pos_v0_1e-5": "#ff7f0e",
-        "steady_ab_pos_v0_1e-4": "#2ca02c",
-        "steady_ab_neg_v0_1e-6": "#1f77b4",
-        "steady_ab_neg_v0_1e-5": "#ff7f0e",
-        "steady_ab_neg_v0_1e-4": "#2ca02c",
-        "aging_ab_neg_dc_1e-6": "#1f77b4",
-        "aging_ab_neg_dc_1e-5": "#ff7f0e",
-        "aging_ab_neg_dc_1e-4": "#2ca02c",
-    }
-    return palette[case.name]
-
-
-def selected_cases(groups: Iterable[str], names: Iterable[str]) -> dict[str, list[BenchmarkCase]]:
+def selected_cases(
+    groups: Iterable[str],
+    names: Iterable[str],
+) -> dict[str, list[BenchmarkCase]]:
     grouped = {group: [] for group in GROUP_ORDER}
-    allowed = set(groups)
+    allowed_groups = set(groups)
     allowed_names = set(names)
+    known_names = {case.name for case in BENCHMARK_CASES}
+    missing = sorted(allowed_names - known_names)
+    if missing:
+        raise ValueError(f"Unknown benchmark case(s): {', '.join(missing)}")
     for case in BENCHMARK_CASES:
-        if case.group not in allowed:
+        if case.group not in allowed_groups:
             continue
         if allowed_names and case.name not in allowed_names:
             continue
@@ -298,23 +129,133 @@ def selected_cases(groups: Iterable[str], names: Iterable[str]) -> dict[str, lis
     return grouped
 
 
-def compare_series(num_time: np.ndarray, num_stress: np.ndarray, ana_time: np.ndarray, ana_stress: np.ndarray) -> float:
-    ana_on_num = np.interp(num_time, ana_time, ana_stress)
-    scale = max(np.max(np.abs(ana_on_num)), 1.0)
-    return float(np.max(np.abs(num_stress - ana_on_num)) / scale)
+def draw_schematic(axis: plt.Axes) -> None:
+    points = np.array(
+        ((0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0))
+    )
+    triangles = np.array(((0, 1, 3), (1, 2, 3)), dtype=int)
+    mesh = mtri.Triangulation(points[:, 0], points[:, 1], triangles)
+    axis.triplot(mesh, color="black", linewidth=1.2)
+    axis.scatter(points[:, 0], points[:, 1], s=22, color="black", zorder=3)
+
+    green = "#009E73"
+    axis.annotate(
+        "",
+        xy=(0.5, 0.5),
+        xytext=(0.0, 0.0),
+        arrowprops={
+            "arrowstyle": "<->",
+            "color": green,
+            "linewidth": 1.1,
+            "shrinkA": 1.5,
+            "shrinkB": 0.0,
+        },
+    )
+    foot = np.array((0.5, 0.5))
+    along = np.array((1.0, -1.0)) / math.sqrt(2.0)
+    inward = np.array((-1.0, -1.0)) / math.sqrt(2.0)
+    first = foot + 0.065 * along
+    second = foot + 0.065 * inward
+    right_angle = np.vstack((first, first + second - foot, second))
+    axis.plot(right_angle[:, 0], right_angle[:, 1], color=green, linewidth=0.8)
+    axis.text(
+        0.32,
+        0.19,
+        r"$w$",
+        color=green,
+        fontsize=10.5,
+        ha="center",
+        va="center",
+    )
+    axis.text(
+        0.5,
+        -0.22,
+        r"$\dot\varepsilon_{\mathrm{II}}=v_x/2H$ in both elements",
+        color="#555555",
+        fontsize=8.6,
+        ha="center",
+        va="center",
+    )
+
+    for x_value in (0.0, 1.0):
+        axis.plot(
+            (x_value, x_value - 0.05, x_value + 0.05, x_value),
+            (0.0, -0.10, -0.10, 0.0),
+            color="black",
+            linewidth=0.9,
+        )
+        axis.arrow(
+            x_value,
+            1.0,
+            0.19,
+            0.0,
+            head_width=0.035,
+            head_length=0.05,
+            length_includes_head=True,
+            color="#0072B2",
+            linewidth=1.0,
+        )
+
+    axis.text(
+        0.5,
+        1.07,
+        r"$v_x=10^{-5}$ m s$^{-1}$",
+        ha="center",
+        va="bottom",
+        fontsize=10,
+    )
+    axis.set_xlim(-0.12, 1.22)
+    axis.set_ylim(-0.30, 1.16)
+    axis.set_aspect("equal", adjustable="box")
+    axis.set_xlabel("x (m)")
+    axis.set_ylabel("y (m)")
+    axis.set_xticks((0.0, 0.5, 1.0))
+    axis.set_yticks((0.0, 0.5, 1.0))
+    axis.tick_params(width=1.0, length=4)
+    axis.set_title("Simple-shear benchmark", pad=11)
+
+
+def style_stress_axis(axis: plt.Axes, title: str) -> None:
+    axis.set_title(title, pad=5)
+    axis.set_ylabel(r"$|\sigma_{xy}|$ (MPa)")
+    axis.set_xlim(0.0, 2000.0)
+    axis.tick_params(width=1.0, length=4, labelbottom=False)
+
+
+def style_error_axis(axis: plt.Axes) -> None:
+    axis.set_xlim(0.0, 2000.0)
+    axis.set_xlabel("Time (s)")
+    axis.set_ylabel("Rel. error\n(%)", labelpad=3)
+    axis.set_yscale("log")
+    axis.yaxis.set_major_locator(LogLocator(base=10, numticks=4))
+    axis.yaxis.set_minor_formatter(NullFormatter())
+    axis.tick_params(width=0.9, length=3.5)
+
+
+def add_panel_label(axis: plt.Axes, label: str) -> None:
+    axis.text(
+        -0.17,
+        1.08,
+        label,
+        transform=axis.transAxes,
+        ha="left",
+        va="top",
+        fontsize=12,
+        fontweight="bold",
+    )
 
 
 def cleanup_pycache(root_dir: Path) -> None:
     for path in root_dir.rglob("__pycache__"):
         if path.is_dir():
-            import shutil
-
             shutil.rmtree(path, ignore_errors=True)
 
 
 def main() -> None:
     script_dir = Path(__file__).resolve().parent
-    parser = argparse.ArgumentParser(description="Plot the monitor-based simple-shear benchmark suite.")
+    parser = argparse.ArgumentParser(
+        description="Plot the paper's monitor-based simple-shear benchmark."
+    )
     parser.add_argument(
         "--output-root",
         type=Path,
@@ -344,18 +285,18 @@ def main() -> None:
     parser.add_argument(
         "--check",
         action="store_true",
-        help="Fail if any loaded numerical curve exceeds the relative error tolerance.",
+        help="Fail if any loaded stress curve exceeds the error tolerance.",
     )
     parser.add_argument(
         "--no-save",
         action="store_true",
-        help="Do not save a PNG. Useful for CI/functional checks.",
+        help="Do not save a figure or metrics CSV.",
     )
     parser.add_argument(
         "--max-relative-error",
         type=float,
-        default=5e-3,
-        help="Tolerance used with --check.",
+        default=2.0e-5,
+        help="Fractional pointwise error tolerance used with --check.",
     )
     args = parser.parse_args()
 
@@ -363,83 +304,226 @@ def main() -> None:
     output_root = args.output_root.resolve()
     set_plot_style()
 
-    titles = {
-        "ep": "EP Benchmark",
-        "steady_ab_pos": "Steady RSF, a-b > 0",
-        "steady_ab_neg": "Steady RSF, a-b < 0",
-        "aging_ab_neg": "Aging RSF, a-b < 0",
-    }
-    panel_tags = {
-        "ep": "(a)",
-        "steady_ab_pos": "(b)",
-        "steady_ab_neg": "(c)",
-        "aging_ab_neg": "(d)",
-    }
+    figure = plt.figure(figsize=(7.4, 7.0))
+    outer = figure.add_gridspec(
+        2,
+        2,
+        hspace=0.30,
+        wspace=0.30,
+        left=0.095,
+        right=0.965,
+        top=0.945,
+        bottom=0.065,
+    )
+    schematic_axis = figure.add_subplot(outer[0, 0])
+    draw_schematic(schematic_axis)
+    add_panel_label(schematic_axis, "a")
 
-    fig, axes = plt.subplots(2, 2, figsize=(13.5, 9.5), constrained_layout=True)
-    axes_by_group = dict(zip(GROUP_ORDER, axes.flatten()))
-
-    checked_errors: list[tuple[str, float]] = []
+    slots = {
+        "ep": outer[0, 1],
+        "steady_ab_neg": outer[1, 0],
+        "aging_ab_neg": outer[1, 1],
+    }
+    panel_labels = {
+        "ep": "b",
+        "steady_ab_neg": "c",
+        "aging_ab_neg": "d",
+    }
+    metrics_rows: list[dict[str, str | int | float]] = []
+    failures: list[str] = []
 
     for group in GROUP_ORDER:
-        if group not in grouped_cases or not grouped_cases[group]:
-            continue
+        inner = slots[group].subgridspec(
+            2,
+            1,
+            height_ratios=[2.15, 1.0],
+            hspace=0.10,
+        )
+        stress_axis = figure.add_subplot(inner[0])
+        error_axis = figure.add_subplot(inner[1], sharex=stress_axis)
+        add_panel_label(stress_axis, panel_labels[group])
 
-        ax = axes_by_group[group]
-        style_axis(ax, panel_tags[group], titles[group])
-
-        for case in grouped_cases[group]:
+        for index, case in enumerate(grouped_cases[group]):
             case_dir = output_root / case.name
             if not case_dir.is_dir():
-                print(f"[skip] missing case directory: {case_dir}")
+                message = f"missing case directory: {case_dir}"
+                print(f"[skip] {message}", file=sys.stderr)
+                if args.check:
+                    failures.append(message)
                 continue
 
-            num_time, num_stress = load_monitor_stress(case_dir)
-            ana_time, ana_stress = analytical_series(case, total_time=float(num_time[-1]))
-            rel_error = compare_series(num_time, num_stress, ana_time, ana_stress)
-            checked_errors.append((case.name, rel_error))
+            data = load_monitor_case(case_dir)
+            numerical = data.mean_abs_stress
+            reference = analytical_stress(case, data.time_s)
+            metrics = pointwise_error_metrics(numerical, reference)
+            errors_pct = [
+                100.0 * abs(num - ref) / abs(ref)
+                for num, ref in zip(numerical[1:], reference[1:])
+            ]
 
-            color = case_color(case)
-            label = case_label(case)
-            ax.plot(
-                ana_time,
-                ana_stress * STRESS_SCALE,
+            color = case_color(index)
+            linestyle = case_linestyle(index)
+            marker = case_marker(index)
+            stress_axis.plot(
+                data.time_s,
+                np.asarray(reference) * STRESS_SCALE,
                 color=color,
-                linestyle="-",
-                linewidth=LINE_W,
-                label=f"Analytic, {label}",
+                linestyle=linestyle,
+                label=parameter_text(case),
             )
-            ax.plot(
-                num_time,
-                num_stress * STRESS_SCALE,
+            marker_slice = slice(index, None, 3)
+            stress_axis.plot(
+                np.asarray(data.time_s)[marker_slice],
+                np.asarray(numerical)[marker_slice] * STRESS_SCALE,
                 linestyle="none",
-                marker="o",
-                markersize=MARKER_SIZE,
+                marker=marker,
+                markersize=4.2,
                 markerfacecolor="none",
-                markeredgewidth=MARKER_EDGE_W,
+                markeredgewidth=1.0,
                 color=color,
-                label=f"DynEarthSol, {label}",
             )
-            print(f"[ok] {case.name}: max relative error = {rel_error:.3e}")
+            error_axis.plot(
+                data.time_s[1:],
+                errors_pct,
+                color=color,
+                linestyle=linestyle,
+                linewidth=1.2,
+            )
 
-        handles, labels = ax.get_legend_handles_labels()
+            element_spread = max(
+                abs(left - right)
+                for left, right in zip(
+                    data.stress_by_element[0],
+                    data.stress_by_element[1],
+                )
+            )
+            stress_scale = max(
+                max(values) for values in data.stress_by_element
+            )
+            metrics_rows.append(
+                {
+                    "case": case.name,
+                    "group": group,
+                    "parameter": parameter_text(case).replace("$", ""),
+                    "samples": metrics.samples,
+                    "mean_pct": 100.0 * metrics.mean_fraction,
+                    "max_pct": 100.0 * metrics.max_fraction,
+                    "final_pct": 100.0 * metrics.final_fraction,
+                    "element_spread_pct": (
+                        100.0 * element_spread / max(stress_scale, 1.0)
+                    ),
+                }
+            )
+            print(
+                f"[ok] {case.name}: "
+                f"mean={100.0 * metrics.mean_fraction:.3e}%, "
+                f"max={100.0 * metrics.max_fraction:.3e}%"
+            )
+            if args.check and metrics.max_fraction > args.max_relative_error:
+                failures.append(
+                    f"{case.name}={metrics.max_fraction:.3e}"
+                )
+
+        style_stress_axis(stress_axis, GROUP_TITLE[group])
+        style_error_axis(error_axis)
+        handles, labels = stress_axis.get_legend_handles_labels()
         if handles:
-            legend = ax.legend(handles, labels, loc="best")
-            style_legend(legend)
+            stress_axis.legend(
+                handles,
+                labels,
+                loc="lower right",
+                frameon=False,
+                handlelength=2.4,
+                borderaxespad=0.3,
+            )
+
+        if group == "aging_ab_neg":
+            inset = stress_axis.inset_axes((0.520, 0.485, 0.445, 0.375))
+            for index, case in enumerate(grouped_cases[group]):
+                transient_dir = output_root / f"{case.name}_transient"
+                if not transient_dir.is_dir():
+                    continue
+                transient = load_monitor_case(transient_dir)
+                state = transient.state_by_element[1]
+                if state is None:
+                    continue
+                theta_ss = [
+                    case.characteristic_distance / slip_rate(value)
+                    for value in transient.time_s
+                ]
+                numerical_ratio = [
+                    value / steady
+                    for value, steady in zip(state, theta_ss)
+                ]
+                reference_ratio = analytical_state_ratio(
+                    case,
+                    transient.time_s,
+                )
+                color = case_color(index)
+                linestyle = case_linestyle(index)
+                marker = case_marker(index)
+                inset.plot(
+                    transient.time_s[1:],
+                    reference_ratio[1:],
+                    color=color,
+                    linestyle=linestyle,
+                    linewidth=1.3,
+                )
+                requested_times = np.geomspace(
+                    1.0,
+                    float(transient.time_s[-1]),
+                    11,
+                ) * (1.0 + 0.09 * index)
+                indices = np.unique(
+                    np.clip(
+                        np.searchsorted(transient.time_s, requested_times),
+                        1,
+                        len(transient.time_s) - 1,
+                    )
+                )
+                inset.plot(
+                    np.asarray(transient.time_s)[indices],
+                    np.asarray(numerical_ratio)[indices],
+                    linestyle="none",
+                    marker=marker,
+                    markersize=3.6,
+                    markerfacecolor="none",
+                    markeredgewidth=0.9,
+                    color=color,
+                )
+            inset.set_xscale("log")
+            inset.set_xlim(1.0, 2000.0)
+            inset.set_xlabel("Time (s)", fontsize=7.2, labelpad=1.5)
+            inset.set_ylabel(
+                r"$\theta/\theta_{\mathrm{ss}}$",
+                fontsize=7.6,
+                labelpad=1.5,
+            )
+            inset.set_yticks((0.7, 0.8, 0.9, 1.0))
+            inset.tick_params(labelsize=6.6, width=0.8, length=2.8)
 
     output_path = args.output.resolve()
     if not args.no_save:
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        fig.savefig(output_path, dpi=300)
-    plt.close(fig)
-    if not args.no_save:
+        figure.savefig(output_path, dpi=300)
+        metrics_path = output_path.with_name(
+            f"{output_path.stem}_metrics.csv"
+        )
+        if metrics_rows:
+            with metrics_path.open("w", encoding="utf-8", newline="") as handle:
+                writer = csv.DictWriter(
+                    handle,
+                    fieldnames=list(metrics_rows[0].keys()),
+                )
+                writer.writeheader()
+                writer.writerows(metrics_rows)
         print(f"[saved] {output_path}")
+        if metrics_rows:
+            print(f"[saved] {metrics_path}")
+    plt.close(figure)
 
-    if args.check:
-        failed = [(name, err) for name, err in checked_errors if err > args.max_relative_error]
-        if failed:
-            details = ", ".join(f"{name}={err:.3e}" for name, err in failed)
-            raise SystemExit(f"Benchmark check failed: {details}")
+    if failures:
+        raise SystemExit("Benchmark check failed: " + ", ".join(failures))
 
 
 if __name__ == "__main__":

--- a/benchmarks/simple_shear_rsf/run_simple_shear_benchmark.py
+++ b/benchmarks/simple_shear_rsf/run_simple_shear_benchmark.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run the simple-shear benchmark suite from one base CFG template."""
+"""Generate and run the paper's local EP/RSF benchmark cases."""
 
 from __future__ import annotations
 
@@ -15,6 +15,14 @@ from typing import Iterable
 sys.dont_write_bytecode = True
 
 
+SHEAR_MAX_STEPS = 200_000
+SHEAR_MONITOR_STEP_INTERVAL = 4_000
+TRANSIENT_MONITOR_STEP_INTERVAL = 100
+SHEAR_FIXED_DT_S = 0.01
+HEALING_MAX_STEPS = 1_546
+HEALING_FIXED_DT_S = 259_200.0
+
+
 @dataclass(frozen=True)
 class BenchmarkCase:
     name: str
@@ -28,22 +36,44 @@ class BenchmarkCase:
     state_var_model: int
 
 
+@dataclass(frozen=True)
+class RunSpec:
+    name: str
+    case: BenchmarkCase
+    max_steps: int
+    output_step_interval: int
+    monitor_step_interval: int
+    fixed_dt_s: float
+    upper_boundary_x_mode: int
+    upper_boundary_x_velocity: float
+    characteristic_speed_line: str
+
+
 BENCHMARK_CASES: tuple[BenchmarkCase, ...] = (
     BenchmarkCase("ep_phi30", "ep", "elasto-plastic", 30.0, 0.0, 0.0, 1e-3, 1e-5, 0),
     BenchmarkCase("ep_phi20", "ep", "elasto-plastic", 20.0, 0.0, 0.0, 1e-3, 1e-5, 0),
     BenchmarkCase("ep_phi10", "ep", "elasto-plastic", 10.0, 0.0, 0.0, 1e-3, 1e-5, 0),
-    BenchmarkCase("steady_ab_pos_v0_1e-6", "steady_ab_pos", "elasto-plastic-rate-state-friction", 30.0, 0.2, 0.1, 1e-3, 1e-6, 0),
-    BenchmarkCase("steady_ab_pos_v0_1e-5", "steady_ab_pos", "elasto-plastic-rate-state-friction", 30.0, 0.2, 0.1, 1e-3, 1e-5, 0),
-    BenchmarkCase("steady_ab_pos_v0_1e-4", "steady_ab_pos", "elasto-plastic-rate-state-friction", 30.0, 0.2, 0.1, 1e-3, 1e-4, 0),
     BenchmarkCase("steady_ab_neg_v0_1e-6", "steady_ab_neg", "elasto-plastic-rate-state-friction", 30.0, 0.2, 0.3, 1e-3, 1e-6, 0),
     BenchmarkCase("steady_ab_neg_v0_1e-5", "steady_ab_neg", "elasto-plastic-rate-state-friction", 30.0, 0.2, 0.3, 1e-3, 1e-5, 0),
     BenchmarkCase("steady_ab_neg_v0_1e-4", "steady_ab_neg", "elasto-plastic-rate-state-friction", 30.0, 0.2, 0.3, 1e-3, 1e-4, 0),
-    BenchmarkCase("aging_ab_neg_dc_1e-6", "aging_ab_neg", "elasto-plastic-rate-state-friction", 30.0, 0.2, 0.3, 1e-6, 1e-5, 1),
-    BenchmarkCase("aging_ab_neg_dc_1e-5", "aging_ab_neg", "elasto-plastic-rate-state-friction", 30.0, 0.2, 0.3, 1e-5, 1e-5, 1),
-    BenchmarkCase("aging_ab_neg_dc_1e-4", "aging_ab_neg", "elasto-plastic-rate-state-friction", 30.0, 0.2, 0.3, 1e-4, 1e-5, 1),
+    BenchmarkCase("aging_ab_neg_dc_1e-3", "aging_ab_neg", "elasto-plastic-rate-state-friction", 30.0, 0.2, 0.3, 1e-3, 1e-5, 1),
+    BenchmarkCase("aging_ab_neg_dc_3e-3", "aging_ab_neg", "elasto-plastic-rate-state-friction", 30.0, 0.2, 0.3, 3e-3, 1e-5, 1),
+    BenchmarkCase("aging_ab_neg_dc_1e-2", "aging_ab_neg", "elasto-plastic-rate-state-friction", 30.0, 0.2, 0.3, 1e-2, 1e-5, 1),
 )
 
-GROUP_ORDER = ("ep", "steady_ab_pos", "steady_ab_neg", "aging_ab_neg")
+HEALING_CASE = BenchmarkCase(
+    "healing_zero_velocity",
+    "healing",
+    "elasto-plastic-rate-state-friction",
+    30.0,
+    0.011,
+    0.017,
+    1e-2,
+    4e-9,
+    1,
+)
+
+GROUP_ORDER = ("ep", "steady_ab_neg", "aging_ab_neg")
 
 
 def candidate_executables(script_dir: Path) -> Iterable[Path]:
@@ -54,17 +84,17 @@ def candidate_executables(script_dir: Path) -> Iterable[Path]:
 
 def resolve_executable(script_dir: Path, explicit: str | None) -> Path:
     if explicit:
-        p = Path(explicit).expanduser().resolve()
-        if p.is_file() and os.access(p, os.X_OK):
-            return p
-        raise FileNotFoundError(f"--exe is not executable: {p}")
+        path = Path(explicit).expanduser().resolve()
+        if path.is_file() and os.access(path, os.X_OK):
+            return path
+        raise FileNotFoundError(f"--exe is not executable: {path}")
 
     env_exe = os.environ.get("DYNEXE")
     if env_exe:
-        p = Path(env_exe).expanduser().resolve()
-        if p.is_file() and os.access(p, os.X_OK):
-            return p
-        raise FileNotFoundError(f"DYNEXE is set but not executable: {p}")
+        path = Path(env_exe).expanduser().resolve()
+        if path.is_file() and os.access(path, os.X_OK):
+            return path
+        raise FileNotFoundError(f"DYNEXE is set but not executable: {path}")
 
     for candidate in candidate_executables(script_dir):
         if candidate.is_file() and os.access(candidate, os.X_OK):
@@ -79,11 +109,16 @@ def format_float(value: float) -> str:
     return f"{value:.17g}"
 
 
-def render_cfg(template_text: str, case: BenchmarkCase, max_steps: int, output_step_interval: int, monitor_step_interval: int) -> str:
+def render_cfg(template_text: str, spec: RunSpec) -> str:
+    case = spec.case
     replacements = {
         "__MODELNAME__": "result",
-        "__MAX_STEPS__": str(max_steps),
-        "__OUTPUT_STEP_INTERVAL__": str(output_step_interval),
+        "__MAX_STEPS__": str(spec.max_steps),
+        "__OUTPUT_STEP_INTERVAL__": str(spec.output_step_interval),
+        "__FIXED_DT__": format_float(spec.fixed_dt_s),
+        "__CHARACTERISTIC_SPEED_CONTROL__": spec.characteristic_speed_line,
+        "__UPPER_BOUNDARY_X_MODE__": str(spec.upper_boundary_x_mode),
+        "__UPPER_BOUNDARY_X_VELOCITY__": format_float(spec.upper_boundary_x_velocity),
         "__RHEOLOGY_TYPE__": case.rheology_type,
         "__FRICTION_ANGLE_DEG__": format_float(case.friction_angle_deg),
         "__DIRECT_A__": format_float(case.direct_a),
@@ -91,13 +126,18 @@ def render_cfg(template_text: str, case: BenchmarkCase, max_steps: int, output_s
         "__CHARACTERISTIC_DISTANCE__": format_float(case.characteristic_distance),
         "__CHARACTERISTIC_VELOCITY__": format_float(case.characteristic_velocity),
         "__STATE_VAR_MODEL__": str(case.state_var_model),
+        "__RSF_RATE_CONTROL__": (
+            "" if case.group == "ep" else "rsf_slip_rate_projection_option = 1"
+        ),
         "__MONITOR_PREFIX__": "monitor",
-        "__MONITOR_STEP_INTERVAL__": str(monitor_step_interval),
+        "__MONITOR_STEP_INTERVAL__": str(spec.monitor_step_interval),
     }
 
     rendered = template_text
     for old, new in replacements.items():
         rendered = rendered.replace(old, new)
+    if "__" in rendered:
+        raise ValueError(f"Unsubstituted CFG placeholder in {spec.name}")
     return rendered
 
 
@@ -107,11 +147,70 @@ def select_cases(groups: list[str], names: list[str]) -> list[BenchmarkCase]:
         allowed = set(groups)
         selected = [case for case in selected if case.group in allowed]
     if names:
+        known = {case.name for case in BENCHMARK_CASES}
+        missing = sorted(set(names) - known)
+        if missing:
+            raise ValueError(f"Unknown benchmark case(s): {', '.join(missing)}")
         allowed = set(names)
         selected = [case for case in selected if case.name in allowed]
     if not selected:
         raise ValueError("No benchmark cases selected.")
     return selected
+
+
+def make_run_specs(
+    cases: list[BenchmarkCase],
+    max_steps: int,
+    output_step_interval: int,
+    monitor_step_interval: int,
+    aging_transient: bool,
+    include_healing: bool,
+) -> list[RunSpec]:
+    specs = [
+        RunSpec(
+            case.name,
+            case,
+            max_steps,
+            output_step_interval,
+            monitor_step_interval,
+            SHEAR_FIXED_DT_S,
+            4,
+            1e-5,
+            "",
+        )
+        for case in cases
+    ]
+    if aging_transient:
+        specs.extend(
+            RunSpec(
+                f"{case.name}_transient",
+                case,
+                max_steps,
+                output_step_interval,
+                TRANSIENT_MONITOR_STEP_INTERVAL,
+                SHEAR_FIXED_DT_S,
+                4,
+                1e-5,
+                "",
+            )
+            for case in cases
+            if case.group == "aging_ab_neg"
+        )
+    if include_healing:
+        specs.append(
+            RunSpec(
+                HEALING_CASE.name,
+                HEALING_CASE,
+                HEALING_MAX_STEPS,
+                HEALING_MAX_STEPS,
+                1,
+                HEALING_FIXED_DT_S,
+                1,
+                0.0,
+                "characteristic_speed = 4e-9",
+            )
+        )
+    return specs
 
 
 def cleanup_case_dir(case_dir: Path) -> None:
@@ -138,20 +237,20 @@ def cleanup_pycache(root_dir: Path) -> None:
 
 def main() -> None:
     script_dir = Path(__file__).resolve().parent
-    parser = argparse.ArgumentParser(description="Run monitor-based simple-shear benchmark sweeps.")
+    parser = argparse.ArgumentParser(description="Run the paper's local EP/RSF benchmark suite.")
     parser.add_argument("--exe", default=None, help="Path to dynearthsol2d. If omitted, auto-detect.")
     parser.add_argument(
         "--groups",
         nargs="+",
         choices=GROUP_ORDER,
         default=list(GROUP_ORDER),
-        help="Benchmark groups to run.",
+        help="Simple-shear benchmark groups to run.",
     )
     parser.add_argument(
         "--cases",
         nargs="+",
         default=[],
-        help="Optional explicit case-name filter.",
+        help="Optional explicit simple-shear case-name filter.",
     )
     parser.add_argument(
         "--output-root",
@@ -162,20 +261,30 @@ def main() -> None:
     parser.add_argument(
         "--max-steps",
         type=int,
-        default=2000,
-        help="Number of time steps for each run.",
+        default=SHEAR_MAX_STEPS,
+        help="Number of 0.01 s steps for each simple-shear run.",
     )
     parser.add_argument(
         "--monitor-step-interval",
         type=int,
-        default=40,
-        help="Monitor output interval in solver steps.",
+        default=SHEAR_MONITOR_STEP_INTERVAL,
+        help="Simple-shear monitor interval in solver steps.",
     )
     parser.add_argument(
         "--output-step-interval",
         type=int,
-        default=2000,
-        help="Full-field output interval. Keep large because the benchmark reads monitor CSVs.",
+        default=None,
+        help="Full-field output interval. Defaults to --max-steps.",
+    )
+    parser.add_argument(
+        "--aging-transient",
+        action="store_true",
+        help="Also run aging cases with 1 s monitor output for the figure inset.",
+    )
+    parser.add_argument(
+        "--healing",
+        action="store_true",
+        help="Also run the paper's separate zero-velocity healing test.",
     )
     parser.add_argument(
         "--skip-run",
@@ -189,16 +298,24 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    output_step_interval = args.output_step_interval or args.max_steps
     if args.max_steps < 1:
         raise ValueError("--max-steps must be >= 1")
     if args.monitor_step_interval < 1:
         raise ValueError("--monitor-step-interval must be >= 1")
-    if args.output_step_interval < 1:
+    if output_step_interval < 1:
         raise ValueError("--output-step-interval must be >= 1")
 
-    selected_cases = select_cases(args.groups, args.cases)
-    template_path = script_dir / "simple_shear_base.cfg"
-    template_text = template_path.read_text(encoding="utf-8")
+    selected = select_cases(args.groups, args.cases)
+    specs = make_run_specs(
+        selected,
+        args.max_steps,
+        output_step_interval,
+        args.monitor_step_interval,
+        args.aging_transient,
+        args.healing,
+    )
+    template_text = (script_dir / "simple_shear_base.cfg").read_text(encoding="utf-8")
     output_root = args.output_root.resolve()
     output_root.mkdir(parents=True, exist_ok=True)
 
@@ -206,27 +323,17 @@ def main() -> None:
     if exe is not None:
         print(f"[exe] {exe}")
 
-    for index, case in enumerate(selected_cases, start=1):
-        case_dir = output_root / case.name
+    for index, spec in enumerate(specs, start=1):
+        case_dir = output_root / spec.name
         case_dir.mkdir(parents=True, exist_ok=True)
         if args.clean:
             cleanup_case_dir(case_dir)
             case_dir.mkdir(parents=True, exist_ok=True)
 
-        cfg_text = render_cfg(
-            template_text=template_text,
-            case=case,
-            max_steps=args.max_steps,
-            output_step_interval=args.output_step_interval,
-            monitor_step_interval=args.monitor_step_interval,
-        )
-        cfg_path = write_case_cfg(case_dir, cfg_text)
-        print(f"[prep] {index:02d}/{len(selected_cases)} {case.name} -> {cfg_path}")
-
-        if args.skip_run:
-            continue
-
-        subprocess.run([str(exe), str(cfg_path)], cwd=case_dir, check=True)
+        cfg_path = write_case_cfg(case_dir, render_cfg(template_text, spec))
+        print(f"[prep] {index:02d}/{len(specs)} {spec.name} -> {cfg_path}")
+        if not args.skip_run:
+            subprocess.run([str(exe), str(cfg_path)], cwd=case_dir, check=True)
 
     print("[done] benchmark case generation complete")
 

--- a/benchmarks/simple_shear_rsf/simple_shear_base.cfg
+++ b/benchmarks/simple_shear_rsf/simple_shear_base.cfg
@@ -14,11 +14,13 @@ remeshing_option = 0
 
 [control]
 gravity = 0
-fixed_dt = 1.0
+fixed_dt = __FIXED_DT__
+__CHARACTERISTIC_SPEED_CONTROL__
 inertial_scaling = 1e5
 surface_process_option = 0
 use_global_velocity_scaling = true
 damping_option = 1
+__RSF_RATE_CONTROL__
 
 [ic]
 weakzone_option = 0
@@ -33,9 +35,9 @@ vbc_y1 = 1
 vbc_val_y0 = 0
 vbc_val_y1 = 0
 vbc_z0 = 1
-vbc_z1 = 4
+vbc_z1 = __UPPER_BOUNDARY_X_MODE__
 vbc_val_z0 = 0
-vbc_val_z1 = 1e-5
+vbc_val_z1 = __UPPER_BOUNDARY_X_VELOCITY__
 
 surface_temperature = 273
 mantle_temperature = 273

--- a/dynearthsol.cxx
+++ b/dynearthsol.cxx
@@ -190,7 +190,9 @@ void init(const Param& param, Variables& var)
     // apply_vbcs reads for any node on two boundaries at once.
     create_boundary_normals(var, *var.bnormals, var.edge_vec, var.edge_slot);
     apply_vbcs(param, var, *var.vel); // Global-velocity scaling needs boundary conditions before compute_mass.
-    var.dt = compute_dt(param, var);  // Global-velocity scaling needs dt before compute_mass.
+    // The RSF state variable is initialized below; skip its bound for this
+    // bootstrap call. main() recomputes dt after state initialization.
+    var.dt = compute_dt(param, var, false);
     compute_mass(param, var, var.max_vbc_val, *var.volume_n, *var.mass, *var.tmass, *var.hmass, *var.ymass, *var.tmp_result);
 
 #ifdef USEMMG
@@ -875,6 +877,14 @@ int main(int argc, const char* argv[])
         apply_vbcs(param, var, *var.vel);
         if (param.control.has_moving_mesh)
             update_mesh(param, var);
+        else if (param.control.rsf_dtheta_max > 0.0) {
+            // Select the next step from the accepted velocity. The GVS mass
+            // must follow the same current rate used by the state bound.
+            var.dt = compute_dt(param, var);
+            compute_mass(param, var, var.max_vbc_val, *var.volume_n,
+                         *var.mass, *var.tmass, *var.hmass, *var.ymass,
+                         *var.tmp_result);
+        }
 
         // elastic stress/strain are objective (frame-indifferent)
         if (var.mat->rheol_type & MatProps::rh_elastic)

--- a/dynearthsol.cxx
+++ b/dynearthsol.cxx
@@ -422,6 +422,11 @@ void restart(const Param& param, Variables& var)
         if (!restored_state_variable) {
             std::cout << "  RSF restart fallback applied for missing state variable dataset.\n";
         }
+        if (param.control.rsf_slip_rate_projection_option ==
+            rsf_slip_rate_projection_total_strain_rate) {
+            update_strain_rate(var, *var.strain_rate);
+            #pragma acc wait
+        }
         refresh_rsf_friction(param, var, *var.dyn_fric_coeff, *var.state_variable);
     }
 

--- a/examples/defaults.cfg
+++ b/examples/defaults.cfg
@@ -160,6 +160,7 @@ resolution = 30e3
 #has_moving_mesh = yes
 #use_global_velocity_scaling = no
 #rsf_slip_rate_projection_option = 0 # 0: maximum-shear (historical default); 1: total-strain invariant
+#rsf_dtheta_max = 0                  # aging-law dt bound for option 1; 0 disables it
 
 #is_using_mixed_stress = yes
 

--- a/examples/defaults.cfg
+++ b/examples/defaults.cfg
@@ -255,6 +255,8 @@ resolution = 30e3
 #num_mattype_layers = 2
 #layer_mattypes = [0,1]
 #mattype_layer_depths = [0.5]
+#initial_stress_option = 0 # 0: legacy; 1: homogeneous absolute stress at gravity=0
+#initial_stress = [0,0,0] # 2-D [sxx,szz,sxz]; 3-D [sxx,syy,szz,sxy,sxz,syz]
 
 #weakzone_option = 1
 #is_restarting_weakzone = no

--- a/examples/defaults.cfg
+++ b/examples/defaults.cfg
@@ -159,6 +159,7 @@ resolution = 30e3
 
 #has_moving_mesh = yes
 #use_global_velocity_scaling = no
+#mass_scaling_reference_speed = shear # G/rho ceiling (historical); bulk selects K/rho
 #rsf_slip_rate_projection_option = 0 # 0: maximum-shear (historical default); 1: total-strain invariant
 #rsf_dtheta_max = 0                  # aging-law dt bound for option 1; 0 disables it
 

--- a/examples/defaults.cfg
+++ b/examples/defaults.cfg
@@ -159,6 +159,7 @@ resolution = 30e3
 
 #has_moving_mesh = yes
 #use_global_velocity_scaling = no
+#rsf_slip_rate_projection_option = 0 # 0: maximum-shear (historical default); 1: total-strain invariant
 
 #is_using_mixed_stress = yes
 

--- a/geometry.cxx
+++ b/geometry.cxx
@@ -115,6 +115,15 @@ static inline double current_strain_rate_invariant(
     return second_invariant(strain_rate);
 }
 
+#pragma acc routine seq
+static inline double mass_scaling_modulus(
+    const Param& param, const MatProps& mat, int e)
+{
+    return (param.control.mass_scaling_reference_speed ==
+            mass_scaling_speed_bulk) ?
+        mat.bulkm(e) : mat.shearm(e);
+}
+
 /* Given two points, returns the distance^2 */
 template <typename T>
 double dist2(T a, T b)
@@ -1714,7 +1723,11 @@ double compute_dt(const Param& param, Variables& var,
         minl = std::min(minl, minh);
 
         // Find global min delta t to meet CFL condition
-        global_dt_min = std::min(global_dt_min, minh/std::sqrt(var.mat->shearm(e)/var.mat->rho(e)) /5.0);
+        global_dt_min = std::min(
+            global_dt_min,
+            minh / std::sqrt(
+                mass_scaling_modulus(param, *var.mat, e) /
+                var.mat->rho(e)) / 5.0);
     }
 
     #pragma acc wait
@@ -1927,7 +1940,11 @@ void compute_mass(const Param &param, const Variables &var,
 
             if(param.control.use_global_velocity_scaling)
             {
-                double apprent_speed = std::min(pseudo_speed_ATP, std::sqrt(var.mat->shearm(e)/var.mat->rho(e))); // minimum speed
+                double apprent_speed = std::min(
+                    pseudo_speed_ATP,
+                    std::sqrt(
+                        mass_scaling_modulus(param, *var.mat, e) /
+                        var.mat->rho(e)));
 
                 rho = (param.control.is_quasi_static) ?
                 (*var.mat).bulkm(e) / (apprent_speed * apprent_speed) :  // pseudo density for quasi-static sim

--- a/geometry.cxx
+++ b/geometry.cxx
@@ -12,6 +12,109 @@
 #include "mesh.hpp"
 #include "output.hpp"
 
+#ifdef THREED
+#pragma acc routine seq
+static inline void get_geometry_shape_fn(
+    const Variables &var, int e,
+    double shpdx[4], double shpdy[4], double shpdz[4])
+{
+    ConstArrayIndirectAccessor d =
+        var.coord->view_const((*var.connectivity)[e]);
+    const double iv = 1.0 / (6.0 * (*var.volume)[e]);
+
+    const double x01 = d[0][0] - d[1][0];
+    const double x02 = d[0][0] - d[2][0];
+    const double x03 = d[0][0] - d[3][0];
+    const double x12 = d[1][0] - d[2][0];
+    const double x13 = d[1][0] - d[3][0];
+    const double x23 = d[2][0] - d[3][0];
+    const double y01 = d[0][1] - d[1][1];
+    const double y02 = d[0][1] - d[2][1];
+    const double y03 = d[0][1] - d[3][1];
+    const double y12 = d[1][1] - d[2][1];
+    const double y13 = d[1][1] - d[3][1];
+    const double y23 = d[2][1] - d[3][1];
+    const double z01 = d[0][2] - d[1][2];
+    const double z02 = d[0][2] - d[2][2];
+    const double z03 = d[0][2] - d[3][2];
+    const double z12 = d[1][2] - d[2][2];
+    const double z13 = d[1][2] - d[3][2];
+    const double z23 = d[2][2] - d[3][2];
+
+    shpdx[0] = iv * (y13*z12 - y12*z13);
+    shpdx[1] = iv * (y02*z23 - y23*z02);
+    shpdx[2] = iv * (y13*z03 - y03*z13);
+    shpdx[3] = iv * (y01*z02 - y02*z01);
+
+    shpdy[0] = iv * (z13*x12 - z12*x13);
+    shpdy[1] = iv * (z02*x23 - z23*x02);
+    shpdy[2] = iv * (z13*x03 - z03*x13);
+    shpdy[3] = iv * (z01*x02 - z02*x01);
+
+    shpdz[0] = iv * (x13*y12 - x12*y13);
+    shpdz[1] = iv * (x02*y23 - x23*y02);
+    shpdz[2] = iv * (x13*y03 - x03*y13);
+    shpdz[3] = iv * (x01*y02 - x02*y01);
+}
+#else
+#pragma acc routine seq
+static inline void get_geometry_shape_fn(
+    const Variables &var, int e, double shpdx[3], double shpdz[3])
+{
+    ConstArrayIndirectAccessor d =
+        var.coord->view_const((*var.connectivity)[e]);
+    const double iv = 1.0 / (2.0 * (*var.volume)[e]);
+
+    shpdx[0] = iv * (d[1][1] - d[2][1]);
+    shpdx[1] = iv * (d[2][1] - d[0][1]);
+    shpdx[2] = iv * (d[0][1] - d[1][1]);
+
+    shpdz[0] = iv * (d[2][0] - d[1][0]);
+    shpdz[1] = iv * (d[0][0] - d[2][0]);
+    shpdz[2] = iv * (d[1][0] - d[0][0]);
+}
+#endif
+
+#pragma acc routine seq
+static inline double current_strain_rate_invariant(
+    const Variables &var, int e)
+{
+#ifdef THREED
+    double shpdx[NODES_PER_ELEM];
+    double shpdy[NODES_PER_ELEM];
+    double shpdz[NODES_PER_ELEM];
+    get_geometry_shape_fn(var, e, shpdx, shpdy, shpdz);
+#else
+    double shpdx[NODES_PER_ELEM];
+    double shpdz[NODES_PER_ELEM];
+    get_geometry_shape_fn(var, e, shpdx, shpdz);
+#endif
+    ConstArrayIndirectAccessor v =
+        var.vel->view_const((*var.connectivity)[e]);
+    double strain_rate[NSTR] = {0.0};
+
+    #pragma acc loop seq
+    for (int i = 0; i < NODES_PER_ELEM; ++i) {
+        strain_rate[0] += v[i][0] * shpdx[i];
+#ifdef THREED
+        strain_rate[1] += v[i][1] * shpdy[i];
+        strain_rate[2] += v[i][2] * shpdz[i];
+        strain_rate[3] +=
+            0.5 * (v[i][0] * shpdy[i] + v[i][1] * shpdx[i]);
+        strain_rate[4] +=
+            0.5 * (v[i][0] * shpdz[i] + v[i][2] * shpdx[i]);
+        strain_rate[5] +=
+            0.5 * (v[i][1] * shpdz[i] + v[i][2] * shpdy[i]);
+#else
+        strain_rate[1] += v[i][1] * shpdz[i];
+        strain_rate[2] +=
+            0.5 * (v[i][0] * shpdz[i] + v[i][1] * shpdx[i]);
+#endif
+    }
+
+    return second_invariant(strain_rate);
+}
+
 /* Given two points, returns the distance^2 */
 template <typename T>
 double dist2(T a, T b)
@@ -1477,7 +1580,8 @@ void restore_stress_from_ref(const Param &param, const Variables &var,
 #endif
 }
 
-double compute_dt(const Param& param, Variables& var)
+double compute_dt(const Param& param, Variables& var,
+                  bool include_rsf_state_limit)
 
 {
 #ifdef NPROF
@@ -1488,9 +1592,18 @@ double compute_dt(const Param& param, Variables& var)
 
     // dynamic dt
     double dt_maxwell = std::numeric_limits<double>::max();
+    double dt_rsf = std::numeric_limits<double>::max();
     double dt_diffusion = std::numeric_limits<double>::max();
     double dt_hydro_diffusion = std::numeric_limits<double>::max();
     double minl = std::numeric_limits<double>::max();
+    const bool uses_rsf_state_step_limit =
+        include_rsf_state_limit &&
+        (param.mat.rheol_type & MatProps::rh_rsf) &&
+        param.mat.state_var_model == 1 &&
+        param.control.rsf_slip_rate_projection_option ==
+            rsf_slip_rate_projection_total_strain_rate;
+    const double rsf_dtheta_max = uses_rsf_state_step_limit ?
+        param.control.rsf_dtheta_max : 0.0;
 
     // Define element velocity arrays
     // double_vec velocity_x_element(var.nelem, 0.0);
@@ -1503,12 +1616,12 @@ double compute_dt(const Param& param, Variables& var)
     double global_dt_min = std::numeric_limits<double>::max(); // based on length and S wave velocity
 
 #ifndef ACC
-    #pragma omp parallel for reduction(min:minl, dt_maxwell, dt_diffusion, dt_hydro_diffusion, global_dt_min) \
+    #pragma omp parallel for reduction(min:minl, dt_maxwell, dt_rsf, dt_diffusion, dt_hydro_diffusion, global_dt_min) \
         reduction(max: global_max_vem) \
-        default(none) shared(param, var)
+        default(none) shared(param, var) firstprivate(rsf_dtheta_max)
     // No private() clause needed: vx/vy/vz_element are declared inside the loop.
 #endif
-    #pragma acc parallel loop gang vector reduction(min:minl, dt_maxwell, dt_diffusion, dt_hydro_diffusion, global_dt_min) \
+    #pragma acc parallel loop gang vector reduction(min:minl, dt_maxwell, dt_rsf, dt_diffusion, dt_hydro_diffusion, global_dt_min) \
         reduction(max: global_max_vem) async
     for (int e=0; e<var.nelem; ++e) {
 
@@ -1576,6 +1689,18 @@ double compute_dt(const Param& param, Variables& var)
 #endif
         dt_maxwell = std::min(dt_maxwell,
                               0.5 * var.mat->visc_min / (1e-40 + var.mat->shearm(e)));
+        if (rsf_dtheta_max > 0) {
+            const double rate =
+                2.0 * minh * current_strain_rate_invariant(var, e);
+            const double dc = var.mat->d_c(e);
+            if (rate > 0 && dc > 0)
+                dt_rsf = std::min(
+                    dt_rsf, rsf_dtheta_max * dc / rate);
+            const double theta = (*var.state_variable)[e];
+            if (theta > 0)
+                dt_rsf = std::min(
+                    dt_rsf, rsf_dtheta_max * theta);
+        }
         if (param.control.has_thermal_diffusion)
             dt_diffusion = std::min(dt_diffusion,
                                     0.5 * minh * minh / var.mat->therm_diff_max);
@@ -1627,14 +1752,18 @@ double compute_dt(const Param& param, Variables& var)
     }
 
     // Combine dt calculations and incorporate dt_hydro_diffusion
-    double dt = std::min({dt_elastic, dt_maxwell, dt_advection, dt_diffusion, dt_hydro_diffusion}) * param.control.dt_fraction;
+    double dt = std::min({dt_elastic, dt_maxwell, dt_rsf, dt_advection,
+                          dt_diffusion, dt_hydro_diffusion}) *
+                param.control.dt_fraction;
     // double dt = std::min({dt_elastic, dt_maxwell, dt_advection, dt_diffusion}) * param.control.dt_fraction;
     if (param.debug.dt) {
-        std::cout << "step #" << var.steps << "  dt: " << dt_maxwell << " " << dt_diffusion << " " 
+        std::cout << "step #" << var.steps << "  dt: " << dt_maxwell << " "
+                  << dt_rsf << " " << dt_diffusion << " "
                   << dt_hydro_diffusion << " " << dt_advection << " " << dt_elastic << " sec\n";
     }
     if (dt <= 0) {
-        std::cerr << "Error: dt <= 0!  " << dt_maxwell << " " << dt_diffusion
+        std::cerr << "Error: dt <= 0!  " << dt_maxwell << " " << dt_rsf
+                  << " " << dt_diffusion
                   << " " << dt_hydro_diffusion << " " << dt_advection << " " << dt_elastic << "\n";
         var.output->write_exact_error(var);
         die(EXIT_RUNTIME_NAN);
@@ -1925,4 +2054,3 @@ double worst_elem_quality(const array_t &coord, const conn_t &connectivity,
     }
     return q;
 }
-

--- a/geometry.hpp
+++ b/geometry.hpp
@@ -93,7 +93,8 @@ void restore_stress_from_ref(const Param& param, const Variables& var,
                              const SurfaceTopo& topo,
                              tensor_t* stress, double_vec* stressyy);
 
-double compute_dt(const Param& param, Variables& var);
+double compute_dt(const Param& param, Variables& var,
+                  bool include_rsf_state_limit = true);
 
 // double compute_dt_PT(const Param& param, const Variables& var);
 

--- a/ic.cxx
+++ b/ic.cxx
@@ -316,6 +316,32 @@ namespace {
     };
 
 
+void set_homogeneous_initial_stress(const Param &param, const Variables &var,
+                                    tensor_t &stress, double_vec &stressyy,
+                                    double_vec &old_mean_stress,
+                                    tensor_t &strain)
+{
+    double imposed[NSTR];
+    for (int i = 0; i < NSTR; ++i)
+        imposed[i] = param.ic.initial_stress[i];
+    const bool is_plane_strain = param.mat.is_plane_strain;
+
+    #pragma acc parallel loop gang vector copyin(imposed[0:NSTR]) async
+    for (int e = 0; e < var.nelem; ++e) {
+        TensorAccessor s = stress[e];
+        TensorAccessor eps = strain[e];
+        for (int i = 0; i < NSTR; ++i) {
+            s[i] = imposed[i];
+            eps[i] = 0.0;
+        }
+        old_mean_stress[e] = trace(s) / NDIMS;
+        if (is_plane_strain)
+            stressyy[e] = old_mean_stress[e];
+    }
+    #pragma acc wait
+}
+
+
 } // anonymous namespace
 
 
@@ -325,6 +351,9 @@ void initial_stress_state(const Param &param, const Variables &var,
 {
     if (param.control.gravity == 0) {
         compensation_pressure = 0;
+        if (param.ic.initial_stress_option == 1)
+            set_homogeneous_initial_stress(
+                param, var, stress, stressyy, old_mean_stress, strain);
         return;
     }
 
@@ -367,6 +396,9 @@ void initial_stress_state_1d_load(const Param &param, const Variables &var,
 {
     if (param.control.gravity == 0) {
         compensation_pressure = 0;
+        if (param.ic.initial_stress_option == 1)
+            set_homogeneous_initial_stress(
+                param, var, stress, stressyy, old_mean_stress, strain);
         return;
     }
 

--- a/input.cxx
+++ b/input.cxx
@@ -419,6 +419,13 @@ static void declare_parameters(po::options_description &cfg,
          ("control.use_global_velocity_scaling",
           po::value<bool>(&p.control.use_global_velocity_scaling)->default_value(false),
           "Use the global maximum model velocity to scale both dt and pseudo-density/mass scaling.\n")
+        ("control.mass_scaling_reference_speed",
+         po::value<std::string>()->default_value("shear"),
+         "Elastic-speed ceiling used by global velocity scaling. It sets the floor of\n"
+         "the fictitious density rho_fict = K / v_elastic^2.\n"
+         "shear: sqrt(G/rho), giving rho_fict >= rho K/G (historical default).\n"
+         "bulk : sqrt(K/rho), giving rho_fict >= rho and restoring physical density\n"
+         "       when the pseudo-wave speed reaches the bulk-wave ceiling.\n")
         ("control.rsf_slip_rate_projection_option",
          po::value<int>(&p.control.rsf_slip_rate_projection_option)
              ->default_value(rsf_slip_rate_projection_maximum_shear),
@@ -1389,6 +1396,23 @@ static void validate_parameters(const po::variables_map &vm, Param &p)
     // material properties
     //
     {
+        const std::string str =
+            vm["control.mass_scaling_reference_speed"].as<std::string>();
+        if (str == std::string("shear"))
+            p.control.mass_scaling_reference_speed =
+                mass_scaling_speed_shear;
+        else if (str == std::string("bulk"))
+            p.control.mass_scaling_reference_speed =
+                mass_scaling_speed_bulk;
+        else {
+            std::cerr
+                << "Error: control.mass_scaling_reference_speed must be "
+                   "'shear' or 'bulk', not '" << str << "'\n";
+            die(EXIT_CONFIG_VALUE);
+        }
+    }
+
+    {
         std::string str = vm["mat.rheology_type"].as<std::string>();
         if (str == std::string("elastic"))
             p.mat.rheol_type = MatProps::rh_elastic;
@@ -1414,6 +1438,13 @@ static void validate_parameters(const po::variables_map &vm, Param &p)
         if ((p.mat.rheol_type & MatProps::rh_rsf) && !p.control.use_global_velocity_scaling) {
             p.control.use_global_velocity_scaling = true;
             std::cerr << "Warning: RSF rheology requires control.use_global_velocity_scaling=true. Forcing it on.\n";
+        }
+        if (p.control.mass_scaling_reference_speed ==
+                mass_scaling_speed_bulk &&
+            !p.control.use_global_velocity_scaling) {
+            die(EXIT_CONFIG_VALUE,
+                "control.mass_scaling_reference_speed=bulk requires "
+                "control.use_global_velocity_scaling=true.");
         }
 
 #ifdef THREED

--- a/input.cxx
+++ b/input.cxx
@@ -419,6 +419,14 @@ static void declare_parameters(po::options_description &cfg,
          ("control.use_global_velocity_scaling",
           po::value<bool>(&p.control.use_global_velocity_scaling)->default_value(false),
           "Use the global maximum model velocity to scale both dt and pseudo-density/mass scaling.\n")
+        ("control.rsf_slip_rate_projection_option",
+         po::value<int>(&p.control.rsf_slip_rate_projection_option)
+             ->default_value(rsf_slip_rate_projection_maximum_shear),
+         "Velocity-dimensional rate supplied to the RSF update.\n"
+         "0: project the element velocity onto the maximum-shear direction inferred from stress\n"
+         "   (default; the historical behavior).\n"
+         "1: use V = 2 w eps_II from the total deviatoric strain rate, where w is the\n"
+         "   element's minimum altitude.\n")
         ;
 
     cfg.add_options()
@@ -1307,6 +1315,13 @@ static void validate_parameters(const po::variables_map &vm, Param &p)
             std::cerr << "Error: control.ref_pressure_option must be 0, 1, or 2 (got "
                       << p.control.ref_pressure_option << ").\n";
             die(EXIT_CONFIG_VALUE);
+        }
+        if (p.control.rsf_slip_rate_projection_option !=
+                rsf_slip_rate_projection_maximum_shear &&
+            p.control.rsf_slip_rate_projection_option !=
+                rsf_slip_rate_projection_total_strain_rate) {
+            die(EXIT_CONFIG_VALUE,
+                "control.rsf_slip_rate_projection_option must be 0 or 1.");
         }
 
     }

--- a/input.cxx
+++ b/input.cxx
@@ -781,6 +781,19 @@ static void declare_parameters(po::options_description &cfg,
          "Initial excess_pore_pressure except for boundary.\n")
          ("ic.has_body_force_adjustment", po::value<bool>(&p.ic.has_body_force_adjustment)->default_value(false),
          "Conducting PT loop to get initial stress field from inital guess")
+        ("ic.initial_stress_option", po::value<int>(&p.ic.initial_stress_option)->default_value(0),
+         "How to initialize stress?\n"
+         "0: use the legacy gravity-dependent initialization.\n"
+         "1: prescribe a homogeneous absolute Cauchy stress tensor; requires gravity=0.\n")
+#ifdef THREED
+        ("ic.initial_stress", po::value<std::string>()->default_value("[0,0,0,0,0,0]"),
+         "Homogeneous absolute Cauchy stress [sxx,syy,szz,sxy,sxz,syz] in Pa; "
+         "compression is negative.")
+#else
+        ("ic.initial_stress", po::value<std::string>()->default_value("[0,0,0]"),
+         "Homogeneous absolute Cauchy stress [sxx,szz,sxz] in Pa; compression is "
+         "negative. Plane strain initializes syy=(sxx+szz)/2.")
+#endif
 
         ;
 
@@ -1375,6 +1388,26 @@ static void validate_parameters(const po::variables_map &vm, Param &p)
                 std::cerr << "Error: the content of ic.mattype_layer_depths is not ordered from"
                     " small to big values.\n";
                 die(EXIT_CONFIG_VALUE);
+            }
+        }
+
+        if (p.ic.initial_stress_option != 0 &&
+            p.ic.initial_stress_option != 1) {
+            die(EXIT_CONFIG_VALUE,
+                "ic.initial_stress_option must be 0 or 1.");
+        }
+        get_numbers(vm, "ic.initial_stress", p.ic.initial_stress, NSTR);
+        if (p.ic.initial_stress_option == 1) {
+            if (p.control.gravity != 0.0) {
+                die(EXIT_CONFIG_VALUE,
+                    "ic.initial_stress_option=1 prescribes an absolute stress "
+                    "tensor and requires control.gravity=0.");
+            }
+            for (int i = 0; i < NSTR; ++i) {
+                if (!std::isfinite(p.ic.initial_stress[i])) {
+                    die(EXIT_CONFIG_VALUE,
+                        "ic.initial_stress must contain only finite values.");
+                }
             }
         }
 

--- a/input.cxx
+++ b/input.cxx
@@ -427,6 +427,12 @@ static void declare_parameters(po::options_description &cfg,
          "   (default; the historical behavior).\n"
          "1: use V = 2 w eps_II from the total deviatoric strain rate, where w is the\n"
          "   element's minimum altitude.\n")
+        ("control.rsf_dtheta_max",
+         po::value<double>(&p.control.rsf_dtheta_max)->default_value(0.0),
+         "For adaptive stepping with the aging law and total-strain rate option 1, apply\n"
+         "dt <= f D_c / V and dt <= f theta over all elements. The two bounds limit\n"
+         "slip within one characteristic distance and fractional healing per step.\n"
+         "f must be in [0, 2); 0 (default) disables this state-update limit.\n")
         ;
 
     cfg.add_options()
@@ -1323,6 +1329,12 @@ static void validate_parameters(const po::variables_map &vm, Param &p)
             die(EXIT_CONFIG_VALUE,
                 "control.rsf_slip_rate_projection_option must be 0 or 1.");
         }
+        if (!std::isfinite(p.control.rsf_dtheta_max) ||
+            p.control.rsf_dtheta_max < 0 ||
+            p.control.rsf_dtheta_max >= 2) {
+            die(EXIT_CONFIG_VALUE,
+                "control.rsf_dtheta_max must be finite and in [0, 2).");
+        }
 
     }
 
@@ -1493,6 +1505,42 @@ static void validate_parameters(const po::variables_map &vm, Param &p)
         get_numbers(vm, "mat.characteristic_distance", p.mat.characteristic_distance, p.mat.nmat, -1);
         if (p.mat.state_var_model < 0 || p.mat.state_var_model > 2) {
             die(EXIT_CONFIG_VALUE, "mat.state_var_model must be 0, 1, or 2.");
+        }
+        if (p.control.rsf_dtheta_max > 0) {
+            if (p.control.fixed_dt != 0.0) {
+                die(EXIT_CONFIG_VALUE,
+                    "control.rsf_dtheta_max requires control.fixed_dt=0.");
+            }
+            if (p.control.has_PT) {
+                die(EXIT_CONFIG_VALUE,
+                    "control.rsf_dtheta_max is not supported with "
+                    "control.has_PT=true.");
+            }
+            if (p.ic.has_body_force_adjustment) {
+                die(EXIT_CONFIG_VALUE,
+                    "control.rsf_dtheta_max is not supported with "
+                    "ic.has_body_force_adjustment=true.");
+            }
+            if (p.ic.isostasy_adjustment_time_in_yr > 0) {
+                die(EXIT_CONFIG_VALUE,
+                    "control.rsf_dtheta_max is not supported during "
+                    "isostasy adjustment.");
+            }
+            if (!(p.mat.rheol_type & MatProps::rh_rsf)) {
+                die(EXIT_CONFIG_VALUE,
+                    "control.rsf_dtheta_max requires an RSF rheology.");
+            }
+            if (p.mat.state_var_model != 1) {
+                die(EXIT_CONFIG_VALUE,
+                    "control.rsf_dtheta_max requires the aging law "
+                    "(mat.state_var_model=1).");
+            }
+            if (p.control.rsf_slip_rate_projection_option !=
+                rsf_slip_rate_projection_total_strain_rate) {
+                die(EXIT_CONFIG_VALUE,
+                    "control.rsf_dtheta_max requires "
+                    "control.rsf_slip_rate_projection_option=1.");
+            }
         }
         if (p.mat.rheol_type & MatProps::rh_rsf) {
             for (int m = 0; m < p.mat.nmat; ++m) {

--- a/matprops.cxx
+++ b/matprops.cxx
@@ -9,6 +9,13 @@
 namespace {
 
     #pragma acc routine seq
+    inline double rsf_slip_rate_eff(double slip_rate)
+    {
+        const double cutoff = 1e-16;
+        return (slip_rate > cutoff) ? slip_rate : cutoff;
+    }
+
+    #pragma acc routine seq
     double get_prem_pressure(double depth)
     {
         // reference pressure profile from isotropic PREM model
@@ -491,7 +498,7 @@ void MatProps::plastic_weakening_rsf(int e, double pls,
     const double static_friction_angle = f / n;
     const double mu_0 = std::tan(DEG2RAD * static_friction_angle);
 
-    const double v_eff = std::max(slip_rate, 1e-30);
+    const double v_eff = rsf_slip_rate_eff(slip_rate);
     const double cv_eff = std::max(c_v_avg, 1e-30);
     const double dc_eff = std::max(d_c_avg, 1e-30);
     const double theta_eff = std::max(state_variable, 1e-30);
@@ -537,7 +544,8 @@ void MatProps::update_state_variable(int e, double slip_rate, double& state_vari
             d = (n > 0) ? (d / n) : 0.0;
             if (d < 1e-12) return;
 
-            const double dtheta = (1.0 - (slip_rate * state_variable / d)) * dt;
+            const double slip_rate_eff = rsf_slip_rate_eff(slip_rate);
+            const double dtheta = (1.0 - (slip_rate_eff * state_variable / d)) * dt;
             if (!std::isfinite(dtheta)) return;
 
             double new_theta = state_variable + dtheta;
@@ -563,21 +571,22 @@ void MatProps::update_state_variable(int e, double slip_rate, double& state_vari
             if (theta < theta_min) theta = theta_min;
             if (theta > theta_max) theta = theta_max;
 
-            double ratio = slip_rate * theta / d;
+            const double slip_rate_eff = rsf_slip_rate_eff(slip_rate);
+            double ratio = slip_rate_eff * theta / d;
             if (ratio < ratio_min) ratio = ratio_min;
 
             const double dtheta = -ratio * std::log(ratio) * dt;
             if (std::isfinite(dtheta)) {
                 double new_theta = theta + dtheta;
                 if (!std::isfinite(new_theta) || new_theta <= 0.0) {
-                    state_variable = d / std::max(slip_rate, 1e-30);
+                    state_variable = d / slip_rate_eff;
                 } else {
                     if (new_theta < theta_min) new_theta = theta_min;
                     if (new_theta > theta_max) new_theta = theta_max;
                     state_variable = new_theta;
                 }
             } else {
-                state_variable = d / std::max(slip_rate, 1e-30);
+                state_variable = d / slip_rate_eff;
             }
         }
         break;

--- a/parameters.hpp
+++ b/parameters.hpp
@@ -260,6 +260,7 @@ struct Control {
 
     bool has_moving_mesh;
     bool use_global_velocity_scaling;
+    int rsf_slip_rate_projection_option;
 
 };
 
@@ -500,6 +501,11 @@ struct Markers {
 struct Debug {
     bool dt;
 //    bool has_two_layers_for;
+};
+
+enum RSFSlipRateProjectionOption {
+    rsf_slip_rate_projection_maximum_shear = 0,
+    rsf_slip_rate_projection_total_strain_rate = 1
 };
 
 enum MonitorRebindMode {

--- a/parameters.hpp
+++ b/parameters.hpp
@@ -260,6 +260,7 @@ struct Control {
 
     bool has_moving_mesh;
     bool use_global_velocity_scaling;
+    int mass_scaling_reference_speed;
     int rsf_slip_rate_projection_option;
     double rsf_dtheta_max;
 
@@ -507,6 +508,11 @@ struct Debug {
 enum RSFSlipRateProjectionOption {
     rsf_slip_rate_projection_maximum_shear = 0,
     rsf_slip_rate_projection_total_strain_rate = 1
+};
+
+enum MassScalingReferenceSpeed {
+    mass_scaling_speed_shear = 0,
+    mass_scaling_speed_bulk = 1
 };
 
 enum MonitorRebindMode {

--- a/parameters.hpp
+++ b/parameters.hpp
@@ -261,6 +261,7 @@ struct Control {
     bool has_moving_mesh;
     bool use_global_velocity_scaling;
     int rsf_slip_rate_projection_option;
+    double rsf_dtheta_max;
 
 };
 

--- a/parameters.hpp
+++ b/parameters.hpp
@@ -421,6 +421,8 @@ struct IC {
 
     double excess_pore_pressure;
     bool has_body_force_adjustment;
+    int initial_stress_option;
+    double_vec initial_stress;
 };
 
 struct Mat {

--- a/rheology.cxx
+++ b/rheology.cxx
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cmath>
 #include <iostream>
 
@@ -207,6 +208,71 @@ static void compute_slip_rate3(ConstTensorAccessor s, double vx, double vy, doub
     slip_rate = std::sqrt(slip_magnitude_1 * slip_magnitude_1 + slip_magnitude_2 * slip_magnitude_2);
 }
 
+// Element width w for V = 2 w eps_II: the minimum altitude, matching compute_dt().
+#pragma acc routine seq
+static double elem_band_width(ConstArrayIndirectAccessor coord, double volume)
+{
+#ifdef THREED
+    const int facet[4][3] = {{0,1,2}, {0,1,3}, {0,2,3}, {1,2,3}};
+    double max_area = 0.0;
+    #pragma acc loop seq
+    for (int i = 0; i < 4; ++i) {
+        ConstArrayAccessor p = coord[facet[i][0]];
+        ConstArrayAccessor q = coord[facet[i][1]];
+        ConstArrayAccessor r = coord[facet[i][2]];
+        const double u0 = q[0] - p[0];
+        const double u1 = q[1] - p[1];
+        const double u2 = q[2] - p[2];
+        const double v0 = r[0] - p[0];
+        const double v1 = r[1] - p[1];
+        const double v2 = r[2] - p[2];
+        const double c0 = u1 * v2 - u2 * v1;
+        const double c1 = u2 * v0 - u0 * v2;
+        const double c2 = u0 * v1 - u1 * v0;
+        const double area = 0.5 * std::sqrt(c0*c0 + c1*c1 + c2*c2);
+        max_area = std::max(max_area, area);
+    }
+    return (max_area > 0.0) ? 3.0 * volume / max_area : 0.0;
+#else
+    double max_length2 = 0.0;
+    #pragma acc loop seq
+    for (int i = 0; i < 3; ++i) {
+        ConstArrayAccessor p = coord[i];
+        ConstArrayAccessor q = coord[(i + 1) % 3];
+        const double dx = p[0] - q[0];
+        const double dz = p[1] - q[1];
+        max_length2 = std::max(max_length2, dx*dx + dz*dz);
+    }
+    const double max_length = std::sqrt(max_length2);
+    return (max_length > 0.0) ? 2.0 * volume / max_length : 0.0;
+#endif
+}
+
+#pragma acc routine seq
+static void select_slip_rate2(int projection_option, double continuum_rate,
+                              ConstTensorAccessor stress,
+                              double& vx, double& vz, double& slip_rate)
+{
+    if (projection_option == rsf_slip_rate_projection_total_strain_rate) {
+        slip_rate = continuum_rate;
+        return;
+    }
+    compute_slip_rate2(stress, vx, vz, slip_rate);
+}
+
+#pragma acc routine seq
+static void select_slip_rate3(int projection_option, double continuum_rate,
+                              ConstTensorAccessor stress,
+                              double vx, double vy, double vz,
+                              double& slip_rate)
+{
+    if (projection_option == rsf_slip_rate_projection_total_strain_rate) {
+        slip_rate = continuum_rate;
+        return;
+    }
+    compute_slip_rate3(stress, vx, vy, vz, slip_rate);
+}
+
 void refresh_rsf_friction(const Param& param, Variables& var,
                           double_vec& dyn_fric_coeff,
                           const double_vec& state_variable)
@@ -217,27 +283,45 @@ void refresh_rsf_friction(const Param& param, Variables& var,
     #pragma omp parallel for default(none) shared(param, var, dyn_fric_coeff, state_variable)
 #endif
     for (int e = 0; e < var.nelem; ++e) {
-        ConstArrayIndirectAccessor v = var.vel->view_const((*var.connectivity)[e]);
+        const int projection_option =
+            param.control.rsf_slip_rate_projection_option;
         double vx = 0.0;
         double vy = 0.0;
-        const double weight = 1.0 / NODES_PER_ELEM;
 #ifdef THREED
         double vz = 0.0;
 #endif
 
-        for (int j = 0; j < NODES_PER_ELEM; ++j) {
-            vx += v[j][0] * weight;
-            vy += v[j][1] * weight;
+        if (projection_option ==
+            rsf_slip_rate_projection_maximum_shear) {
+            ConstArrayIndirectAccessor v =
+                var.vel->view_const((*var.connectivity)[e]);
+            const double weight = 1.0 / NODES_PER_ELEM;
+            for (int j = 0; j < NODES_PER_ELEM; ++j) {
+                vx += v[j][0] * weight;
+                vy += v[j][1] * weight;
 #ifdef THREED
-            vz += v[j][2] * weight;
+                vz += v[j][2] * weight;
 #endif
+            }
+        }
+
+        double continuum_rate = 0.0;
+        if (projection_option ==
+            rsf_slip_rate_projection_total_strain_rate) {
+            const double width = elem_band_width(
+                var.coord->view_const((*var.connectivity)[e]),
+                (*var.volume)[e]);
+            continuum_rate =
+                2.0 * width * second_invariant((*var.strain_rate)[e]);
         }
 
         double slip_rate = 0.0;
 #ifdef THREED
-        compute_slip_rate3((*var.stress)[e], vx, vy, vz, slip_rate);
+        select_slip_rate3(projection_option, continuum_rate,
+                          (*var.stress)[e], vx, vy, vz, slip_rate);
 #else
-        compute_slip_rate2((*var.stress)[e], vx, vy, slip_rate);
+        select_slip_rate2(projection_option, continuum_rate,
+                          (*var.stress)[e], vx, vy, slip_rate);
 #endif
         var.mat->rsf_friction_from_state(e, (*var.plstrain)[e], slip_rate,
                                          state_variable[e], dyn_fric_coeff[e],
@@ -713,16 +797,21 @@ void update_stress(const Param& param, Variables& var, tensor_t& stress,
 
     // Loop-invariant, so the per-element gathers they gate are decided once.
     const bool has_hydraulic_diffusion = param.control.has_hydraulic_diffusion;
-    // Only the two rate-and-state branches call compute_slip_rate*, which is the
-    // sole consumer of the centroid velocity.
+    // Only option 0 projects the centroid velocity; option 1 derives its rate
+    // from the strain-rate invariant.
     const bool needs_slip_rate = (param.mat.rheol_type == MatProps::rh_ep_rsf)
                               || (param.mat.rheol_type == MatProps::rh_evp_rsf);
+    const bool needs_projected_velocity =
+        needs_slip_rate &&
+        param.control.rsf_slip_rate_projection_option ==
+            rsf_slip_rate_projection_maximum_shear;
 
 #ifndef ACC
     #pragma omp parallel for default(none) shared(param, var, dppressure, \
         vel, stress, stressyy, dpressure, viscosity, strain, plstrain, delta_plstrain, \
         strain_rate, dyn_fric_coeff, state_variable) \
-        firstprivate(has_hydraulic_diffusion, needs_slip_rate)
+        firstprivate(has_hydraulic_diffusion, needs_slip_rate, \
+                     needs_projected_velocity)
 #endif
     #pragma acc parallel loop gang vector async // TODO: ACC: CPU and GPU results are differet because of using 3x3 in elasto_plastic
     for (int e = 0; e < var.nelem; e++) {
@@ -748,7 +837,7 @@ void update_stress(const Param& param, Variables& var, tensor_t& stress,
 #ifdef THREED
         double vz = 0.0;
 #endif
-        if (needs_slip_rate) {
+        if (needs_projected_velocity) {
             const array_t& vel = *var.vel;
             #pragma acc loop seq
             for (int j = 0; j < NODES_PER_ELEM; ++j) {
@@ -790,6 +879,15 @@ void update_stress(const Param& param, Variables& var, tensor_t& stress,
             for (int i=0; i<NDIMS; ++i) {
                 edot[i] += ((*var.edvoldt)[e] - div) / NDIMS;  // XXX: should NDIMS -> 3 in plane strain?
             }
+        }
+
+        double continuum_rate = 0.0;
+        if (needs_slip_rate &&
+            param.control.rsf_slip_rate_projection_option ==
+                rsf_slip_rate_projection_total_strain_rate) {
+            const double width = elem_band_width(
+                var.coord->view_const(conn), (*var.volume)[e]);
+            continuum_rate = 2.0 * width * second_invariant(edot);
         }
 
         // update strain with strain rate
@@ -928,9 +1026,13 @@ void update_stress(const Param& param, Variables& var, tensor_t& stress,
                 double slip_rate;
                 
 #ifdef THREED
-                compute_slip_rate3(s, vx, vy, vz, slip_rate); // Calculate slip vector magnitude in 3D
+                select_slip_rate3(
+                    param.control.rsf_slip_rate_projection_option,
+                    continuum_rate, s, vx, vy, vz, slip_rate);
 #else
-                compute_slip_rate2(s, vx, vy, slip_rate); // Calculate slip vector magnitude in 2D
+                select_slip_rate2(
+                    param.control.rsf_slip_rate_projection_option,
+                    continuum_rate, s, vx, vy, slip_rate);
 #endif
         
                 double amc, anphi, anpsi, hardn, ten_max;
@@ -971,9 +1073,13 @@ void update_stress(const Param& param, Variables& var, tensor_t& stress,
                 double slip_rate;
                 
 #ifdef THREED
-                compute_slip_rate3(s, vx, vy, vz, slip_rate); // Calculate slip vector magnitude in 3D
+                select_slip_rate3(
+                    param.control.rsf_slip_rate_projection_option,
+                    continuum_rate, s, vx, vy, vz, slip_rate);
 #else
-                compute_slip_rate2(s, vx, vy, slip_rate); // Calculate slip vector magnitude in 2D
+                select_slip_rate2(
+                    param.control.rsf_slip_rate_projection_option,
+                    continuum_rate, s, vx, vy, slip_rate);
 #endif
 
                 double amc, anphi, anpsi, hardn, ten_max;

--- a/tests/functional/2d-rsf-ats.sh
+++ b/tests/functional/2d-rsf-ats.sh
@@ -7,3 +7,6 @@ repo_root=$(cd "${script_dir}/../.." && pwd)
 cd "${script_dir}"
 PYTHONDONTWRITEBYTECODE=1 python3 "${repo_root}/benchmarks/simple_shear_rsf/check_simple_shear_benchmark.py" \
   --exe "${repo_root}/dynearthsol2d"
+
+PYTHONDONTWRITEBYTECODE=1 python3 "${script_dir}/rsf_controls/check_rsf_controls.py" \
+  --exe "${repo_root}/dynearthsol2d"

--- a/tests/functional/initial_stress/check_initial_stress.py
+++ b/tests/functional/initial_stress/check_initial_stress.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Check zero-gravity homogeneous absolute initial stress at t=0."""
+
+from __future__ import annotations
+
+import argparse
+import math
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import h5py
+
+
+sys.dont_write_bytecode = True
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[2]
+DEFAULT_EXE = REPO_ROOT / "dynearthsol2d"
+DEFAULT_CFG = HERE / "initial_stress.cfg"
+PRESCRIBED_STRESS = (-5.0e6, -3.0e6, 9.0e5)
+PRESCRIBED_STRESSYY = -4.0e6
+
+
+def read_array(path: Path, dataset: str):
+    if not path.is_file():
+        raise AssertionError(f"missing output file: {path}")
+    with h5py.File(path, "r") as output:
+        if dataset not in output:
+            raise AssertionError(f"{path}: missing dataset {dataset!r}")
+        return output[dataset][...]
+
+
+def render_cfg(
+    template: str,
+    modelname: str,
+    option: int,
+    gravity: float,
+) -> str:
+    replacements = {
+        "__MODELNAME__": modelname,
+        "__GRAVITY__": f"{gravity:.17g}",
+        "__INITIAL_STRESS_OPTION__": str(option),
+        "__INITIAL_STRESS__": "["
+        + ",".join(f"{value:.17g}" for value in PRESCRIBED_STRESS)
+        + "]",
+    }
+    cfg = template
+    for token, value in replacements.items():
+        if cfg.count(token) != 1:
+            raise AssertionError(f"expected one config token {token}")
+        cfg = cfg.replace(token, value)
+    if "__" in cfg:
+        raise AssertionError("unexpanded config token remains")
+    return cfg
+
+
+def run_model(
+    exe: Path,
+    template: str,
+    root: Path,
+    label: str,
+    *,
+    option: int,
+    gravity: float,
+    threads: int,
+    expect_success: bool = True,
+) -> tuple[Path, str, subprocess.CompletedProcess[str]]:
+    modelname = f"initial_stress_{label}_omp{threads}"
+    run_dir = root / modelname
+    run_dir.mkdir()
+    cfg_path = run_dir / "input.cfg"
+    cfg_path.write_text(
+        render_cfg(template, modelname, option, gravity),
+        encoding="ascii",
+    )
+    env = os.environ.copy()
+    env["OMP_NUM_THREADS"] = str(threads)
+    result = subprocess.run(
+        [str(exe), str(cfg_path)],
+        cwd=run_dir,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    if expect_success and result.returncode != 0:
+        raise RuntimeError(
+            f"{label} OMP={threads} failed with {result.returncode}:\n"
+            f"{result.stdout}"
+        )
+    if not expect_success and result.returncode == 0:
+        raise AssertionError(f"{label} OMP={threads} unexpectedly succeeded")
+    return run_dir, modelname, result
+
+
+def assert_close(label: str, actual: float, expected: float) -> None:
+    if not math.isclose(actual, expected, rel_tol=1.0e-12, abs_tol=1.0e-8):
+        raise AssertionError(
+            f"{label}: {actual:.17e} != {expected:.17e}"
+        )
+
+
+def check_initial_state(
+    run_dir: Path,
+    modelname: str,
+    expected_stress: tuple[float, float, float],
+    expected_stressyy: float,
+) -> None:
+    stress = read_array(
+        run_dir / f"{modelname}.save.000000.vtkhdf", "stress"
+    )
+    strain = read_array(
+        run_dir / f"{modelname}.save.000000.vtkhdf", "strain"
+    )
+    stressyy = read_array(
+        run_dir / f"{modelname}.chkpt.000000.vtkhdf", "stressyy"
+    )
+    if len(stress) != len(strain) or len(stress) != len(stressyy):
+        raise AssertionError("initial stress/strain/stressyy counts differ")
+    for element, (stress_e, strain_e, stressyy_e) in enumerate(
+        zip(stress, strain, stressyy)
+    ):
+        for component, expected in enumerate(expected_stress):
+            assert_close(
+                f"element {element} stress[{component}]",
+                float(stress_e[component]),
+                expected,
+            )
+            assert_close(
+                f"element {element} strain[{component}]",
+                float(strain_e[component]),
+                0.0,
+            )
+        assert_close(
+            f"element {element} stressyy",
+            float(stressyy_e),
+            expected_stressyy,
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--exe", type=Path, default=DEFAULT_EXE)
+    parser.add_argument("--cfg", type=Path, default=DEFAULT_CFG)
+    parser.add_argument("--threads", type=int, nargs="+", default=[1, 4])
+    args = parser.parse_args()
+    exe = args.exe.expanduser().resolve()
+    cfg_path = args.cfg.expanduser().resolve()
+    if not exe.is_file() or not os.access(exe, os.X_OK):
+        raise FileNotFoundError(f"executable not found: {exe}")
+    template = cfg_path.read_text(encoding="ascii")
+
+    with tempfile.TemporaryDirectory(prefix="des-initial-stress-") as temp:
+        root = Path(temp)
+        for threads in args.threads:
+            if threads <= 0:
+                raise ValueError("thread counts must be positive")
+            baseline_dir, baseline_name, _ = run_model(
+                exe,
+                template,
+                root,
+                "legacy",
+                option=0,
+                gravity=0.0,
+                threads=threads,
+            )
+            check_initial_state(
+                baseline_dir,
+                baseline_name,
+                (0.0, 0.0, 0.0),
+                0.0,
+            )
+            imposed_dir, imposed_name, _ = run_model(
+                exe,
+                template,
+                root,
+                "absolute",
+                option=1,
+                gravity=0.0,
+                threads=threads,
+            )
+            check_initial_state(
+                imposed_dir,
+                imposed_name,
+                PRESCRIBED_STRESS,
+                PRESCRIBED_STRESSYY,
+            )
+            print(f"initial stress t=0 regression OMP={threads}: PASS")
+
+        _, _, invalid = run_model(
+            exe,
+            template,
+            root,
+            "gravity_rejected",
+            option=1,
+            gravity=9.81,
+            threads=1,
+            expect_success=False,
+        )
+        if "requires control.gravity=0" not in invalid.stdout:
+            raise AssertionError(
+                "missing gravity incompatibility diagnostic:\n"
+                + invalid.stdout
+            )
+        print("initial stress gravity compatibility check: PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/functional/initial_stress/initial_stress.cfg
+++ b/tests/functional/initial_stress/initial_stress.cfg
@@ -1,0 +1,54 @@
+# Zero-gravity t=0 fixture for homogeneous absolute initial stress.
+
+[sim]
+modelname = __MODELNAME__
+max_steps = 1
+output_step_interval = 1
+checkpoint_frame_interval = 1
+has_initial_checkpoint = yes
+has_marker_output = no
+is_outputting_averaged_fields = no
+
+[mesh]
+xlength = 1
+ylength = 1
+zlength = 1
+resolution = 0.5
+quality_check_step_interval = 100
+remeshing_option = 0
+
+[control]
+gravity = __GRAVITY__
+fixed_dt = 1
+inertial_scaling = 1e5
+surface_process_option = 0
+has_moving_mesh = no
+use_global_velocity_scaling = no
+
+[ic]
+weakzone_option = 0
+initial_stress_option = __INITIAL_STRESS_OPTION__
+initial_stress = __INITIAL_STRESS__
+
+[bc]
+vbc_x0 = 1
+vbc_x1 = 1
+vbc_val_x0 = 0
+vbc_val_x1 = 0
+vbc_z0 = 1
+vbc_z1 = 1
+vbc_val_z0 = 0
+vbc_val_z1 = 0
+surface_temperature = 273
+mantle_temperature = 273
+has_winkler_foundation = no
+has_water_loading = no
+
+[mat]
+rheology_type = elastic
+is_plane_strain = yes
+num_materials = 1
+rho0 = [1]
+alpha = [0]
+bulk_modulus = [2e8]
+shear_modulus = [2e8]

--- a/tests/functional/rsf_controls/check_rsf_controls.py
+++ b/tests/functional/rsf_controls/check_rsf_controls.py
@@ -20,7 +20,11 @@ REPO_ROOT = SCRIPT_DIR.parents[2]
 BENCHMARK_DIR = REPO_ROOT / "benchmarks" / "simple_shear_rsf"
 sys.path.insert(0, str(BENCHMARK_DIR))
 
-from run_simple_shear_benchmark import BenchmarkCase, render_cfg  # noqa: E402
+from run_simple_shear_benchmark import (  # noqa: E402
+    BenchmarkCase,
+    RunSpec,
+    render_cfg,
+)
 
 
 VX_TOP = 1.0e-5
@@ -57,25 +61,37 @@ def make_cfg(
         state_var_model=state_model,
     )
     template = (BENCHMARK_DIR / "simple_shear_base.cfg").read_text(encoding="utf-8")
-    cfg = render_cfg(template, case, max_steps, max_steps, 1)
-    cfg = replace_once(cfg, "fixed_dt = 1.0", f"fixed_dt = {fixed_dt:.17e}")
+    spec = RunSpec(
+        name="rsf_control",
+        case=case,
+        max_steps=max_steps,
+        output_step_interval=max_steps,
+        monitor_step_interval=1,
+        fixed_dt_s=fixed_dt,
+        upper_boundary_x_mode=4,
+        upper_boundary_x_velocity=top_velocity,
+        characteristic_speed_line="",
+    )
+    cfg = render_cfg(template, spec)
     cfg = replace_once(
         cfg,
         "inertial_scaling = 1e5",
         f"inertial_scaling = {inertial_scaling:.17e}",
     )
-    cfg = replace_once(
-        cfg,
-        "vbc_val_z1 = 1e-5",
-        f"vbc_val_z1 = {top_velocity:.17e}",
-    )
+    rate_control = "rsf_slip_rate_projection_option = 1"
+    if rate_option is None:
+        cfg = replace_once(cfg, rate_control, "")
+    elif rate_option != 1:
+        cfg = replace_once(
+            cfg,
+            rate_control,
+            f"rsf_slip_rate_projection_option = {rate_option}",
+        )
     controls = ["damping_option = 1", "dt_fraction = 1"]
     if moving_mesh is not None:
         controls.append(
             "has_moving_mesh = " + ("yes" if moving_mesh else "no")
         )
-    if rate_option is not None:
-        controls.append(f"rsf_slip_rate_projection_option = {rate_option}")
     if dtheta_max is not None:
         controls.append(f"rsf_dtheta_max = {dtheta_max:.17e}")
     cfg = replace_once(cfg, "damping_option = 1", "\n".join(controls))

--- a/tests/functional/rsf_controls/check_rsf_controls.py
+++ b/tests/functional/rsf_controls/check_rsf_controls.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""Focused checks for selectable RSF slip-rate calculations."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import h5py
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[2]
+BENCHMARK_DIR = REPO_ROOT / "benchmarks" / "simple_shear_rsf"
+sys.path.insert(0, str(BENCHMARK_DIR))
+
+from run_simple_shear_benchmark import BenchmarkCase, render_cfg  # noqa: E402
+
+
+VX_TOP = 1.0e-5
+
+
+def replace_once(text: str, old: str, new: str) -> str:
+    if text.count(old) != 1:
+        raise ValueError(f"Expected exactly one occurrence of {old!r}")
+    return text.replace(old, new, 1)
+
+
+def make_cfg(
+    *,
+    fixed_dt: float,
+    dc: float,
+    state_model: int = 1,
+    rate_option: int | None = 1,
+    max_steps: int = 1,
+) -> str:
+    case = BenchmarkCase(
+        name="rsf_control",
+        group="aging_ab_neg",
+        rheology_type="elasto-plastic-rate-state-friction",
+        friction_angle_deg=30.0,
+        direct_a=0.2,
+        evolution_b=0.3,
+        characteristic_distance=dc,
+        characteristic_velocity=1.0e-5,
+        state_var_model=state_model,
+    )
+    template = (BENCHMARK_DIR / "simple_shear_base.cfg").read_text(encoding="utf-8")
+    cfg = render_cfg(template, case, max_steps, max_steps, 1)
+    cfg = replace_once(cfg, "fixed_dt = 1.0", f"fixed_dt = {fixed_dt:.17e}")
+    if rate_option is not None:
+        cfg = replace_once(
+            cfg,
+            "damping_option = 1",
+            "damping_option = 1\n"
+            f"rsf_slip_rate_projection_option = {rate_option}",
+        )
+    return cfg
+
+
+def run_cfg(
+    exe: Path,
+    root: Path,
+    name: str,
+    cfg: str,
+    *,
+    expect_success: bool = True,
+):
+    run_dir = root / name
+    run_dir.mkdir()
+    cfg_path = run_dir / "case.cfg"
+    cfg_path.write_text(cfg, encoding="utf-8")
+    result = subprocess.run(
+        [str(exe), str(cfg_path)],
+        cwd=run_dir,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    if expect_success and result.returncode != 0:
+        raise RuntimeError(f"{name} failed with {result.returncode}:\n{result.stdout}")
+    if not expect_success and result.returncode == 0:
+        raise AssertionError(f"{name} unexpectedly succeeded")
+    return run_dir, result
+
+
+def monitor_rows(run_dir: Path) -> list[list[dict[str, str]]]:
+    paths = sorted(run_dir.glob("monitor_point_*.csv"))
+    if len(paths) != 2:
+        raise AssertionError(f"Expected two monitor files in {run_dir}, found {len(paths)}")
+    output = []
+    for path in paths:
+        with path.open("r", encoding="utf-8", newline="") as handle:
+            output.append(list(csv.DictReader(handle)))
+    return output
+
+
+def assert_close(
+    label: str,
+    actual: float,
+    expected: float,
+    rel: float = 2.0e-12,
+) -> None:
+    scale = max(abs(expected), 1.0e-30)
+    if not math.isfinite(actual) or abs(actual - expected) > rel * scale:
+        raise AssertionError(f"{label}: {actual:.17e} != {expected:.17e}")
+
+
+def check_invariant_rate(exe: Path, root: Path) -> None:
+    dt = 1.0e-2
+    dc = 1.0e-3
+    run_dir, _ = run_cfg(
+        exe,
+        root,
+        "invariant_rate_option1",
+        make_cfg(fixed_dt=dt, dc=dc, rate_option=1),
+    )
+    rows = monitor_rows(run_dir)
+    rate = VX_TOP / math.sqrt(2.0)
+    theta0 = dc / 1.0e-5
+    theta1 = theta0 + dt * (1.0 - rate * theta0 / dc)
+    mu0 = math.tan(math.radians(30.0))
+    mu1 = (
+        mu0
+        + 0.2 * math.log(rate / 1.0e-5)
+        + 0.3 * math.log(1.0e-5 * theta1 / dc)
+    )
+    for index, point_rows in enumerate(rows):
+        assert_close(
+            f"point {index} theta",
+            float(point_rows[1]["state_variable"]),
+            theta1,
+        )
+        assert_close(
+            f"point {index} friction",
+            float(point_rows[1]["dynamic_friction"]),
+            mu1,
+        )
+    print("[ok] option 1 uses the total-strain invariant in both elements")
+
+
+def check_invariant_restart_refresh(exe: Path, root: Path) -> None:
+    seed_cfg = make_cfg(
+        fixed_dt=1.0e-2,
+        dc=1.0e-3,
+        rate_option=1,
+        max_steps=1,
+    )
+    seed_cfg = replace_once(
+        seed_cfg,
+        "output_step_interval = 1",
+        "output_step_interval = 1\ncheckpoint_frame_interval = 1",
+    )
+    seed_dir, _ = run_cfg(exe, root, "invariant_restart_seed", seed_cfg)
+    seed_save = seed_dir / "result.save.000001.vtkhdf"
+    with h5py.File(seed_save, "r") as output:
+        expected_time = output["time_sec"][()].item()
+        expected_theta = output["friction state variable"][...]
+        source = output["/VTKHDF/grid/CellData/strain-rate"]
+        source_values = source[...]
+        if not any(
+            abs(float(value)) > 0.0
+            for element in source_values
+            for value in element
+        ):
+            raise AssertionError("restart seed strain rate is already zero")
+
+    restart_outputs = []
+    for label in ("clean", "poisoned"):
+        if label == "poisoned":
+            with h5py.File(seed_save, "r+") as output:
+                output["/VTKHDF/grid/CellData/strain-rate"][...] = 0.0
+        restart_cfg = make_cfg(
+            fixed_dt=1.0e-2,
+            dc=1.0e-3,
+            rate_option=1,
+            max_steps=2,
+        )
+        restart_cfg = replace_once(
+            restart_cfg,
+            "modelname = result",
+            f"modelname = restarted_{label}\n"
+            "is_restarting = yes\n"
+            f"restarting_from_modelname = {seed_dir / 'result'}\n"
+            "restarting_from_frame = 1",
+        )
+        restart_dir, _ = run_cfg(
+            exe, root, f"invariant_restart_{label}", restart_cfg
+        )
+        restart_save = (
+            restart_dir / f"restarted_{label}.save.000001.vtkhdf"
+        )
+        with h5py.File(restart_save, "r") as output:
+            restart_outputs.append(
+                (
+                    output["time_sec"][()].item(),
+                    output["friction state variable"][...],
+                    output["dynamic friction coefficient"][...],
+                )
+            )
+
+    clean, poisoned = restart_outputs
+    if (
+        clean[1].shape != expected_theta.shape
+        or poisoned[1].shape != clean[1].shape
+    ):
+        raise AssertionError("restart state-variable shapes changed")
+    if clean[2].shape != poisoned[2].shape:
+        raise AssertionError("restart friction shapes changed")
+    assert_close("clean restart frame time", clean[0], expected_time)
+    assert_close("poisoned restart frame time", poisoned[0], expected_time)
+    for element in range(len(expected_theta)):
+        assert_close(
+            f"clean restart element {element} theta",
+            float(clean[1][element]),
+            float(expected_theta[element]),
+        )
+        assert_close(
+            f"poisoned restart element {element} theta",
+            float(poisoned[1][element]),
+            float(expected_theta[element]),
+        )
+        assert_close(
+            f"restart element {element} derived friction",
+            float(poisoned[2][element]),
+            float(clean[2][element]),
+        )
+    print("[ok] option 1 rebuilds its derived rate on restart")
+
+
+def check_maximum_shear_default(exe: Path, root: Path) -> None:
+    explicit_dir, _ = run_cfg(
+        exe,
+        root,
+        "maximum_shear_explicit",
+        make_cfg(fixed_dt=1.0e-2, dc=1.0e-3, state_model=0, rate_option=0),
+    )
+    default_dir, _ = run_cfg(
+        exe,
+        root,
+        "maximum_shear_default",
+        make_cfg(fixed_dt=1.0e-2, dc=1.0e-3, state_model=0, rate_option=None),
+    )
+    explicit_rows = monitor_rows(explicit_dir)
+    default_rows = monitor_rows(default_dir)
+    if len(default_rows) != len(explicit_rows):
+        raise AssertionError("default and explicit option 0 point counts differ")
+    for point, (explicit, default) in enumerate(zip(explicit_rows, default_rows)):
+        if len(default) != len(explicit):
+            raise AssertionError(
+                f"default and explicit option 0 row counts differ at point {point}"
+            )
+        for row, (explicit_record, default_record) in enumerate(
+            zip(explicit, default)
+        ):
+            for field in (
+                "time_s",
+                "stress_0",
+                "stress_1",
+                "stress_2",
+                "state_variable",
+                "dynamic_friction",
+            ):
+                assert_close(
+                    f"default option 0 point {point} row {row} {field}",
+                    float(default_record[field]),
+                    float(explicit_record[field]),
+                )
+
+    friction = [
+        float(point_rows[1]["dynamic_friction"])
+        for point_rows in explicit_rows
+    ]
+    if (
+        not all(math.isfinite(value) for value in friction)
+        or math.isclose(friction[0], friction[1])
+    ):
+        raise AssertionError(
+            "option 0 did not preserve element-wise maximum-shear projection: "
+            f"{friction}"
+        )
+    mu0 = math.tan(math.radians(30.0))
+    expected = sorted(
+        mu0 + (0.2 - 0.3) * math.log(rate / 1.0e-5)
+        for rate in (
+            VX_TOP / (3.0 * math.sqrt(2.0)),
+            2.0 * VX_TOP / (3.0 * math.sqrt(2.0)),
+        )
+    )
+    for index, (actual, target) in enumerate(zip(sorted(friction), expected)):
+        assert_close(f"option 0 analytic friction {index}", actual, target)
+    print("[ok] the default matches option 0 maximum-shear projection")
+
+
+def check_invalid_option(exe: Path, root: Path) -> None:
+    _, result = run_cfg(
+        exe,
+        root,
+        "invalid_projection",
+        make_cfg(fixed_dt=1.0e-2, dc=1.0e-3, rate_option=2),
+        expect_success=False,
+    )
+    if "must be 0 or 1" not in result.stdout:
+        raise AssertionError(
+            "invalid projection did not report its accepted range:\n"
+            f"{result.stdout}"
+        )
+    print("[ok] unsupported projection options are rejected")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--exe", required=True, type=Path)
+    args = parser.parse_args()
+    exe = args.exe.expanduser().resolve()
+    if not exe.is_file() or not os.access(exe, os.X_OK):
+        raise FileNotFoundError(f"Executable not found: {exe}")
+
+    with tempfile.TemporaryDirectory(prefix="des_rsf_controls_") as temp:
+        root = Path(temp)
+        check_invariant_rate(exe, root)
+        check_invariant_restart_refresh(exe, root)
+        check_maximum_shear_default(exe, root)
+        check_invalid_option(exe, root)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/functional/rsf_controls/check_rsf_controls.py
+++ b/tests/functional/rsf_controls/check_rsf_controls.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Focused checks for RSF slip-rate and aging-law stepping."""
+"""Focused checks for RSF controls and the GVS elastic-speed ceiling."""
 
 from __future__ import annotations
 
@@ -524,6 +524,186 @@ def check_moving_mesh_rate_refresh(exe: Path, root: Path) -> None:
     print("[ok] moving mesh uses the analytically updated geometry")
 
 
+def make_mass_scaling_cfg(
+    reference: str | None,
+    *,
+    dynamic: bool = False,
+    global_scaling: bool = True,
+) -> str:
+    cfg = make_cfg(
+        fixed_dt=0.0,
+        dc=1.0e-3,
+        rate_option=None,
+        top_velocity=0.0,
+        moving_mesh=False,
+        inertial_scaling=1.0e6,
+    )
+    cfg = replace_once(
+        cfg,
+        "use_global_velocity_scaling = true",
+        "use_global_velocity_scaling = "
+        + ("true" if global_scaling else "false"),
+    )
+    controls = [
+        "damping_option = 0",
+        "is_quasi_static = " + ("no" if dynamic else "yes"),
+    ]
+    if reference is not None:
+        controls.append(f"mass_scaling_reference_speed = {reference}")
+    cfg = replace_once(
+        cfg, "damping_option = 1", "\n".join(controls)
+    )
+    cfg = replace_once(
+        cfg,
+        "rheology_type = elasto-plastic-rate-state-friction",
+        "rheology_type = elastic",
+    )
+    cfg = replace_once(cfg, "bulk_modulus = [2.0e8]", "bulk_modulus = [5]")
+    cfg = replace_once(cfg, "shear_modulus = [2.0e8]", "shear_modulus = [3]")
+    cfg = replace_once(cfg, "vbc_val_x0 = 0", "vbc_val_x0 = -1e-5")
+    cfg = replace_once(cfg, "vbc_val_x1 = 0", "vbc_val_x1 = 1e-5")
+    cfg = replace_once(cfg, "vbc_z0 = 1", "vbc_z0 = 3")
+    cfg = replace_once(
+        cfg,
+        "vbc_z1 = 4",
+        "vbc_z1 = 0\nstress_bc_z1 = 3\nstress_val_z1 = -1",
+    )
+    cfg = replace_once(
+        cfg,
+        "points_x = [0.3333333333333333, 0.6666666666666666]",
+        "points_x = [0, 1]",
+    )
+    cfg = replace_once(
+        cfg,
+        "points_y = [-0.6666666666666666, -0.3333333333333333]",
+        "points_y = [0, 0]",
+    )
+    cfg = replace_once(
+        cfg,
+        "output_velocity = no",
+        "output_velocity = yes\noutput_force = yes",
+    )
+    cfg = replace_once(
+        cfg, "output_dynamic_friction = yes", "output_dynamic_friction = no"
+    )
+    cfg = replace_once(
+        cfg, "output_state_variable = yes", "output_state_variable = no"
+    )
+    return cfg
+
+
+def check_mass_scaling_reference(exe: Path, root: Path) -> None:
+    cases = (
+        ("default", None, False),
+        ("shear", "shear", False),
+        ("bulk", "bulk", False),
+        ("dynamic", "bulk", True),
+    )
+    times = {}
+    masses = {}
+    for label, reference, dynamic in cases:
+        run_dir, _ = run_cfg(
+            exe,
+            root,
+            f"mass_{label}",
+            make_mass_scaling_cfg(reference, dynamic=dynamic),
+        )
+        rows = monitor_rows(run_dir)
+        times[label] = float(rows[0][1]["time_s"])
+        masses[label] = []
+        for point, point_rows in enumerate(rows):
+            if len(point_rows) != 2:
+                raise AssertionError(
+                    f"mass {label} point {point}: expected two rows"
+                )
+            expected_vx = -1.0e-5 if point == 0 else 1.0e-5
+            assert_close(
+                f"mass {label} point {point} initial velocity_x",
+                float(point_rows[0]["velocity_x"]),
+                expected_vx,
+            )
+            dt = (
+                float(point_rows[1]["time_s"])
+                - float(point_rows[0]["time_s"])
+            )
+            dv = (
+                float(point_rows[1]["velocity_z"])
+                - float(point_rows[0]["velocity_z"])
+            )
+            force = float(point_rows[1]["force_z"])
+            if (
+                not all(math.isfinite(value) for value in (dt, dv, force))
+                or dt <= 0.0
+                or force == 0.0
+                or dv == 0.0
+                or force * dv <= 0.0
+            ):
+                raise AssertionError(
+                    f"mass {label} point {point}: invalid response "
+                    f"dt={dt}, force={force}, dv={dv}"
+                )
+            masses[label].append(dt * force / dv)
+
+    altitude = 1.0 / math.sqrt(2.0)
+    assert_close(
+        "default shear-wave dt floor",
+        times["default"],
+        altitude / (5.0 * math.sqrt(3.0)),
+    )
+    assert_close("explicit shear dt", times["shear"], times["default"])
+    assert_close(
+        "bulk-wave dt floor",
+        times["bulk"],
+        altitude / (5.0 * math.sqrt(5.0)),
+    )
+    for point in range(2):
+        assert_close(
+            f"point {point} default pseudo-mass",
+            masses["default"][point],
+            masses["shear"][point],
+        )
+        assert_close(
+            f"point {point} shear/bulk mass ratio",
+            masses["shear"][point] / masses["bulk"][point],
+            5.0 / 3.0,
+        )
+        assert_close(
+            f"point {point} bulk physical mass",
+            masses["bulk"][point],
+            masses["dynamic"][point],
+        )
+    for index, (actual, expected) in enumerate(
+        zip(sorted(masses["bulk"]), (1.0 / 6.0, 1.0 / 3.0))
+    ):
+        assert_close(f"bulk nodal mass {index}", actual, expected)
+    print(
+        "[ok] GVS preserves the shear default and reaches physical density "
+        "at the bulk-wave ceiling"
+    )
+
+    invalid = (
+        (
+            "invalid_mass_reference",
+            make_mass_scaling_cfg("pwave"),
+            "must be 'shear' or 'bulk'",
+        ),
+        (
+            "bulk_without_gvs",
+            make_mass_scaling_cfg("bulk", global_scaling=False),
+            "requires control.use_global_velocity_scaling=true",
+        ),
+    )
+    for name, cfg, message in invalid:
+        _, result = run_cfg(
+            exe, root, name, cfg, expect_success=False
+        )
+        if message not in result.stdout:
+            raise AssertionError(
+                f"{name}: missing diagnostic {message!r}\n{result.stdout}"
+            )
+    print("[ok] unsupported mass-scaling selections are rejected")
+
+
 def check_invalid_option(exe: Path, root: Path) -> None:
     _, result = run_cfg(
         exe,
@@ -638,6 +818,7 @@ def main() -> None:
         check_state_rate_limit(exe, root)
         check_state_healing_limit(exe, root)
         check_moving_mesh_rate_refresh(exe, root)
+        check_mass_scaling_reference(exe, root)
         check_invalid_option(exe, root)
         check_invalid_state_limits(exe, root)
 

--- a/tests/functional/rsf_controls/check_rsf_controls.py
+++ b/tests/functional/rsf_controls/check_rsf_controls.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Focused checks for selectable RSF slip-rate calculations."""
+"""Focused checks for RSF slip-rate and aging-law stepping."""
 
 from __future__ import annotations
 
@@ -38,6 +38,11 @@ def make_cfg(
     dc: float,
     state_model: int = 1,
     rate_option: int | None = 1,
+    dtheta_max: float | None = None,
+    characteristic_velocity: float = 1.0e-5,
+    top_velocity: float = VX_TOP,
+    moving_mesh: bool | None = None,
+    inertial_scaling: float = 1.0e5,
     max_steps: int = 1,
 ) -> str:
     case = BenchmarkCase(
@@ -48,19 +53,32 @@ def make_cfg(
         direct_a=0.2,
         evolution_b=0.3,
         characteristic_distance=dc,
-        characteristic_velocity=1.0e-5,
+        characteristic_velocity=characteristic_velocity,
         state_var_model=state_model,
     )
     template = (BENCHMARK_DIR / "simple_shear_base.cfg").read_text(encoding="utf-8")
     cfg = render_cfg(template, case, max_steps, max_steps, 1)
     cfg = replace_once(cfg, "fixed_dt = 1.0", f"fixed_dt = {fixed_dt:.17e}")
-    if rate_option is not None:
-        cfg = replace_once(
-            cfg,
-            "damping_option = 1",
-            "damping_option = 1\n"
-            f"rsf_slip_rate_projection_option = {rate_option}",
+    cfg = replace_once(
+        cfg,
+        "inertial_scaling = 1e5",
+        f"inertial_scaling = {inertial_scaling:.17e}",
+    )
+    cfg = replace_once(
+        cfg,
+        "vbc_val_z1 = 1e-5",
+        f"vbc_val_z1 = {top_velocity:.17e}",
+    )
+    controls = ["damping_option = 1", "dt_fraction = 1"]
+    if moving_mesh is not None:
+        controls.append(
+            "has_moving_mesh = " + ("yes" if moving_mesh else "no")
         )
+    if rate_option is not None:
+        controls.append(f"rsf_slip_rate_projection_option = {rate_option}")
+    if dtheta_max is not None:
+        controls.append(f"rsf_dtheta_max = {dtheta_max:.17e}")
+    cfg = replace_once(cfg, "damping_option = 1", "\n".join(controls))
     return cfg
 
 
@@ -299,6 +317,213 @@ def check_maximum_shear_default(exe: Path, root: Path) -> None:
     print("[ok] the default matches option 0 maximum-shear projection")
 
 
+def check_adaptive_state_limit_disabled(exe: Path, root: Path) -> None:
+    dc = 1.0e-3
+    v0 = 1.0e-5
+    expected_dt = 0.5 / math.sqrt(2.0)
+    rate = VX_TOP / math.sqrt(2.0)
+    theta0 = dc / v0
+    expected_theta = theta0 + expected_dt * (
+        1.0 - rate * theta0 / dc
+    )
+    outputs = []
+    for label, limit in (("omitted", None), ("explicit_zero", 0.0)):
+        run_dir, _ = run_cfg(
+            exe,
+            root,
+            f"state_limit_{label}",
+            make_cfg(
+                fixed_dt=0.0,
+                dc=dc,
+                dtheta_max=limit,
+                characteristic_velocity=v0,
+                moving_mesh=False,
+            ),
+        )
+        rows = monitor_rows(run_dir)
+        outputs.append(rows)
+        for point, point_rows in enumerate(rows):
+            if len(point_rows) != 2:
+                raise AssertionError(
+                    f"{label} point {point}: expected two rows"
+                )
+            assert_close(
+                f"{label} point {point} adaptive dt",
+                float(point_rows[1]["time_s"]),
+                expected_dt,
+            )
+            assert_close(
+                f"{label} point {point} theta",
+                float(point_rows[1]["state_variable"]),
+                expected_theta,
+            )
+
+    for point, (omitted, explicit) in enumerate(zip(*outputs)):
+        for row, (omitted_record, explicit_record) in enumerate(
+            zip(omitted, explicit)
+        ):
+            for field in ("time_s", "state_variable", "dynamic_friction"):
+                assert_close(
+                    f"disabled parity point {point} row {row} {field}",
+                    float(explicit_record[field]),
+                    float(omitted_record[field]),
+                )
+    print("[ok] a disabled state bound preserves adaptive stepping")
+
+
+def check_state_rate_limit(exe: Path, root: Path) -> None:
+    dc = 1.0e-6
+    fraction = 0.2
+    v0 = 1.0e-6
+    velocity = VX_TOP
+    cfg = make_cfg(
+        fixed_dt=0.0,
+        dc=dc,
+        dtheta_max=fraction,
+        characteristic_velocity=v0,
+        top_velocity=0.0,
+        moving_mesh=False,
+        max_steps=3,
+    )
+    cfg = replace_once(cfg, "vbc_z1 = 4", "vbc_z1 = 1")
+    cfg = replace_once(
+        cfg,
+        "vbc_val_x1 = 0",
+        f"vbc_val_x1 = {velocity:.17e}\n"
+        "num_vbc_period_x1 = 2\n"
+        "vbc_period_x1_time_in_yr = [0, 1.0e-12]\n"
+        "vbc_period_x1_ratio = [1, 2]",
+    )
+    run_dir, _ = run_cfg(exe, root, "state_rate_limit", cfg)
+    rows = monitor_rows(run_dir)
+    rates = (
+        velocity / math.sqrt(2.0),
+        2.0 * velocity / math.sqrt(2.0),
+        2.0 * velocity / math.sqrt(2.0),
+    )
+    theta = dc / v0
+    for index, point_rows in enumerate(rows):
+        if len(point_rows) != 4:
+            raise AssertionError(
+                f"point {index}: expected initial plus three rows, "
+                f"got {len(point_rows)}"
+            )
+        expected_time = 0.0
+        expected_theta = theta
+        for step, record in enumerate(point_rows):
+            assert_close(
+                f"point {index} step {step} rate-limited time",
+                float(record["time_s"]),
+                expected_time,
+            )
+            assert_close(
+                f"point {index} step {step} rate-limited theta",
+                float(record["state_variable"]),
+                expected_theta,
+            )
+            if step < len(rates):
+                expected_dt = fraction * dc / rates[step]
+                expected_time += expected_dt
+                expected_theta += expected_dt * (
+                    1.0 - rates[step] * expected_theta / dc
+                )
+    print("[ok] fixed mesh refreshes the bound from the current boundary rate")
+
+
+def check_state_healing_limit(exe: Path, root: Path) -> None:
+    dc = 1.0e-6
+    fraction = 0.2
+    v0 = 1.0e-5
+    run_dir, _ = run_cfg(
+        exe,
+        root,
+        "state_healing_limit",
+        make_cfg(
+            fixed_dt=0.0,
+            dc=dc,
+            dtheta_max=fraction,
+            characteristic_velocity=v0,
+            moving_mesh=True,
+        ),
+    )
+    rows = monitor_rows(run_dir)
+    theta0 = dc / v0
+    expected_dt = fraction * theta0
+    rate = VX_TOP / math.sqrt(2.0)
+    theta1 = theta0 + expected_dt * (1.0 - rate * theta0 / dc)
+    for index, point_rows in enumerate(rows):
+        assert_close(
+            f"point {index} healing-limited dt",
+            float(point_rows[1]["time_s"]),
+            expected_dt,
+        )
+        assert_close(
+            f"point {index} healing-limited theta",
+            float(point_rows[1]["state_variable"]),
+            theta1,
+        )
+    print("[ok] the theta arm bounds fractional healing in one step")
+
+
+def check_moving_mesh_rate_refresh(exe: Path, root: Path) -> None:
+    dc = 1.0e-1
+    fraction = 0.2
+    velocity = 1.0
+    cfg = make_cfg(
+        fixed_dt=0.0,
+        dc=dc,
+        dtheta_max=fraction,
+        characteristic_velocity=1.0e-1,
+        top_velocity=0.0,
+        moving_mesh=True,
+        inertial_scaling=1.0,
+        max_steps=2,
+    )
+    cfg = replace_once(
+        cfg,
+        "vbc_val_x1 = 0",
+        f"vbc_val_x1 = {velocity:.17e}",
+    )
+    cfg = replace_once(cfg, "vbc_z1 = 4", "vbc_z1 = 1")
+    run_dir, _ = run_cfg(
+        exe,
+        root,
+        "moving_mesh_rate_refresh",
+        cfg,
+    )
+    rows = monitor_rows(run_dir)
+    for point, point_rows in enumerate(rows):
+        if len(point_rows) != 3:
+            raise AssertionError(
+                f"moving point {point}: expected three rows"
+            )
+        length = 1.0
+        theta = dc / 1.0e-1
+        expected_time = 0.0
+        for step, record in enumerate(point_rows):
+            assert_close(
+                f"moving point {point} step {step} time",
+                float(record["time_s"]),
+                expected_time,
+            )
+            assert_close(
+                f"moving point {point} step {step} theta",
+                float(record["state_variable"]),
+                theta,
+            )
+            if step == 2:
+                continue
+
+            rate = velocity / math.sqrt(length * length + 1.0)
+            dt = fraction * dc / rate
+            if dt >= fraction * theta:
+                raise AssertionError("moving test is not rate limited")
+            expected_time += dt
+            theta += dt * (1.0 - rate * theta / dc)
+            length += velocity * dt
+    print("[ok] moving mesh uses the analytically updated geometry")
+
+
 def check_invalid_option(exe: Path, root: Path) -> None:
     _, result = run_cfg(
         exe,
@@ -315,6 +540,87 @@ def check_invalid_option(exe: Path, root: Path) -> None:
     print("[ok] unsupported projection options are rejected")
 
 
+def check_invalid_state_limits(exe: Path, root: Path) -> None:
+    limit_isostasy = replace_once(
+        make_cfg(fixed_dt=0.0, dc=1.0e-6, dtheta_max=0.2),
+        "weakzone_option = 0",
+        "weakzone_option = 0\nisostasy_adjustment_time_in_yr = 1",
+    )
+    limit_pt = replace_once(
+        make_cfg(fixed_dt=0.0, dc=1.0e-6, dtheta_max=0.2),
+        "dt_fraction = 1",
+        "dt_fraction = 1\nhas_PT = yes",
+    )
+    limit_body_force = replace_once(
+        make_cfg(fixed_dt=0.0, dc=1.0e-6, dtheta_max=0.2),
+        "weakzone_option = 0",
+        "weakzone_option = 0\nhas_body_force_adjustment = yes",
+    )
+    limit_non_rsf = replace_once(
+        make_cfg(fixed_dt=0.0, dc=1.0e-6, dtheta_max=0.2),
+        "rheology_type = elasto-plastic-rate-state-friction",
+        "rheology_type = elastic",
+    )
+    cases = (
+        (
+            "limit_option0",
+            make_cfg(
+                fixed_dt=0.0,
+                dc=1.0e-6,
+                rate_option=0,
+                dtheta_max=0.2,
+            ),
+            "projection_option=1",
+        ),
+        (
+            "limit_steady",
+            make_cfg(
+                fixed_dt=0.0,
+                dc=1.0e-6,
+                state_model=0,
+                dtheta_max=0.2,
+            ),
+            "state_var_model=1",
+        ),
+        (
+            "limit_fixed_dt",
+            make_cfg(fixed_dt=1.0e-2, dc=1.0e-6, dtheta_max=0.2),
+            "requires control.fixed_dt=0",
+        ),
+        (
+            "limit_two",
+            make_cfg(fixed_dt=0.0, dc=1.0e-6, dtheta_max=2.0),
+            "finite and in [0, 2)",
+        ),
+        (
+            "limit_nan",
+            make_cfg(fixed_dt=0.0, dc=1.0e-6, dtheta_max=math.nan),
+            "finite and in [0, 2)",
+        ),
+        ("limit_pt", limit_pt, "control.has_PT=true"),
+        (
+            "limit_body_force",
+            limit_body_force,
+            "ic.has_body_force_adjustment=true",
+        ),
+        (
+            "limit_isostasy",
+            limit_isostasy,
+            "not supported during isostasy adjustment",
+        ),
+        ("limit_non_rsf", limit_non_rsf, "requires an RSF rheology"),
+    )
+    for name, cfg, message in cases:
+        _, result = run_cfg(
+            exe, root, name, cfg, expect_success=False
+        )
+        if message not in result.stdout:
+            raise AssertionError(
+                f"{name}: missing diagnostic {message!r}\n{result.stdout}"
+            )
+    print("[ok] unsupported aging-law timestep combinations are rejected")
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--exe", required=True, type=Path)
@@ -328,7 +634,12 @@ def main() -> None:
         check_invariant_rate(exe, root)
         check_invariant_restart_refresh(exe, root)
         check_maximum_shear_default(exe, root)
+        check_adaptive_state_limit_disabled(exe, root)
+        check_state_rate_limit(exe, root)
+        check_state_healing_limit(exe, root)
+        check_moving_mesh_rate_refresh(exe, root)
         check_invalid_option(exe, root)
+        check_invalid_state_limits(exe, root)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

This PR adds the RSF controls and verification cases required for the revised
DES paper. The implementation is split into six focused commits so that the
constitutive, timestep, mass-scaling, initial-condition, and benchmark changes
can be reviewed independently.

## Scientific and numerical changes

### RSF slip-rate measure

- Add `rsf_slip_rate_projection_option`.
- Keep the historical maximum-shear projection as the default (`0`).
- Add an opt-in total-strain-invariant rate measure (`1`).
- Compute the continuum rate directly from the current element strain-rate
  tensor without evaluating the maximum-shear-direction element velocity on
  that path.
- Rebuild the required rate data after restart and update it from the current
  boundary motion and mesh geometry.

### RSF state evolution and timestep control

- Add the optional `rsf_dtheta_max` aging-law timestep constraint.
- Recompute the timestep bound from the current rate rather than retaining a
  value derived from an earlier state.
- Keep the constraint disabled by default with `rsf_dtheta_max = 0`.
- Apply the paper's `1e-16 m/s` rate floor consistently in the friction,
  aging-law, and slip-law calculations.

### Global velocity scaling

- Add `mass_scaling_reference_speed = shear|bulk`.
- Preserve the historical shear-modulus ceiling as the default.
- Allow the bulk-modulus ceiling to be selected for the mass-scaled density
  and elastic timestep calculation.

### Homogeneous initial stress

- Add `initial_stress_option = 1` for prescribing a homogeneous absolute
  stress tensor in zero-gravity models.
- Support the appropriate tensor components in both 2-D and 3-D.
- Preserve the historical initialization path as the default.

## Backward compatibility

- Maximum-shear RSF projection remains the default.
- The aging-law timestep constraint remains disabled unless requested.
- Shear-based global velocity scaling remains the default.
- Historical initial-stress initialization remains the default.
- The existing `second_invariant` implementation is unchanged.
- Output and checkpoint layouts are unchanged.
- Existing RSF behavior changes only below the documented `1e-16 m/s`
  regularization threshold.

## Paper benchmark

The simple-shear benchmark reproduces nine cases from the revised paper:

- static-friction elastoplasticity at 10, 20, and 30 degrees;
- steady-state RSF at reference velocities of
  `1e-6`, `1e-5`, and `1e-4 m/s`;
- aging-law RSF at characteristic distances of
  `1e-3`, `3e-3`, and `1e-2 m`.

Each case uses a fixed `0.01 s` timestep for 200,000 steps. The benchmark also
includes the separate zero-velocity healing experiment using 1546 three-day
steps.

The checker compares the complete stress history against an independently
integrated reference solution, recovers the rate used by the RSF law from the
monitored friction and state outputs, and independently reproduces the
discrete healing update.

## Validation

- 2-D OpenMP/HDF5 build completed successfully.
- Focused functional checks cover:
  - both RSF rate measures;
  - preservation of the maximum-shear default;
  - restart reconstruction;
  - current boundary-rate refresh;
  - moving-mesh geometry;
  - enabled and disabled aging-law timestep constraints;
  - global-velocity-scaling ceilings;
  - homogeneous initial stress;
  - rejection of invalid controls.
- All nine paper cases and the zero-velocity healing case passed.
- Mean stress errors across the nine cases:
  `4.942e-4%` to `7.117e-4%`.
- Largest pointwise stress error: `1.156e-3%`.
- Maximum relative error in the recovered RSF rate: `5.000e-8`.
- Healing recurrence error: `0`.
- Healing deficit relative to exact zero-rate linear growth:
  `2.027e-6`, consistent with the paper's approximately `2.0e-6`.

## Commit structure

1. `917c189` — add the total-strain-invariant RSF rate
2. `c670ddb` — recompute the aging-law timestep bound from the current rate
3. `62c8861` — select the GVS elastic-speed ceiling
4. `2cabea1` — prescribe homogeneous absolute stress at zero gravity
5. `884d25d` — apply the `1e-16 m/s` rate floor to state evolution
6. `c640a58` — add the strain-rate-based simple-shear benchmark